### PR TITLE
deploy: remote Graviton builder + flag-based release scripts

### DIFF
--- a/deploy/aws-setup.md
+++ b/deploy/aws-setup.md
@@ -40,6 +40,7 @@ provisioning steps below:
         "ec2:RunInstances",
         "ec2:TerminateInstances",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
         "ec2:DescribeImages",
         "ec2:DescribeKeyPairs",
         "ec2:CreateKeyPair",
@@ -58,6 +59,14 @@ provisioning steps below:
         "ec2:DescribeAvailabilityZones"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "RemoteBuildAmiLookup",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters"
+      ],
+      "Resource": "arn:aws:ssm:*::parameter/aws/service/ami-amazon-linux-latest/*"
     },
     {
       "Sid": "IamRoleForInstance",
@@ -230,3 +239,101 @@ For the smoke test, "teardown" is just:
 
 I can script that as `deploy/bin/teardown.sh` once the first deploy is
 green.
+
+## Remote build (transient Graviton spot)
+
+Builds the prod release on a fresh AWS Graviton spot instance instead of
+locally via QEMU emulation. Cuts a ~35-minute desktop build down to
+~5-10 minutes wall-clock and frees up your workstation. Tarballs ship
+builder→prod directly (intra-region, free transfer); your laptop only
+handles verification + CloudFront invalidation.
+
+### What this assumes
+
+- Prod is in `us-east-1` (override with `RC_BUILDER_REGION`).
+- The existing `rc-prod` AWS profile + IAM user with the EC2/SSM
+  permissions in the JSON above (the diff added `ec2:DescribeInstanceStatus`
+  and `ssm:GetParameters` for the AL2023 ARM AMI lookup).
+- The existing `rc-prod` EC2 key pair — same one you ssh prod with. The
+  private key is uploaded to the builder transiently per build and dies
+  with the instance.
+
+### One-time setup
+
+PowerShell:
+
+```powershell
+.\deploy\bin\setup-builder.ps1
+```
+
+Bash (POSIX):
+
+```sh
+./deploy/bin/setup-builder.sh
+```
+
+Either creates a security group `rc-builder-sg` allowing SSH from your
+current public IP. Idempotent — re-run after your home IP changes to add
+the new one (old rules stay; clean up manually if you want the SG tidy).
+
+### Per-build usage
+
+PowerShell (the daily driver on Windows):
+
+```powershell
+# Build remotely + deploy to prod
+.\deploy\release.ps1 -BuildRemote
+
+# Benchmark a remote build: build remotely, pull tarballs back to .\build\,
+# do NOT deploy. Useful before committing to the remote path.
+.\deploy\release.ps1 -BuildRemote -BuildOnly
+
+# Backend-only remote deploy of a specific revision
+.\deploy\release.ps1 f9e221e -BuildRemote -BackOnly
+
+# Get-Help .\deploy\release.ps1 -Detailed   # full flag reference
+```
+
+Bash (POSIX / Git-Bash):
+
+```sh
+./deploy/release.sh --remote                  # remote build + deploy
+./deploy/release.sh --remote --build-only     # benchmark, no deploy
+./deploy/release.sh --remote --back-only f9e221e
+
+./deploy/release.sh --help                    # full flag reference
+```
+
+`remote-build.sh` prints a per-phase timings table at the end so you can
+see exactly where wall-clock goes — the "docker buildx" line is the
+apples-to-apples comparison with your local QEMU build time.
+
+### What happens on AWS
+
+1. `aws ec2 run-instances` — c7g.4xlarge, spot one-time, max price = on-demand
+   (falls back to on-demand automatically if no spot capacity)
+2. `aws ec2 wait instance-status-ok` — typically 60-90s
+3. Source tar-streamed in via SSH
+4. `docker buildx build` natively (no `--platform`)
+5. `deploy/bin/deploy.sh` runs on the builder — scp to prod + remote install
+6. `aws ec2 terminate-instances` (EXIT trap, runs even on failure)
+
+Spot interruption mid-build is the main failure mode and falls back to
+re-running on-demand on the operator's side. Cost per build is ~$0.03
+on spot, ~$0.08 on-demand.
+
+### Cost / size knobs
+
+| PowerShell                  | Bash                         | Effect                                                  |
+| --------------------------- | ---------------------------- | ------------------------------------------------------- |
+| `-BuilderType c7g.2xlarge`  | `--builder-type c7g.2xlarge` | Halve per-build cost, slower build                      |
+| `-OnDemand`                 | `--on-demand`                | Skip the spot attempt (use on-demand)                   |
+| `-Keep`                     | `--keep`                     | Don't terminate builder on exit — **costs $$ until you do** |
+
+### Teardown for the builder resources
+
+```sh
+aws --profile rc-prod ec2 delete-security-group --group-name rc-builder-sg
+```
+
+No other state to clean up — instances are transient.

--- a/deploy/bin/remote-build.sh
+++ b/deploy/bin/remote-build.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+#
+# remote-build.sh — build the prod release on a transient AWS Graviton.
+#
+# Replaces the local `docker buildx ... --platform linux/arm64` step in
+# release.sh, which uses QEMU emulation and takes ~35min on a beefy x86
+# desktop. Native arm64 on a c7g.4xlarge spot instance does it in ~5-8min.
+#
+# What this does:
+#   1. Launch a spot c7g.4xlarge (falls back to on-demand if no spot capacity)
+#   2. Wait for SSH + cloud-init (docker installed)
+#   3. Stream source tree to /home/ec2-user/src/ on the builder
+#   4. Upload the prod ssh key transiently so the builder can ship to prod
+#   5. Run docker buildx natively (no --platform — host IS arm64)
+#   6. Extract tarballs from the build image into src/build/
+#   7. Run deploy/bin/deploy.sh on the builder — scp tarballs to prod (free
+#      intra-region transfer) and ssh-bash-s the install script
+#   8. Terminate the builder (EXIT trap, runs on success and failure)
+#
+# Why we run deploy.sh on the builder rather than pulling tarballs back to
+# the operator and running deploy.sh locally:
+#   - Saves ~100-200MB of EC2→home internet transfer (slow + you pay egress)
+#   - Builder→prod is intra-region: free + ~1GB/s
+#   - deploy.sh is unmodified, just runs in a different shell
+#
+# Caveat: deploy.sh's CloudFront-invalidation tail will warn-and-skip on
+# the builder (no AWS credentials there). release.sh runs the invalidation
+# from the operator's box after this script returns, so cache busting still
+# happens — just from your laptop, not from the builder.
+#
+# Inputs (caller — release.sh — exports these):
+#   REVISION            git short sha to embed in the build
+#   BACK_ONLY_BOOL      "true" | "false"
+#   VUE_BASE            VUE_APP_BASE_URL baked into the Vue bundle
+#   VUE_APP_APPSIGNAL_FRONT  optional AppSignal frontend key
+#   SSH_KEY             path to the prod ssh key (from nodes.sh sourcing)
+#
+# Env vars (all optional):
+#   RC_BUILD_ONLY=1     Build remotely, pull tarballs back to ./build/, do
+#                       NOT deploy. Use for benchmarking or sanity-checking
+#                       a build without touching prod.
+#   RC_BUILDER_TYPE     EC2 instance type. Default: c7g.4xlarge
+#   RC_BUILDER_REGION   AWS region. Default: us-east-1
+#   RC_BUILDER_PROFILE  AWS CLI profile. Default: rc-prod
+#   RC_BUILDER_KEYNAME  EC2 key pair name. Default: rc-prod
+#   RC_BUILDER_SG       security group name. Default: rc-builder-sg
+#   RC_BUILDER_ON_DEMAND=1   skip spot entirely, launch on-demand
+#   RC_BUILDER_KEEP=1   don't terminate on exit (debugging only — costs money)
+#
+# Prints a per-phase timings table at the end (boot+wait, source ship,
+# docker build, deploy/pullback) — useful for benchmarking remote vs local.
+
+set -euo pipefail
+
+REPO=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$REPO"
+
+# Git-Bash on Windows translates args starting with `/` into Windows paths
+# (so `/aws/service/...` becomes `C:/Program Files/Git/aws/service/...`),
+# corrupting SSM parameter names, /dev/xvda block-device specs, etc. Disable
+# the translation when we're under MSYS2/git-bash; no-op on real POSIX.
+if [[ -n "${MSYSTEM:-}" ]]; then
+  export MSYS_NO_PATHCONV=1
+  export MSYS2_ARG_CONV_EXCL='*'
+fi
+
+: "${REVISION:?REVISION required (call from release.sh)}"
+: "${BACK_ONLY_BOOL:?BACK_ONLY_BOOL required (true|false)}"
+: "${VUE_BASE:?VUE_BASE required}"
+
+# Pull SSH_KEY from nodes.sh if not in env. We need the local path to the
+# prod private key so we can upload it transiently to the builder.
+if [[ -z "${SSH_KEY:-}" ]]; then
+  source ./nodes.sh
+fi
+[[ -f "$SSH_KEY" ]] || { echo "[remote-build] fatal: prod ssh key $SSH_KEY not found" >&2; exit 1; }
+
+INSTANCE_TYPE="${RC_BUILDER_TYPE:-c7g.4xlarge}"
+REGION="${RC_BUILDER_REGION:-us-east-1}"
+PROFILE="${RC_BUILDER_PROFILE:-rc-prod}"
+KEY_NAME="${RC_BUILDER_KEYNAME:-rc-prod}"
+SG_NAME="${RC_BUILDER_SG:-rc-builder-sg}"
+
+AWS=(aws --profile "$PROFILE" --region "$REGION")
+
+# --- timing instrumentation -----------------------------------------------
+# All times in seconds since script start. Printed at end as a table.
+T_START=$SECONDS
+T_LAUNCH_DONE=0   # boot + status-ok + docker ready
+T_SHIP_DONE=0     # source streamed to builder
+T_BUILD_DONE=0    # docker buildx finished
+T_EXTRACT_DONE=0  # tarballs copied out of build image
+T_FINAL_DONE=0    # deploy.sh OR pullback finished
+
+print_timings() {
+  local total=$((SECONDS - T_START))
+  cat <<EOF
+
+[remote-build] phase timings
+  launch + status-ok + docker  : ${T_LAUNCH_DONE}s
+  source stream                : $((T_SHIP_DONE - T_LAUNCH_DONE))s
+  docker buildx                : $((T_BUILD_DONE - T_SHIP_DONE))s
+  extract tarballs             : $((T_EXTRACT_DONE - T_BUILD_DONE))s
+  ${T_FINAL_LABEL:-deploy}                        : $((T_FINAL_DONE - T_EXTRACT_DONE))s
+  -----
+  total (excl. terminate)      : ${T_FINAL_DONE}s
+  total (incl. terminate)      : ${total}s
+EOF
+}
+
+# --- pre-flight -----------------------------------------------------------
+command -v aws >/dev/null || { echo "[remote-build] fatal: aws CLI not installed" >&2; exit 1; }
+command -v tar >/dev/null || { echo "[remote-build] fatal: tar not installed" >&2; exit 1; }
+
+SG_ID=$("${AWS[@]}" ec2 describe-security-groups \
+  --filters "Name=group-name,Values=$SG_NAME" \
+  --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo "None")
+if [[ "$SG_ID" == "None" || -z "$SG_ID" ]]; then
+  echo "[remote-build] fatal: security group '$SG_NAME' not found in $REGION" >&2
+  echo "  on Windows: run .\\deploy\\bin\\setup-builder.ps1 once to create it" >&2
+  echo "  on POSIX:   run ./deploy/bin/setup-builder.sh once to create it" >&2
+  exit 1
+fi
+echo "[remote-build] using SG $SG_NAME ($SG_ID)"
+
+# --- resolve latest AL2023 ARM AMI via SSM --------------------------------
+# Using the SSM public parameter means we always get the current AMI without
+# tracking ids by hand. Same approach AWS recommends in their docs.
+AMI_ID=$("${AWS[@]}" ssm get-parameters \
+  --names /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64 \
+  --query 'Parameters[0].Value' --output text)
+if [[ -z "$AMI_ID" || "$AMI_ID" == "None" ]]; then
+  echo "[remote-build] fatal: SSM AMI lookup returned empty" >&2
+  exit 1
+fi
+echo "[remote-build] AMI: $AMI_ID"
+
+# --- launch ---------------------------------------------------------------
+# user-data installs Docker + git on first boot. AL2023 doesn't include
+# docker in the base image. Cloud-init runs async; we poll for `docker info`
+# success via SSH before kicking off the build.
+USER_DATA_PLAIN='#!/bin/bash
+exec > /var/log/builder-init.log 2>&1
+set -x
+dnf install -y docker git
+systemctl enable --now docker
+usermod -aG docker ec2-user
+'
+
+# AWS expects user-data as base64. Use openssl since base64(1) flags differ
+# across platforms (Windows Git-Bash lacks -w, BSD base64 lacks it too).
+USER_DATA=$(printf '%s' "$USER_DATA_PLAIN" | openssl base64 -A)
+
+launch() {
+  local market_args=("$@")
+  "${AWS[@]}" ec2 run-instances \
+    --image-id "$AMI_ID" \
+    --instance-type "$INSTANCE_TYPE" \
+    --key-name "$KEY_NAME" \
+    --security-group-ids "$SG_ID" \
+    --user-data "$USER_DATA" \
+    --block-device-mappings 'DeviceName=/dev/xvda,Ebs={VolumeSize=40,VolumeType=gp3,DeleteOnTermination=true}' \
+    --metadata-options 'HttpTokens=required,HttpEndpoint=enabled' \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=rc-builder-$REVISION},{Key=ManagedBy,Value=rc-remote-build.sh}]" \
+    "${market_args[@]}" \
+    --query 'Instances[0].InstanceId' --output text
+}
+
+if [[ "${RC_BUILDER_ON_DEMAND:-0}" == "1" ]]; then
+  echo "[remote-build] launching on-demand $INSTANCE_TYPE"
+  INSTANCE_ID=$(launch)
+else
+  echo "[remote-build] launching spot $INSTANCE_TYPE (one-time, max=on-demand)"
+  if ! INSTANCE_ID=$(launch \
+      --instance-market-options 'MarketType=spot,SpotOptions={SpotInstanceType=one-time}' \
+      2>/tmp/rc-spot-err); then
+    echo "[remote-build] spot launch failed:"
+    sed 's/^/  /' /tmp/rc-spot-err >&2 || true
+    echo "[remote-build] retrying on-demand"
+    INSTANCE_ID=$(launch)
+  fi
+fi
+echo "[remote-build] instance: $INSTANCE_ID"
+
+cleanup() {
+  local exit_code=$?
+  if [[ "${RC_BUILDER_KEEP:-0}" == "1" ]]; then
+    echo "[remote-build] RC_BUILDER_KEEP=1 — leaving $INSTANCE_ID running"
+    echo "[remote-build] terminate with:"
+    echo "  ${AWS[*]} ec2 terminate-instances --instance-ids $INSTANCE_ID"
+  else
+    echo "[remote-build] terminating $INSTANCE_ID"
+    "${AWS[@]}" ec2 terminate-instances --instance-ids "$INSTANCE_ID" >/dev/null \
+      || echo "[remote-build] WARNING: terminate failed — check console for orphans" >&2
+  fi
+  # Only show timings if we got far enough for them to be meaningful.
+  [[ "$T_FINAL_DONE" -gt 0 ]] && print_timings
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- wait for the instance ------------------------------------------------
+echo "[remote-build] waiting for instance status-ok (typically 60-90s)"
+"${AWS[@]}" ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
+
+PUBLIC_DNS=$("${AWS[@]}" ec2 describe-instances --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[0].Instances[0].PublicDnsName' --output text)
+echo "[remote-build] builder: $PUBLIC_DNS"
+
+SSH_OPTS=(-i "$SSH_KEY"
+  -o StrictHostKeyChecking=accept-new
+  -o UserKnownHostsFile=/dev/null
+  -o LogLevel=ERROR
+  -o ConnectTimeout=10
+  -o ServerAliveInterval=30)
+B="ec2-user@$PUBLIC_DNS"
+
+# cloud-init runs after the status-ok signal. Poll docker readiness so we
+# don't kick off the build while dnf is still installing it.
+echo "[remote-build] waiting for docker on builder"
+for i in $(seq 1 60); do
+  if ssh "${SSH_OPTS[@]}" "$B" 'docker info' >/dev/null 2>&1; then
+    echo "[remote-build] docker up after ${i}x5s"
+    break
+  fi
+  sleep 5
+  if [[ $i -eq 60 ]]; then
+    echo "[remote-build] fatal: docker never came up — check /var/log/builder-init.log on $PUBLIC_DNS" >&2
+    exit 1
+  fi
+done
+T_LAUNCH_DONE=$((SECONDS - T_START))
+
+# --- ship source ----------------------------------------------------------
+# tar | ssh stream avoids needing rsync (not in Git-Bash on Windows).
+# Excludes mirror .dockerignore plus .git (we pass APP_REVISION as a build
+# arg, so the build doesn't need history) and .secrets/.env (host-only).
+echo "[remote-build] streaming source to builder"
+ssh "${SSH_OPTS[@]}" "$B" 'rm -rf src && mkdir -p src'
+tar --exclude='./_build' --exclude='./deps' --exclude='./node_modules' \
+    --exclude='./assets/node_modules' --exclude='./front/node_modules' \
+    --exclude='./build' --exclude='./pgdata' --exclude='./replays' \
+    --exclude='./.git' --exclude='./.elixir_ls' --exclude='./.vscode' \
+    --exclude='./.claude' --exclude='./.secrets' --exclude='./.env' \
+    --exclude='./priv/static' --exclude='./priv/_storage' \
+    --exclude='./cover' --exclude='./doc' \
+    -czf - . | ssh "${SSH_OPTS[@]}" "$B" 'tar -xzf - -C src/'
+T_SHIP_DONE=$((SECONDS - T_START))
+
+# --- upload prod ssh key transiently --------------------------------------
+# The builder needs this to scp tarballs to prod and to ssh-bash-s the
+# install script. Lives only for the life of the spot instance.
+echo "[remote-build] uploading prod ssh key transiently"
+ssh "${SSH_OPTS[@]}" "$B" 'mkdir -p ~/.ssh && chmod 700 ~/.ssh'
+scp "${SSH_OPTS[@]}" "$SSH_KEY" "$B:.ssh/rc-prod.pem"
+ssh "${SSH_OPTS[@]}" "$B" 'chmod 600 ~/.ssh/rc-prod.pem'
+
+# --- build natively -------------------------------------------------------
+NO_CACHE_FLAG=""
+[[ "${RC_NO_CACHE:-1}" == "1" ]] && NO_CACHE_FLAG="--no-cache"
+
+echo "[remote-build] running native arm64 docker build (NO_CACHE=${RC_NO_CACHE:-1})"
+# BUILDKIT_PROGRESS=plain forces line-oriented output instead of the TTY
+# progress bars that use CR-overwrites + ANSI — much easier to read when
+# the stream is captured to a log file on the operator's machine.
+ssh "${SSH_OPTS[@]}" "$B" "set -e
+cd src
+BUILDKIT_PROGRESS=plain docker buildx build $NO_CACHE_FLAG --load -t rc_build_image \\
+  --build-arg APP_REVISION='$REVISION' \\
+  --build-arg BACK_ONLY='$BACK_ONLY_BOOL' \\
+  --build-arg VUE_APP_BASE_URL='$VUE_BASE' \\
+  --build-arg VUE_APP_APPSIGNAL_FRONT='${VUE_APP_APPSIGNAL_FRONT:-}' \\
+  ."
+T_BUILD_DONE=$((SECONDS - T_START))
+
+# --- extract tarballs from the build image into src/build/ ----------------
+# deploy.sh reads from ./build/, so we put them where it expects.
+echo "[remote-build] extracting tarballs from build image"
+ssh "${SSH_OPTS[@]}" "$B" 'set -e
+cd src
+mkdir -p build
+docker rm -f rc_extract >/dev/null 2>&1 || true
+docker create --name rc_extract rc_build_image >/dev/null
+docker cp rc_extract:/home/rc/build/rc.tar.gz build/rc.tar.gz
+'
+if [[ "$BACK_ONLY_BOOL" == "false" ]]; then
+  ssh "${SSH_OPTS[@]}" "$B" 'cd src && docker cp rc_extract:/home/rc/build/vue.tar.gz build/vue.tar.gz'
+fi
+ssh "${SSH_OPTS[@]}" "$B" 'cd src && docker rm rc_extract >/dev/null'
+T_EXTRACT_DONE=$((SECONDS - T_START))
+
+# --- final step: either pull tarballs back (build-only) or deploy from builder
+if [[ "${RC_BUILD_ONLY:-0}" == "1" ]]; then
+  # Build-only mode: pull tarballs back to ./build/ for inspection. Used
+  # for benchmarking remote-vs-local without touching prod. Egress to your
+  # laptop is ~$0.09/GB; tarballs are ~100-200MB so ~$0.018 per build.
+  T_FINAL_LABEL='tarball pullback              '
+  echo "[remote-build] RC_BUILD_ONLY=1 — pulling tarballs back to ./build/"
+  mkdir -p build
+  scp "${SSH_OPTS[@]}" "$B:src/build/rc.tar.gz" ./build/
+  if [[ "$BACK_ONLY_BOOL" == "false" ]]; then
+    scp "${SSH_OPTS[@]}" "$B:src/build/vue.tar.gz" ./build/
+  fi
+  T_FINAL_DONE=$((SECONDS - T_START))
+  echo "[remote-build] build complete — tarballs in ./build/ (NOT deployed)"
+else
+  # Deploy mode: deploy.sh sources nodes.sh which defaults to the prod SSH
+  # host and SSH_KEY=~/.ssh/rc-prod.pem. Both are correct on the builder.
+  T_FINAL_LABEL='deploy.sh (ship to prod)      '
+  echo "[remote-build] running deploy/bin/deploy.sh on builder (ships to prod + remote install)"
+  ssh "${SSH_OPTS[@]}" "$B" 'cd src && bash deploy/bin/deploy.sh'
+  T_FINAL_DONE=$((SECONDS - T_START))
+  echo "[remote-build] build + deploy complete via builder"
+fi

--- a/deploy/bin/setup-builder.ps1
+++ b/deploy/bin/setup-builder.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+  setup-builder.ps1 -- one-time AWS setup for remote builds.
+
+.DESCRIPTION
+  Creates the security group used by deploy/bin/remote-build (the SG
+  inbound SSH rule from your current public IP).
+
+  Run once per AWS account/region. Idempotent: re-running after your
+  home IP changes adds a new rule for the new IP; old rules stay until
+  you clean them up manually with `aws ec2 revoke-security-group-ingress`.
+
+  What it creates:
+    - Security group `rc-builder-sg` in the default VPC.
+    - Inbound rule: SSH (tcp/22) from your current public IP (/32).
+
+  What it reuses (not created here):
+    - EC2 key pair `rc-prod` -- the same one you SSH to prod with. The
+      prod private key is uploaded to the builder transiently per build,
+      so there is no separate builder key to manage.
+
+.PARAMETER AwsProfile
+  AWS CLI profile. Default: rc-prod.
+
+.PARAMETER Region
+  AWS region. Default: us-east-1.
+
+.PARAMETER SgName
+  Security group name. Default: rc-builder-sg.
+
+.EXAMPLE
+  .\deploy\bin\setup-builder.ps1
+  Default profile/region/SG name.
+#>
+
+[CmdletBinding()]
+param(
+  [string]$AwsProfile = "rc-prod",
+  [string]$Region = "us-east-1",
+  [string]$SgName = "rc-builder-sg"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Step([string]$msg) {
+  Write-Host "[setup-builder] $msg"
+}
+
+function Fail([string]$msg, [int]$code = 1) {
+  Write-Host "[setup-builder] fatal: $msg" -ForegroundColor Red
+  exit $code
+}
+
+$awsBase = @('--profile', $AwsProfile, '--region', $Region)
+
+Step "profile=$AwsProfile region=$Region sg=$SgName"
+
+# --- discover your current public IP ------------------------------------------
+# Prefer checkip.amazonaws.com so the IP check stays inside AWS; fall back
+# to ifconfig.me on failure.
+$myIp = $null
+try {
+  $myIp = (Invoke-WebRequest -Uri "https://checkip.amazonaws.com" -UseBasicParsing -TimeoutSec 10).Content.Trim()
+} catch {
+  try {
+    $myIp = (Invoke-WebRequest -Uri "https://ifconfig.me" -UseBasicParsing -TimeoutSec 10).Content.Trim()
+  } catch {
+    Fail "could not detect your public IP (both checkip.amazonaws.com and ifconfig.me failed)"
+  }
+}
+if ($myIp -notmatch '^\d+\.\d+\.\d+\.\d+$') {
+  Fail "detected IP is not a valid IPv4 address: '$myIp'"
+}
+Step "your IP: $myIp"
+
+# --- default VPC --------------------------------------------------------------
+$vpcId = (& aws @awsBase ec2 describe-vpcs `
+  --filters "Name=is-default,Values=true" `
+  --query 'Vpcs[0].VpcId' --output text).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($vpcId) -or $vpcId -eq 'None') {
+  Fail "no default VPC in $Region (or aws CLI failed; profile=$AwsProfile)"
+}
+Step "default VPC: $vpcId"
+
+# --- create or reuse security group -------------------------------------------
+$sgId = (& aws @awsBase ec2 describe-security-groups `
+  --filters "Name=group-name,Values=$SgName" "Name=vpc-id,Values=$vpcId" `
+  --query 'SecurityGroups[0].GroupId' --output text 2>$null)
+if ($sgId) { $sgId = $sgId.Trim() }
+
+if ([string]::IsNullOrWhiteSpace($sgId) -or $sgId -eq 'None') {
+  Step "creating security group $SgName"
+  $sgId = (& aws @awsBase ec2 create-security-group `
+    --group-name $SgName `
+    --description "Transient builders for rc release pipeline" `
+    --vpc-id $vpcId `
+    --query 'GroupId' --output text).Trim()
+  if ($LASTEXITCODE -ne 0) { Fail "create-security-group failed" }
+  & aws @awsBase ec2 create-tags --resources $sgId `
+    --tags 'Key=ManagedBy,Value=rc-setup-builder.ps1' | Out-Null
+} else {
+  Step "security group $SgName already exists ($sgId)"
+}
+
+# --- ensure SSH from your IP is allowed ---------------------------------------
+# Re-running after your IP changes ADDS the new rule. Old rules stay; clean
+# up with `aws ec2 revoke-security-group-ingress` if you want the SG tidy.
+$existing = & aws @awsBase ec2 describe-security-groups --group-ids $sgId `
+  --query "SecurityGroups[0].IpPermissions[?FromPort==``22``].IpRanges[].CidrIp" `
+  --output text
+if ($existing -and ($existing -match [regex]::Escape("$myIp/32"))) {
+  Step "SSH from $myIp/32 already allowed"
+} else {
+  Step "authorizing SSH from $myIp/32"
+  $ruleId = (& aws @awsBase ec2 authorize-security-group-ingress `
+    --group-id $sgId `
+    --protocol tcp --port 22 `
+    --cidr "$myIp/32" `
+    --query 'SecurityGroupRules[0].SecurityGroupRuleId' --output text).Trim()
+  if ($LASTEXITCODE -ne 0) { Fail "authorize-security-group-ingress failed" }
+  Write-Host "  rule id: $ruleId"
+}
+
+Write-Host ""
+Write-Host "=== setup complete ==="
+Write-Host "  security group: $SgName ($sgId)"
+Write-Host "  inbound SSH    : $myIp/32 (and any IPs from prior runs)"
+Write-Host ""
+Write-Host "You can now run a remote build with:"
+Write-Host "  .\deploy\release.ps1 -BuildRemote"

--- a/deploy/bin/setup-builder.sh
+++ b/deploy/bin/setup-builder.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# setup-builder.sh — one-time AWS setup for remote builds.
+#
+# Creates the security group used by deploy/bin/remote-build.sh. Run once
+# per AWS account/region; idempotent so re-runs are safe.
+#
+# What it creates:
+#   - Security group `rc-builder-sg` in the default VPC
+#   - Inbound rule: SSH (tcp/22) from your current public IP (/32)
+#
+# What it reuses (not created here):
+#   - EC2 key pair `rc-prod` — the same one you SSH to prod with. The
+#     prod private key is uploaded to the builder transiently per build,
+#     so there's no separate builder key to manage.
+#
+# Env vars (all optional):
+#   RC_BUILDER_PROFILE  AWS CLI profile. Default: rc-prod
+#   RC_BUILDER_REGION   AWS region. Default: us-east-1
+#   RC_BUILDER_SG       SG name. Default: rc-builder-sg
+
+set -euo pipefail
+
+PROFILE="${RC_BUILDER_PROFILE:-rc-prod}"
+REGION="${RC_BUILDER_REGION:-us-east-1}"
+SG_NAME="${RC_BUILDER_SG:-rc-builder-sg}"
+
+AWS=(aws --profile "$PROFILE" --region "$REGION")
+
+echo "[setup-builder] profile=$PROFILE region=$REGION sg=$SG_NAME"
+
+# --- discover your current public IP --------------------------------------
+# We use checkip.amazonaws.com to keep external dependencies inside AWS.
+# Falls back to ifconfig.me on failure.
+MY_IP=$(curl -fsS https://checkip.amazonaws.com 2>/dev/null \
+        || curl -fsS https://ifconfig.me 2>/dev/null \
+        || true)
+MY_IP=$(echo "$MY_IP" | tr -d '\r\n ')
+if [[ ! "$MY_IP" =~ ^[0-9.]+$ ]]; then
+  echo "[setup-builder] fatal: could not detect your public IP" >&2
+  exit 1
+fi
+echo "[setup-builder] your IP: $MY_IP"
+
+# --- default VPC ----------------------------------------------------------
+VPC_ID=$("${AWS[@]}" ec2 describe-vpcs \
+  --filters Name=is-default,Values=true \
+  --query 'Vpcs[0].VpcId' --output text)
+if [[ "$VPC_ID" == "None" || -z "$VPC_ID" ]]; then
+  echo "[setup-builder] fatal: no default VPC in $REGION" >&2
+  exit 1
+fi
+echo "[setup-builder] default VPC: $VPC_ID"
+
+# --- create or reuse security group ---------------------------------------
+SG_ID=$("${AWS[@]}" ec2 describe-security-groups \
+  --filters "Name=group-name,Values=$SG_NAME" "Name=vpc-id,Values=$VPC_ID" \
+  --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo "None")
+
+if [[ "$SG_ID" == "None" || -z "$SG_ID" ]]; then
+  echo "[setup-builder] creating security group $SG_NAME"
+  SG_ID=$("${AWS[@]}" ec2 create-security-group \
+    --group-name "$SG_NAME" \
+    --description "Transient builders for rc release pipeline" \
+    --vpc-id "$VPC_ID" \
+    --query 'GroupId' --output text)
+  "${AWS[@]}" ec2 create-tags \
+    --resources "$SG_ID" \
+    --tags Key=ManagedBy,Value=rc-setup-builder.sh
+else
+  echo "[setup-builder] security group $SG_NAME already exists ($SG_ID)"
+fi
+
+# --- ensure SSH from your IP is allowed -----------------------------------
+# Re-running the script after your IP changes will add a new rule for the
+# new IP. Old rules stay (idempotent — we only ADD); clean them up manually
+# if you want to keep the SG tidy:
+#   aws ec2 revoke-security-group-ingress --group-id $SG_ID --ip-permissions ...
+EXISTING=$("${AWS[@]}" ec2 describe-security-groups --group-ids "$SG_ID" \
+  --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\`].IpRanges[].CidrIp" \
+  --output text)
+if echo "$EXISTING" | grep -q "$MY_IP/32"; then
+  echo "[setup-builder] SSH from $MY_IP/32 already allowed"
+else
+  echo "[setup-builder] authorizing SSH from $MY_IP/32"
+  "${AWS[@]}" ec2 authorize-security-group-ingress \
+    --group-id "$SG_ID" \
+    --protocol tcp --port 22 \
+    --cidr "$MY_IP/32" \
+    --query 'SecurityGroupRules[0].SecurityGroupRuleId' --output text
+fi
+
+echo
+echo "=== setup complete ==="
+echo "  security group: $SG_NAME ($SG_ID)"
+echo "  inbound SSH    : $MY_IP/32 (and any IPs from prior runs)"
+echo
+echo "You can now run a remote build with:"
+echo "  RC_BUILD_REMOTE=1 ./deploy/release.sh"

--- a/deploy/release.ps1
+++ b/deploy/release.ps1
@@ -1,73 +1,104 @@
 <#
 .SYNOPSIS
-  release.ps1 — single-command production deploy (PowerShell port of release.sh)
+  release.ps1 -- single-command production deploy.
 
 .DESCRIPTION
-  Wraps build → extract → ship → verify → recover into one reproducible
-  pipeline. Exits 0 only when prod is verified running the requested
-  revision AND the post-deploy maintenance-recovery pass left no
-  instances stuck.
+  Wraps build -> ship -> verify -> recover into one reproducible pipeline.
+  Exits 0 only when prod is verified running the requested revision AND
+  the post-deploy maintenance-recovery pass left no instances stuck.
 
-  This is a faithful port of deploy/release.sh — same env-var contract,
-  same exit codes, same output format. Use whichever feels native; both
-  call the same docker buildx, deploy.sh, and rc rpc paths underneath.
+  This is the PowerShell entry point; deploy/release.sh is the bash
+  equivalent. Both accept the same flag set and call the same downstream
+  bash helpers (remote-build.sh, deploy.sh).
 
 .PARAMETER Revision
   Git revision to build and deploy. Defaults to HEAD.
 
-.EXAMPLE
-  .\deploy\release.ps1                  # build and deploy HEAD
-  .\deploy\release.ps1 f9e221e          # specific ref
+.PARAMETER BuildRemote
+  Build on a transient AWS Graviton spot instance (native arm64) instead
+  of locally via QEMU. ~5-10 min vs ~35 min for local. Requires AWS
+  profile rc-prod and a one-time deploy/bin/setup-builder.sh run.
+
+.PARAMETER BuildOnly
+  Build + extract tarballs, then exit. Skips deploy, verify, recovery.
+  Combined with -BuildRemote, pulls the tarballs back to .\build\.
+
+.PARAMETER BackOnly
+  Skip the Vue rebuild. Backend-only release.
+
+.PARAMETER SkipBuild
+  Reuse existing build\*.tar.gz instead of rebuilding. Ignores
+  -BuildRemote (no point spinning up a builder for a deploy-only run).
+
+.PARAMETER AllowCache
+  Allow Docker layer cache. Default is --no-cache because cache
+  poisoning of the COPY layer has shipped wrong revisions to prod before.
+
+.PARAMETER OnDemand
+  Skip the spot launch attempt; go straight to on-demand. Only meaningful
+  with -BuildRemote.
+
+.PARAMETER Keep
+  Don't terminate the builder on exit. Debug only -- it will keep costing
+  on-demand prices until you terminate it manually.
+
+.PARAMETER BuilderType
+  EC2 instance type for remote builds. Default: c7g.4xlarge.
+
+.PARAMETER VueBaseUrl
+  Public URL baked into the Vue bundle. Default: https://tetrarchyfalls.com
+
+.PARAMETER VueAppsignalKey
+  AppSignal frontend key. Default: empty.
 
 .EXAMPLE
-  $env:RC_SKIP_BUILD=1
-  .\deploy\release.ps1                  # reuse existing build\*.tar.gz
+  .\deploy\release.ps1
+  Build and deploy HEAD using the local QEMU path.
+
+.EXAMPLE
+  .\deploy\release.ps1 -BuildRemote
+  Build on a Graviton spot and ship to prod.
+
+.EXAMPLE
+  .\deploy\release.ps1 -BuildRemote -BuildOnly
+  Benchmark a remote build, pull tarballs back to .\build\, don't deploy.
+
+.EXAMPLE
+  .\deploy\release.ps1 f9e221e -BackOnly
+  Backend-only deploy of a specific revision via the local path.
 
 .NOTES
-  Env vars (all optional, behavior matches release.sh):
-
-    RC_SKIP_BUILD=1     Reuse existing build\*.tar.gz instead of rebuilding.
-    RC_BUILD_ONLY=1     Build + extract tarballs, then exit. No deploy.
-    RC_BACK_ONLY=1      Skip the Vue rebuild (~15-20 min instead of ~30-50).
-    RC_NO_CACHE=0       Allow Docker layer cache. Default is on (--no-cache)
-                        because cache poisoning has shipped wrong revisions
-                        to prod before.
-    VUE_APP_BASE_URL    Public URL baked into the Vue bundle.
-                        Default: https://tetrarchyfalls.com
-    VUE_APP_APPSIGNAL_FRONT  AppSignal frontend key. Unused; defaults to "".
-
-  SSH connection (mirrors nodes.sh defaults):
-
-    RC_SSH_HOST         Default: rc@ec2-98-91-16-141.compute-1.amazonaws.com
-    SSH_KEY             Default: $HOME\.ssh\rc-prod.pem
-    RC_SSH_PORT         Default: 22
-    RC_SSH_EXTRA_OPTS   Extra opts passed verbatim to ssh.
-
   Exit codes:
-
-    0  PASS    — prod runs the requested revision, no failures.
-    1  FAIL    — build, deploy, or revision-match verification failed.
-    2  PARTIAL — deploy succeeded and revision matches, but one or more
-                 instances failed to come out of maintenance.
+    0  PASS    -- prod runs the requested revision, no failures.
+    1  FAIL    -- build, deploy, or verification failed.
+    2  PARTIAL -- deploy succeeded but some instances stuck in maintenance.
 
   Requirements on the Windows host:
-    - Docker Desktop running (provides docker.exe + buildx).
+    - Docker Desktop running (only for the local-build path).
     - Git for Windows installed (provides bash.exe + ssh.exe).
-      deploy/bin/deploy.sh is a bash script; this wrapper invokes it via
-      bash.exe. If you have multiple bash installs in PATH (e.g. WSL),
-      git-bash is the recommended one.
     - EC2 key at $HOME\.ssh\rc-prod.pem.
 #>
 
 [CmdletBinding()]
 param(
   [Parameter(Position=0)]
-  [string]$Revision = "HEAD"
+  [string]$Revision = "HEAD",
+
+  [switch]$BuildRemote,
+  [switch]$BuildOnly,
+  [switch]$BackOnly,
+  [switch]$SkipBuild,
+  [switch]$AllowCache,
+  [switch]$OnDemand,
+  [switch]$Keep,
+  [string]$BuilderType = "c7g.4xlarge",
+  [string]$VueBaseUrl = "https://tetrarchyfalls.com",
+  [string]$VueAppsignalKey = ""
 )
 
 $ErrorActionPreference = "Stop"
-# Force UTF-8 on the pipe to native commands so the recovery heredoc
-# reaches the remote bash intact even if it contains non-ASCII bytes.
+# Force UTF-8 on the pipe to native commands so the recovery heredoc reaches
+# the remote bash intact even if it contains non-ASCII bytes.
 $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 
 function Step([string]$msg) {
@@ -83,7 +114,7 @@ function Fail([string]$msg, [int]$code = 1) {
 # C:\Windows\System32\bash.exe (WSL stub) first, which tries to exec
 # /bin/bash inside a WSL distro and fails noisily if WSL isn't set up.
 # We want Git for Windows's bash, which understands MSYS paths and runs
-# deploy.sh's POSIX-isms without surprises.
+# our POSIX scripts without surprises.
 function Get-GitBashPath {
   $candidates = @(
     (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
@@ -93,12 +124,19 @@ function Get-GitBashPath {
   foreach ($p in $candidates) {
     if ($p -and (Test-Path $p)) { return $p }
   }
-  # Last resort: any bash in PATH that isn't the WSL stub.
   $found = & where.exe bash 2>$null |
     Where-Object { $_ -and ($_ -notmatch [regex]::Escape("$env:WINDIR\System32\bash.exe")) } |
     Select-Object -First 1
   if ($found) { return $found }
   return $null
+}
+
+# Single-quote a value for inline-env-var assignment to a bash command line.
+# We use bash -c "FOO='val' BAR='val' exec ./script.sh" to set env on the
+# child without polluting the PS session. Embedded single quotes get
+# escaped via the standard '\'' trick.
+function BashEnvLit([string]$v) {
+  "'" + ($v -replace "'", "'\''") + "'"
 }
 
 # === 0. locate repo root and pin cwd =========================================
@@ -121,72 +159,170 @@ try {
     [System.Text.UTF8Encoding]::new($false))
   Step "target revision: $resolved"
 
-  # === 2. resolve options ====================================================
-  $skipBuild = $env:RC_SKIP_BUILD -eq '1'
-  $buildOnly = $env:RC_BUILD_ONLY -eq '1'
-  $backOnly  = $env:RC_BACK_ONLY  -eq '1'
-  $noCache   = $env:RC_NO_CACHE -ne '0'  # default ON
+  # === 2. derived options ====================================================
+  $backOnlyBool = if ($BackOnly) { 'true' } else { 'false' }
 
-  $vueBase   = if ($env:VUE_APP_BASE_URL) { $env:VUE_APP_BASE_URL } else { 'https://tetrarchyfalls.com' }
-  $appsignal = if ($env:VUE_APP_APPSIGNAL_FRONT) { $env:VUE_APP_APPSIGNAL_FRONT } else { '' }
-
-  # === 3. build (default: --no-cache to defeat layer-cache poisoning) =======
-  if ($skipBuild) {
-    Step "RC_SKIP_BUILD=1 — reusing build\*.tar.gz"
+  # === 3. build ==============================================================
+  if ($SkipBuild) {
+    Step "-SkipBuild -- reusing build\*.tar.gz"
+    if ($BuildRemote) {
+      Step "  (ignoring -BuildRemote: no point spinning up a builder for a deploy-only run)"
+    }
     if (-not (Test-Path "build\rc.tar.gz")) {
-      Fail "build\rc.tar.gz missing — run a build first"
+      Fail "build\rc.tar.gz missing -- run a build first"
     }
-    if (-not $backOnly -and -not (Test-Path "build\vue.tar.gz")) {
-      Fail "build\vue.tar.gz missing (set RC_BACK_ONLY=1 to skip Vue)"
+    if (-not $BackOnly -and -not (Test-Path "build\vue.tar.gz")) {
+      Fail "build\vue.tar.gz missing (pass -BackOnly to skip Vue)"
     }
+    $remoteUsed = $false
+  }
+  elseif ($BuildRemote) {
+    # Remote build path: launches a transient Graviton spot, builds natively,
+    # ships tarballs builder->prod, runs deploy.sh on the builder.
+    # NOTE: in remote mode deploy.sh runs on the builder, so we SKIP the
+    # local deploy.sh invocation later.
+    Step "-BuildRemote -- building on transient AWS Graviton"
+    $gitBash = Get-GitBashPath
+    if (-not $gitBash) {
+      Fail "git-bash not found -- install Git for Windows (https://git-scm.com/download/win)"
+    }
+
+    # Build the env-var prefix for bash. Internal contract with remote-build.sh
+    # -- these are NOT user-facing flags, just how the parent passes state to
+    # the helper. Inline assignment + exec keeps it scoped to the child.
+    $envAssigns = @(
+      "REVISION=$(BashEnvLit $resolved)",
+      "BACK_ONLY_BOOL=$(BashEnvLit $backOnlyBool)",
+      "VUE_BASE=$(BashEnvLit $VueBaseUrl)",
+      "VUE_APP_APPSIGNAL_FRONT=$(BashEnvLit $VueAppsignalKey)"
+    )
+    if ($BuildOnly)    { $envAssigns += "RC_BUILD_ONLY=1" }
+    if ($OnDemand)     { $envAssigns += "RC_BUILDER_ON_DEMAND=1" }
+    if ($Keep)         { $envAssigns += "RC_BUILDER_KEEP=1" }
+    if ($BuilderType -ne "c7g.4xlarge") {
+      $envAssigns += "RC_BUILDER_TYPE=$(BashEnvLit $BuilderType)"
+    }
+
+    $cmdline = ($envAssigns -join ' ') + ' exec ./deploy/bin/remote-build.sh'
+
+    # Capture all output to a timestamped log file under build/. Terminal
+    # stays quiet during the multi-minute build instead of being flooded
+    # with docker buildx output. On failure we tail the log automatically
+    # so the operator doesn't have to open it. The log survives a spot
+    # interruption mid-build because it's written to the operator's disk,
+    # not the builder's ephemeral storage.
+    New-Item -ItemType Directory -Force "build" | Out-Null
+    $logFile = "build\remote-build-$resolved-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+    Step "  output -> $logFile"
+    Step "  (terminal stays quiet; ~7-10 min. follow live in another shell:"
+    Step "    Get-Content '$logFile' -Wait )"
+
+    & $gitBash -c $cmdline *> $logFile
+    $buildExit = $LASTEXITCODE
+
+    if ($buildExit -ne 0) {
+      Step "remote build FAILED (exit $buildExit) -- last 50 lines of log:"
+      Get-Content $logFile -Tail 50 | ForEach-Object { Write-Host "  $_" }
+      Fail "remote-build.sh failed (exit $buildExit) -- full log: $logFile"
+    }
+
+    # Build succeeded. Show the per-phase timings table (last ~12 lines of
+    # the log) on the terminal so the operator sees the headline result
+    # without opening the file.
+    Step "remote build complete -- phase timings from $logFile :"
+    Get-Content $logFile -Tail 12 | ForEach-Object { Write-Host "  $_" }
+    $remoteUsed = $true
   }
   else {
+    # Local QEMU path: docker buildx with --platform linux/arm64 on x86.
+    # Slow (~35 min) but doesn't need AWS. Useful as a fallback.
     $cacheFlag = @()
-    if ($noCache) { $cacheFlag += "--no-cache" }
-    $backOnlyBool = if ($backOnly) { 'true' } else { 'false' }
+    if (-not $AllowCache) { $cacheFlag += "--no-cache" }
 
-    Step "building arm64 release (BACK_ONLY=$backOnlyBool, NO_CACHE=$([int]$noCache))"
-    & docker buildx build @cacheFlag --platform linux/arm64 --load -t rc_build_image `
-      --build-arg "APP_REVISION=$resolved" `
-      --build-arg "BACK_ONLY=$backOnlyBool" `
-      --build-arg "VUE_APP_BASE_URL=$vueBase" `
-      --build-arg "VUE_APP_APPSIGNAL_FRONT=$appsignal" `
-      .
-    if ($LASTEXITCODE -ne 0) { Fail "docker buildx build failed (exit $LASTEXITCODE)" }
+    Step "building arm64 release locally via QEMU (BackOnly=$BackOnly, AllowCache=$AllowCache)"
+    Step "  tip: pass -BuildRemote to build on a native-arm Graviton in ~5-10min"
 
-    Step "extracting tarballs"
-    & docker rm -f rc_extract *> $null
-    & docker create --platform linux/arm64 --name rc_extract rc_build_image *> $null
-    if ($LASTEXITCODE -ne 0) { Fail "docker create failed (exit $LASTEXITCODE)" }
-    & docker cp "rc_extract:/home/rc/build/rc.tar.gz" "./build/"
-    if ($LASTEXITCODE -ne 0) { Fail "docker cp rc.tar.gz failed" }
-    if (-not $backOnly) {
-      & docker cp "rc_extract:/home/rc/build/vue.tar.gz" "./build/"
-      if ($LASTEXITCODE -ne 0) { Fail "docker cp vue.tar.gz failed" }
+    # Capture all output to a timestamped log file under build/. Same
+    # pattern as the -BuildRemote branch above; keeps the terminal quiet
+    # during a ~35 min build and auto-tails the log if buildx fails.
+    New-Item -ItemType Directory -Force "build" | Out-Null
+    $logFile = "build\local-build-$resolved-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+    Step "  output -> $logFile"
+    Step "  (terminal stays quiet; ~35 min for full local build. Follow live:"
+    Step "    Get-Content '$logFile' -Wait )"
+
+    # BUILDKIT_PROGRESS=plain makes the captured log readable (the default
+    # TTY progress bars use CR-overwrites + ANSI that turn into noise in
+    # a file). Scoped via try/finally so it doesn't leak into the PS
+    # session if buildx throws.
+    $t0 = Get-Date
+    $env:BUILDKIT_PROGRESS = "plain"
+    try {
+      & docker buildx build @cacheFlag --platform linux/arm64 --load -t rc_build_image `
+        --build-arg "APP_REVISION=$resolved" `
+        --build-arg "BACK_ONLY=$backOnlyBool" `
+        --build-arg "VUE_APP_BASE_URL=$VueBaseUrl" `
+        --build-arg "VUE_APP_APPSIGNAL_FRONT=$VueAppsignalKey" `
+        . *> $logFile
+      $buildExit = $LASTEXITCODE
+    } finally {
+      Remove-Item Env:BUILDKIT_PROGRESS -ErrorAction SilentlyContinue
     }
-    & docker rm rc_extract *> $null
+
+    if ($buildExit -ne 0) {
+      Step "local build FAILED (exit $buildExit) -- last 50 lines of log:"
+      Get-Content $logFile -Tail 50 | ForEach-Object { Write-Host "  $_" }
+      Fail "docker buildx build failed (exit $buildExit) -- full log: $logFile"
+    }
+
+    # Extract tarballs from the build image. Fast (seconds) but redirected
+    # too so a single log captures the whole local-build phase. Append-all
+    # (*>>) preserves the buildx output already in the file.
+    & docker rm -f rc_extract *>> $logFile
+    & docker create --platform linux/arm64 --name rc_extract rc_build_image *>> $logFile
+    if ($LASTEXITCODE -ne 0) {
+      Step "docker create FAILED -- last 30 lines of log:"
+      Get-Content $logFile -Tail 30 | ForEach-Object { Write-Host "  $_" }
+      Fail "docker create failed (exit $LASTEXITCODE) -- full log: $logFile"
+    }
+    & docker cp "rc_extract:/home/rc/build/rc.tar.gz" "./build/" *>> $logFile
+    if ($LASTEXITCODE -ne 0) { Fail "docker cp rc.tar.gz failed -- full log: $logFile" }
+    if (-not $BackOnly) {
+      & docker cp "rc_extract:/home/rc/build/vue.tar.gz" "./build/" *>> $logFile
+      if ($LASTEXITCODE -ne 0) { Fail "docker cp vue.tar.gz failed -- full log: $logFile" }
+    }
+    & docker rm rc_extract *>> $logFile
+
+    $elapsed = [int]((Get-Date) - $t0).TotalSeconds
+    Step "local build complete in ${elapsed}s -- full log: $logFile"
+    $remoteUsed = $false
   }
 
-  if ($buildOnly) {
-    Step "RC_BUILD_ONLY=1 — tarballs in build\, skipping deploy"
+  # === 4. build-only short-circuit ==========================================
+  if ($BuildOnly) {
+    Step "-BuildOnly -- tarballs in build\, skipping deploy"
     Get-ChildItem build\*.tar.gz | Format-Table Name, Length, LastWriteTime -AutoSize
     exit 0
   }
 
-  # === 4. ship to prod (delegate to deploy.sh — leave it alone) =============
-  # deploy.sh is bash. Resolve git-bash explicitly because a bare `bash` on
-  # Windows resolves to the WSL stub first and fails with
-  # `execvpe(/bin/bash) failed: No such file or directory` when WSL isn't
-  # set up. See Get-GitBashPath above for the lookup order.
-  $gitBash = Get-GitBashPath
-  if (-not $gitBash) {
-    Fail "git-bash not found — install Git for Windows (https://git-scm.com/download/win)"
+  # === 5. ship to prod ======================================================
+  # In remote mode, deploy.sh already ran on the builder -- skip the local
+  # invocation. deploy.sh is bash; resolve git-bash explicitly because a
+  # bare `bash` on Windows resolves to the WSL stub first.
+  if (-not $remoteUsed) {
+    $gitBash = Get-GitBashPath
+    if (-not $gitBash) {
+      Fail "git-bash not found -- install Git for Windows (https://git-scm.com/download/win)"
+    }
+    Step "running deploy/bin/deploy.sh (via $gitBash)"
+    & $gitBash "deploy/bin/deploy.sh"
+    if ($LASTEXITCODE -ne 0) { Fail "deploy.sh failed (exit $LASTEXITCODE)" }
   }
-  Step "running deploy/bin/deploy.sh (via $gitBash)"
-  & $gitBash "deploy/bin/deploy.sh"
-  if ($LASTEXITCODE -ne 0) { Fail "deploy.sh failed (exit $LASTEXITCODE)" }
+  else {
+    Step "skipping local deploy.sh -- deploy was run on the builder"
+  }
 
-  # === 5. resolve SSH connection params (mirror nodes.sh) ===================
+  # === 6. resolve SSH connection params (mirror nodes.sh) ===================
   $sshHost  = if ($env:RC_SSH_HOST)  { $env:RC_SSH_HOST }  else { 'rc@ec2-98-91-16-141.compute-1.amazonaws.com' }
   $sshKey   = if ($env:SSH_KEY)      { $env:SSH_KEY }       else { Join-Path $HOME '.ssh\rc-prod.pem' }
   $sshPort  = if ($env:RC_SSH_PORT)  { $env:RC_SSH_PORT }  else { '22' }
@@ -196,7 +332,7 @@ try {
     $sshArgs += ($env:RC_SSH_EXTRA_OPTS -split '\s+' | Where-Object { $_ })
   }
 
-  # === 6. verify deployed revision (read priv/VERSION on prod, NOT journal) =
+  # === 7. verify deployed revision (read priv/VERSION on prod, NOT journal) =
   Step "verifying deployed revision on $sshHost"
   $prodRevRaw = & ssh @sshArgs $sshHost 'cat /home/rc/rc/lib/rc-*/priv/VERSION 2>/dev/null'
   $prodRev = ($prodRevRaw | Out-String) -replace '\s', ''
@@ -205,23 +341,20 @@ try {
     $prodDisplay = if ($prodRev) { $prodRev } else { '<unreadable>' }
     Write-Host ""
     Write-Host "========================================" -ForegroundColor Red
-    Write-Host "  RELEASE: FAIL — wrong revision live"   -ForegroundColor Red
+    Write-Host "  RELEASE: FAIL -- wrong revision live"   -ForegroundColor Red
     Write-Host "========================================" -ForegroundColor Red
     Write-Host "  expected : $resolved"
     Write-Host "  prod     : $prodDisplay"
     Write-Host "========================================" -ForegroundColor Red
     Write-Host "  The deploy itself ran but prod is on the wrong revision. Likely cause:"
-    Write-Host "  Docker layer cache served a stale COPY layer. Re-run with RC_NO_CACHE=1"
-    Write-Host "  (default) and verify rc_build_image was rebuilt (not cache-hit)."
+    Write-Host "  Docker layer cache served a stale COPY layer. Re-run without -AllowCache"
+    Write-Host "  and verify rc_build_image was rebuilt (not cache-hit)."
     exit 1
   }
 
-  # === 7. per-instance maintenance recovery =================================
+  # === 8. per-instance maintenance recovery =================================
   Step "running per-instance maintenance recovery"
 
-  # Heredoc piped to remote bash. Single-quoted PS here-string means no
-  # variable expansion on our side. The remote rpc gets the Elixir code
-  # via single-quoted shell, so $ and #{...} pass through literally.
   $remoteScript = @'
 set -e
 cd /home/rc
@@ -257,11 +390,9 @@ set -a; . /etc/rc/env; set +a
 '@
 
   # Strip ALL CRs. PowerShell here-strings preserve CRLF on Windows, AND
-  # the `|` pipeline to a native command re-injects the OS line terminator
-  # (CRLF on Windows) — so a simple -replace on the heredoc isn't enough.
-  # The Elixir parser bails with `unexpected token: carriage return` if any
-  # ^M survives. Belt-and-braces: strip them now, then write bytes directly
-  # to ssh's stdin (skipping the pipeline) below.
+  # the `|` pipeline to a native command re-injects the OS line terminator --
+  # so a simple -replace on the heredoc isn't enough. The Elixir parser
+  # bails with `unexpected token: carriage return` if any ^M survives.
   $remoteScript = $remoteScript -replace "`r", ""
 
   # Drive ssh via .NET Process so we can write raw UTF-8 bytes to stdin
@@ -287,9 +418,6 @@ set -a; . /etc/rc/env; set +a
   $proc.StandardInput.BaseStream.Write($scriptBytes, 0, $scriptBytes.Length)
   $proc.StandardInput.Close()
 
-  # Read both streams before WaitForExit to avoid the classic pipe-fills
-  # deadlock. Output here is small (a few result lines), so sequential
-  # ReadToEnd is fine.
   $stdout = $proc.StandardOutput.ReadToEnd()
   $stderr = $proc.StandardError.ReadToEnd()
   $proc.WaitForExit()
@@ -307,15 +435,39 @@ set -a; . /etc/rc/env; set +a
     }
   }
 
-  # If the rpc itself errored (couldn't even start), we'll have neither
-  # restored nor failed lines but a non-zero exit. Treat as partial.
   $rpcProbablyBroken = (
     $recoveryExit -ne 0 -and
     $restoredIds.Count -eq 0 -and
     $failedLines.Count -eq 0
   )
 
-  # === 8. final summary =====================================================
+  # === 9. CloudFront invalidation (remote-build mode only) ==================
+  # deploy.sh's tail handles this when it runs locally. In remote mode it
+  # ran on the builder with no AWS credentials, so the invalidation was
+  # warn-and-skipped. Re-run it here from the operator's box. Skipped for
+  # backend-only deploys (no Vue change to invalidate).
+  if ($remoteUsed -and -not $BackOnly) {
+    Step "running CloudFront invalidation (post-remote-build)"
+    $cfIdFile = Join-Path $repo ".secrets\cf_distribution_id.txt"
+    if (-not (Test-Path $cfIdFile)) {
+      Write-Host "[release] WARNING: .secrets\cf_distribution_id.txt missing -- skipping invalidation" -ForegroundColor Yellow
+    }
+    elseif (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+      Write-Host "[release] WARNING: aws CLI not installed locally -- skipping invalidation" -ForegroundColor Yellow
+    }
+    else {
+      $cfDistId = (Get-Content $cfIdFile -Raw).Trim()
+      & aws --profile rc-prod cloudfront create-invalidation `
+        --distribution-id $cfDistId `
+        --paths '/portal/*' `
+        --query 'Invalidation.[Id,Status]' --output text
+      if ($LASTEXITCODE -ne 0) {
+        Write-Host "[release] WARNING: invalidation failed -- edge caches will age out naturally" -ForegroundColor Yellow
+      }
+    }
+  }
+
+  # === 10. final summary ====================================================
   $restoredStr = if ($restoredIds.Count -gt 0) { $restoredIds -join ' ' } else { 'none' }
 
   Write-Host ""
@@ -328,9 +480,9 @@ set -a; . /etc/rc/env; set +a
   if ($failedLines.Count -gt 0) {
     Write-Host "  failed        :"
     foreach ($f in $failedLines) { Write-Host "    $f" }
-    Write-Host "  (instances still in maintenance — investigate via ssh)"
+    Write-Host "  (instances still in maintenance -- investigate via ssh)"
     Write-Host "========================================"
-    Write-Host "  RELEASE: PARTIAL — recovery incomplete" -ForegroundColor Yellow
+    Write-Host "  RELEASE: PARTIAL -- recovery incomplete" -ForegroundColor Yellow
     exit 2
   }
 
@@ -341,7 +493,7 @@ set -a; . /etc/rc/env; set +a
       if ($line) { Write-Host "    $line" }
     }
     Write-Host "========================================"
-    Write-Host "  RELEASE: PARTIAL — recovery rpc errored" -ForegroundColor Yellow
+    Write-Host "  RELEASE: PARTIAL -- recovery rpc errored" -ForegroundColor Yellow
     exit 2
   }
 

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -8,24 +8,30 @@
 # instances stuck.
 #
 # Usage:
-#   ./deploy/release.sh                  # build and deploy HEAD
-#   ./deploy/release.sh <git-ref>        # build and deploy a specific ref
+#   ./deploy/release.sh [flags] [<git-ref>]
 #
-# Env vars (all optional):
-#   RC_SKIP_BUILD=1     Reuse existing build/*.tar.gz instead of rebuilding.
-#                       Use after a manual `make build` / `make build-back`.
-#   RC_BUILD_ONLY=1     Build + extract tarballs, then exit. Skips deploy,
-#                       verify, and recovery. Useful for testing builds
-#                       without touching prod.
-#   RC_BACK_ONLY=1      Skip the Vue rebuild (faster — ~15-20 min instead of
-#                       ~30-50 min on amd64-emulating-arm64). Skips Vue
-#                       extraction too; existing vue.tar.gz is not touched.
-#   RC_NO_CACHE=0       Allow Docker layer cache. Default is 1 (--no-cache)
-#                       because cache poisoning of the COPY layer has
-#                       shipped wrong revisions to prod in the past.
-#   VUE_APP_BASE_URL    Public URL baked into the Vue bundle.
-#                       Default: https://tetrarchyfalls.com
-#   VUE_APP_APPSIGNAL_FRONT  AppSignal frontend key. Unused; defaults to empty.
+# Flags:
+#   --remote             Build on a transient AWS Graviton spot instance
+#                        (native arm64) instead of locally via QEMU. Ships
+#                        tarballs builder→prod directly. ~5-10min vs ~35min
+#                        local. Requires AWS profile rc-prod and a one-time
+#                        `deploy/bin/setup-builder.sh` run.
+#   --build-only         Build + extract tarballs, then exit. With --remote,
+#                        pulls tarballs back to ./build/ and skips deploy.
+#   --back-only          Skip the Vue rebuild (backend-only release).
+#   --skip-build         Reuse existing build/*.tar.gz instead of rebuilding.
+#                        Ignores --remote (no builder needed for deploy-only).
+#   --cache              Allow Docker layer cache. Default is --no-cache
+#                        because cache poisoning of the COPY layer has
+#                        shipped wrong revisions to prod in the past.
+#   --on-demand          Skip the spot attempt, launch on-demand. With --remote.
+#   --keep               Don't terminate the builder on exit (debug only).
+#   --builder-type <t>   EC2 instance type for the remote builder.
+#                        Default: c7g.4xlarge.
+#   --vue-base <url>     Public URL baked into the Vue bundle.
+#                        Default: https://tetrarchyfalls.com
+#   --vue-appsignal <k>  AppSignal frontend key. Default: empty.
+#   -h, --help           Show this and exit.
 #
 # Exit codes:
 #   0  PASS    — prod runs the requested revision, no failures.
@@ -43,8 +49,43 @@ set -euo pipefail
 REPO=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO"
 
+# === flags ====================================================================
+REV_INPUT="HEAD"
+BUILD_REMOTE=0
+BUILD_ONLY=0
+BACK_ONLY=0
+SKIP_BUILD=0
+ALLOW_CACHE=0
+ON_DEMAND=0
+KEEP_BUILDER=0
+BUILDER_TYPE="c7g.4xlarge"
+VUE_BASE="https://tetrarchyfalls.com"
+VUE_APPSIGNAL_KEY=""
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote)         BUILD_REMOTE=1; shift ;;
+    --build-only)     BUILD_ONLY=1; shift ;;
+    --back-only)      BACK_ONLY=1; shift ;;
+    --skip-build)     SKIP_BUILD=1; shift ;;
+    --cache)          ALLOW_CACHE=1; shift ;;
+    --on-demand)      ON_DEMAND=1; shift ;;
+    --keep)           KEEP_BUILDER=1; shift ;;
+    --builder-type)   BUILDER_TYPE="${2:?--builder-type requires a value}"; shift 2 ;;
+    --vue-base)       VUE_BASE="${2:?--vue-base requires a value}"; shift 2 ;;
+    --vue-appsignal)  VUE_APPSIGNAL_KEY="${2:?--vue-appsignal requires a value}"; shift 2 ;;
+    -h|--help)        usage; exit 0 ;;
+    --)               shift; REV_INPUT="${1:-HEAD}"; break ;;
+    -*)               echo "[release] unknown flag: $1" >&2; echo "  run --help for usage" >&2; exit 1 ;;
+    *)                REV_INPUT="$1"; shift ;;
+  esac
+done
+
 # === 1. resolve target revision ===============================================
-REV_INPUT="${1:-HEAD}"
 if ! REVISION=$(git rev-parse --short "$REV_INPUT" 2>/dev/null); then
   echo "[release] fatal: unknown git revision '$REV_INPUT'" >&2
   exit 1
@@ -52,32 +93,53 @@ fi
 echo "$REVISION" > priv/VERSION
 echo "[release] target revision: $REVISION"
 
-# === 2. build (default: --no-cache to defeat layer-cache poisoning) ==========
-BACK_ONLY=${RC_BACK_ONLY:-0}
-NO_CACHE=${RC_NO_CACHE:-1}
-VUE_BASE=${VUE_APP_BASE_URL:-https://tetrarchyfalls.com}
+# === 2. build =================================================================
+if [[ "$BACK_ONLY" == "1" ]]; then BACK_ONLY_BOOL=true; else BACK_ONLY_BOOL=false; fi
+REMOTE_USED=0
 
-if [[ "${RC_SKIP_BUILD:-0}" == "1" ]]; then
-  echo "[release] RC_SKIP_BUILD=1 — reusing build/*.tar.gz"
+if [[ "$SKIP_BUILD" == "1" ]]; then
+  echo "[release] --skip-build — reusing build/*.tar.gz"
+  if [[ "$BUILD_REMOTE" == "1" ]]; then
+    echo "[release]   (ignoring --remote: no point spinning up a builder for a deploy-only run)"
+  fi
   if [[ ! -f build/rc.tar.gz ]]; then
     echo "[release] fatal: build/rc.tar.gz missing — run a build first" >&2
     exit 1
   fi
   if [[ "$BACK_ONLY" != "1" && ! -f build/vue.tar.gz ]]; then
-    echo "[release] fatal: build/vue.tar.gz missing (set RC_BACK_ONLY=1 to skip Vue)" >&2
+    echo "[release] fatal: build/vue.tar.gz missing (pass --back-only to skip Vue)" >&2
     exit 1
   fi
+elif [[ "$BUILD_REMOTE" == "1" ]]; then
+  # Remote build path: launches a transient Graviton spot, builds natively,
+  # ships tarballs builder→prod, runs deploy.sh on the builder.
+  # NOTE: deploy.sh runs on the builder via remote-build.sh, so we SKIP the
+  # local deploy.sh invocation later.
+  echo "[release] --remote — building on transient AWS Graviton"
+
+  # Internal env-var contract with remote-build.sh — not user-visible.
+  export REVISION
+  export BACK_ONLY_BOOL
+  export VUE_BASE
+  export VUE_APP_APPSIGNAL_FRONT="$VUE_APPSIGNAL_KEY"
+  [[ "$BUILD_ONLY"   == "1" ]] && export RC_BUILD_ONLY=1
+  [[ "$ON_DEMAND"    == "1" ]] && export RC_BUILDER_ON_DEMAND=1
+  [[ "$KEEP_BUILDER" == "1" ]] && export RC_BUILDER_KEEP=1
+  [[ "$BUILDER_TYPE" != "c7g.4xlarge" ]] && export RC_BUILDER_TYPE="$BUILDER_TYPE"
+
+  ./deploy/bin/remote-build.sh
+  REMOTE_USED=1
 else
   CACHE_FLAG=()
-  [[ "$NO_CACHE" == "1" ]] && CACHE_FLAG+=(--no-cache)
-  if [[ "$BACK_ONLY" == "1" ]]; then BACK_ONLY_BOOL=true; else BACK_ONLY_BOOL=false; fi
+  [[ "$ALLOW_CACHE" == "0" ]] && CACHE_FLAG+=(--no-cache)
 
-  echo "[release] building arm64 release (BACK_ONLY=$BACK_ONLY_BOOL, NO_CACHE=$NO_CACHE)"
+  echo "[release] building arm64 release locally via QEMU (BackOnly=$BACK_ONLY_BOOL, AllowCache=$ALLOW_CACHE)"
+  echo "[release]   tip: pass --remote to build on a native-arm Graviton in ~5-10min"
   docker buildx build "${CACHE_FLAG[@]}" --platform linux/arm64 --load -t rc_build_image \
     --build-arg APP_REVISION="$REVISION" \
     --build-arg BACK_ONLY="$BACK_ONLY_BOOL" \
     --build-arg VUE_APP_BASE_URL="$VUE_BASE" \
-    --build-arg VUE_APP_APPSIGNAL_FRONT="${VUE_APP_APPSIGNAL_FRONT:-}" \
+    --build-arg VUE_APP_APPSIGNAL_FRONT="$VUE_APPSIGNAL_KEY" \
     .
 
   echo "[release] extracting tarballs"
@@ -90,15 +152,20 @@ else
   docker rm rc_extract >/dev/null
 fi
 
-if [[ "${RC_BUILD_ONLY:-0}" == "1" ]]; then
-  echo "[release] RC_BUILD_ONLY=1 — tarballs in build/, skipping deploy"
+if [[ "$BUILD_ONLY" == "1" ]]; then
+  echo "[release] --build-only — tarballs in build/, skipping deploy"
   ls -la build/*.tar.gz
   exit 0
 fi
 
 # === 3. ship to prod (delegate to deploy.sh — leave it alone) =================
-echo "[release] running deploy/bin/deploy.sh"
-./deploy/bin/deploy.sh
+# In --remote mode this already happened on the builder; skip.
+if [[ "$REMOTE_USED" == "0" ]]; then
+  echo "[release] running deploy/bin/deploy.sh"
+  ./deploy/bin/deploy.sh
+else
+  echo "[release] skipping local deploy.sh — deploy was run on the builder"
+fi
 
 # === 4. verify deployed revision (read priv/VERSION on prod, NOT journal) =====
 # Reading from the static file is immune to journalctl rollover, which is
@@ -208,6 +275,28 @@ if [[ "$RPC_PROBABLY_BROKEN" -eq 1 ]]; then
   echo "========================================"
   echo "  RELEASE: PARTIAL — recovery rpc errored"
   exit 2
+fi
+
+# === 7. CloudFront invalidation (remote-build mode only) ======================
+# deploy.sh's tail does this when it runs locally. In --remote mode deploy.sh
+# ran on the builder, which has no aws credentials, so its invalidation was
+# warn-and-skipped. Re-run it here from the operator's box. Skipped for
+# back-only deploys (no Vue change to invalidate) and for the local-build
+# path (already handled by deploy.sh).
+if [[ "$REMOTE_USED" == "1" && "$BACK_ONLY" != "1" ]]; then
+  echo "[release] running CloudFront invalidation (post-remote-build)"
+  if [[ ! -f .secrets/cf_distribution_id.txt ]]; then
+    echo "[release] WARNING: .secrets/cf_distribution_id.txt missing — skipping invalidation"
+  elif ! command -v aws >/dev/null 2>&1; then
+    echo "[release] WARNING: aws CLI not installed locally — skipping invalidation"
+  else
+    CF_DIST_ID=$(cat .secrets/cf_distribution_id.txt)
+    aws --profile rc-prod cloudfront create-invalidation \
+      --distribution-id "$CF_DIST_ID" \
+      --paths '/portal/*' \
+      --query 'Invalidation.[Id,Status]' --output text \
+      || echo "[release] WARNING: invalidation failed — edge caches will age out naturally"
+  fi
 fi
 
 echo "  failed        : none"


### PR DESCRIPTION
Local arm64 builds via QEMU on x86 take ~35 min on a high-end desktop. This adds a remote-build path that launches a transient AWS Graviton spot instance (native arm64), builds there, and ships tarballs to prod directly. End-to-end ~7 min vs ~35 min; ~$0.03/build on spot, ~$0.08 on-demand fallback.

Also replaces env-var-driven control flow in release.sh and release.ps1 with proper flag interfaces (--remote / -BuildRemote, --build-only / -BuildOnly, etc.). Build output redirects to a per-build log file under build/ so the terminal stays clean during multi-minute builds; on failure the last 50 lines auto-tail.