### PR TITLE
Claude/focused sanderson 0ff9cc

### DIFF
--- a/front/src/game/map/blocks/system.js
+++ b/front/src/game/map/blocks/system.js
@@ -1,6 +1,11 @@
 import {
+  Color,
+  FrontSide,
   Group,
+  InstancedMesh,
   Mesh,
+  MeshBasicMaterial,
+  Object3D,
   RingGeometry,
   ShapeBufferGeometry,
   PlaneGeometry,
@@ -15,6 +20,17 @@ import Block from './block';
 
 const nearHoverDisk = new RingGeometry(0.0001, 0.5, 32);
 const farHoverDisk = new RingGeometry(0.0001, 2, 32);
+
+// Unit-radius ring geometry shared by every per-mode rings InstancedMesh.
+// Each instance is scaled to its actual radius via setMatrixAt — one
+// geometry instead of one-per-system collapses N draw calls + N
+// vertex buffers into 1.
+const ringUnitGeometry = new RingGeometry(0.0001, 1, 128);
+
+// Reusable scratch objects for building instance matrices/colors so the
+// per-system loop doesn't allocate in a hot rebuild path.
+const _scratchDummy = new Object3D();
+const _scratchColor = new Color();
 
 const modes = ['population', 'visibility', 'radar'];
 
@@ -127,6 +143,13 @@ export default class System extends Block {
       this.groups[mode].add(sng);
       this.groups[mode].add(sfg);
 
+      // Build the per-mode rings InstancedMesh (visibility / population
+      // modes only). One InstancedMesh covers every eligible system in
+      // the galaxy — collapses ~N RingGeometry meshes into a single
+      // draw call. Repaints flow back through createSystems so this
+      // helper finds and disposes the previous InstancedMesh.
+      this.buildRingsInstancedMesh(sng, mode);
+
       // Systems are static in world space — panning is camera-driven (the
       // view matrix), not object-driven. Disabling matrixAutoUpdate skips
       // the per-frame updateMatrix/compose work on every system mesh,
@@ -141,6 +164,75 @@ export default class System extends Block {
         o.updateMatrix();
       });
     });
+  }
+
+  // Build the rings InstancedMesh for one mode's systems-near group.
+  // Only 'visibility' and 'population' modes show rings; 'radar' is a
+  // no-op (we still clear any leftover instance from a prior mode).
+  // Faction-tinted per-instance color is applied via setColorAt
+  // (multiplied with the material's white base color in the shader).
+  buildRingsInstancedMesh(sng, mode) {
+    const existing = sng.children.find((c) => c.name === 'system-rings');
+    if (existing) {
+      sng.remove(existing);
+      // ringUnitGeometry is shared across all rebuilds — don't dispose it.
+      existing.material.dispose();
+      existing.dispose();
+    }
+
+    if (mode !== 'visibility' && mode !== 'population') return;
+
+    let eligible;
+    if (mode === 'visibility') {
+      eligible = this.map.data.systems.filter((s) => s.visibility > 0);
+    } else {
+      eligible = this.map.data.systems
+        .filter((s) => s.visibility > 2
+          && store.state.game.data.population_class.some((pc) => pc.key === s.class));
+    }
+    if (eligible.length === 0) return;
+
+    const material = new MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.25,
+      side: FrontSide,
+    });
+    const rings = new InstancedMesh(ringUnitGeometry, material, eligible.length);
+    rings.name = 'system-rings';
+    // Default frustum culling tests the unit geometry's bounding sphere
+    // (radius 1 at the InstancedMesh's local origin) — wrong for a mesh
+    // whose instances span the whole galaxy. Disable so the culler doesn't
+    // hide instances that are actually in view.
+    rings.frustumCulled = false;
+
+    eligible.forEach((system, i) => {
+      let radius;
+      if (mode === 'visibility') {
+        radius = 0.25 * system.visibility;
+      } else {
+        const pc = store.state.game.data.population_class.find((p) => p.key === system.class);
+        radius = 0.15 * pc.points;
+      }
+      _scratchDummy.position.set(
+        system.position.x,
+        system.position.y,
+        config.MAP.Z_SYSTEM_NEAR_STAR - 0.01,
+      );
+      _scratchDummy.scale.set(radius, radius, 1);
+      _scratchDummy.quaternion.set(0, 0, 0, 1);
+      _scratchDummy.updateMatrix();
+      rings.setMatrixAt(i, _scratchDummy.matrix);
+
+      const faction = system.faction || 'neutral';
+      _scratchColor.set(this.colors[faction].hex.normal);
+      rings.setColorAt(i, _scratchColor);
+    });
+
+    rings.instanceMatrix.needsUpdate = true;
+    if (rings.instanceColor) rings.instanceColor.needsUpdate = true;
+
+    sng.add(rings);
   }
 
   nearSystem(system, name, mode) {
@@ -228,6 +320,9 @@ export default class System extends Block {
       }
     }
 
+    // Mode-specific numeric label ('1'..'5' for visibility, population
+    // points for population). The corresponding ring around each system
+    // is built in bulk by buildRingsInstancedMesh, not here.
     if (mode === 'visibility') {
       if (system.visibility > 0) {
         sn.add(this.createSystemLabel(system, { x: 0.26, y: 0.26 }, `${system.visibility}`, true, {
@@ -235,13 +330,6 @@ export default class System extends Block {
           textColor: this.map.materials.white,
           zIndex: config.MAP.Z_SYSTEM_NEAR_LABEL,
         }));
-
-        // size-visibility related circle
-        const disk = new RingGeometry(0.0001, 0.25 * system.visibility, 128);
-        const mesh = new Mesh(disk, colors.material.normal.clone());
-        mesh.position.set(system.position.x, system.position.y, config.MAP.Z_SYSTEM_NEAR_STAR - 0.01);
-        mesh.material.opacity = 0.25;
-        sn.add(mesh);
       }
     } else if (mode === 'population') {
       if (populationClass && system.visibility > 2) {
@@ -250,13 +338,6 @@ export default class System extends Block {
           textColor: this.map.materials.white,
           zIndex: config.MAP.Z_SYSTEM_NEAR_LABEL,
         }));
-
-        // size-class related circle
-        const disk = new RingGeometry(0.0001, 0.15 * populationClass.points, 128);
-        const mesh = new Mesh(disk, colors.material.normal.clone());
-        mesh.position.set(system.position.x, system.position.y, config.MAP.Z_SYSTEM_NEAR_STAR - 0.01);
-        mesh.material.opacity = 0.25;
-        sn.add(mesh);
       }
     }
 

--- a/front/src/game/map/blocks/system.js
+++ b/front/src/game/map/blocks/system.js
@@ -27,6 +27,14 @@ const farHoverDisk = new RingGeometry(0.0001, 2, 32);
 // vertex buffers into 1.
 const ringUnitGeometry = new RingGeometry(0.0001, 1, 128);
 
+// 1x1 quad shared by every per-variant base-sprite InstancedMesh. Each
+// instance is scaled to the variant's display size via setMatrixAt. The
+// original code used three.js Sprites (auto-billboarded quads); for the
+// galaxy's top-down view with camera rotation disabled in prod
+// (Map.controls.enableRotate = this.isDev), a flat XY plane facing +Z
+// is visually identical.
+const planeUnitGeometry = new PlaneGeometry(1, 1);
+
 // Reusable scratch objects for building instance matrices/colors so the
 // per-system loop doesn't allocate in a hot rebuild path.
 const _scratchDummy = new Object3D();
@@ -166,6 +174,14 @@ export default class System extends Block {
       // helper finds and disposes the previous InstancedMesh.
       this.buildRingsInstancedMesh(sng, mode);
 
+      // Build the per-variant base-sprite InstancedMeshes. One
+      // InstancedMesh per (system type × habitability × visibility)
+      // combination — typically a couple dozen variants instead of
+      // ~N individual Sprite Objects. Hover detection in map.js
+      // resolves an instanceId back to the per-system sn Group via
+      // the userData map populated here.
+      this.buildBaseSpritesInstancedMeshes(sng);
+
       // Systems are static in world space — panning is camera-driven (the
       // view matrix), not object-driven. Disabling matrixAutoUpdate skips
       // the per-frame updateMatrix/compose work on every system mesh,
@@ -251,6 +267,84 @@ export default class System extends Block {
     sng.add(rings);
   }
 
+  // Build per-variant base-sprite InstancedMeshes inside a mode's sng.
+  // The original code created one cloned Sprite per system; this groups
+  // systems by (type, habitability, visibility) and builds one
+  // InstancedMesh per group. Each InstancedMesh stores an
+  // instanceId → sn map in userData so the hover code in map.js can
+  // resolve a raycast intersection to the per-system Group that carries
+  // the gameObject and showOnHover children.
+  buildBaseSpritesInstancedMeshes(sng) {
+    const existing = sng.children.filter((c) => c.name && c.name.startsWith('system-base|'));
+    existing.forEach((c) => {
+      sng.remove(c);
+      c.material.dispose();
+      c.dispose();
+    });
+
+    // Group systems by sprite variant.
+    const variants = new Map();
+    this.map.data.systems.forEach((system) => {
+      const habitability = ['uninhabitable', 'uninhabited'].includes(system.status) ? 'uninhabited' : 'inhabited';
+      const visibility = system.visibility === 0 ? 'unknown' : 'known';
+      const key = `system-base|${system.type}|${habitability}|${visibility}`;
+      let entry = variants.get(key);
+      if (!entry) {
+        entry = { type: system.type, habitability, visibility, systems: [] };
+        variants.set(key, entry);
+      }
+      entry.systems.push(system);
+    });
+
+    variants.forEach((variant, key) => {
+      if (variant.systems.length === 0) return;
+
+      const sourceSprite = this.map.materials.sprites.systems[variant.type][variant.habitability][variant.visibility];
+      const sourceMaterial = sourceSprite.material;
+      const size = sourceSprite.scale.x;
+
+      // Mirror the source SpriteMaterial as a MeshBasicMaterial. Set
+      // transparent explicitly — the original SpriteMaterial relied on
+      // an implicit Sprite-side transparency flag that doesn't survive
+      // the swap to a plain Mesh.
+      const material = new MeshBasicMaterial({
+        map: sourceMaterial.map,
+        transparent: true,
+        opacity: sourceMaterial.opacity,
+        side: FrontSide,
+      });
+
+      const instanced = new InstancedMesh(planeUnitGeometry, material, variant.systems.length);
+      instanced.name = key;
+      instanced.frustumCulled = false;
+      instanced.userData.hoverable = true;
+      instanced.userData.systemGroupByInstanceId = {};
+
+      variant.systems.forEach((system, i) => {
+        _scratchDummy.position.set(
+          system.position.x,
+          system.position.y,
+          config.MAP.Z_SYSTEM_NEAR_STAR,
+        );
+        _scratchDummy.scale.set(size, size, 1);
+        _scratchDummy.quaternion.set(0, 0, 0, 1);
+        _scratchDummy.updateMatrix();
+        instanced.setMatrixAt(i, _scratchDummy.matrix);
+
+        // Look up the per-system Group already created by nearSystem
+        // and stash it on the InstancedMesh keyed by instanceId. The
+        // hover code special-cases isInstancedMesh intersections to
+        // read this map and treat the looked-up sn as if the cursor
+        // had hit it directly.
+        const sn = sng.children.find((c) => c.userData && c.userData.name === `system-${system.id}`);
+        if (sn) instanced.userData.systemGroupByInstanceId[i] = sn;
+      });
+
+      instanced.instanceMatrix.needsUpdate = true;
+      sng.add(instanced);
+    });
+  }
+
   nearSystem(system, name, mode) {
     const sn = new Group();
     sn.name = 'system-near';
@@ -270,11 +364,10 @@ export default class System extends Block {
     // this.hoverIndicator built in _create and managed by
     // Map#showHover/hideHover.)
 
-    // system sprite
-    const base = this.map.materials.sprites.systems[system.type][habitability][visibility].clone();
-    base.position.set(system.position.x, system.position.y, config.MAP.Z_SYSTEM_NEAR_STAR);
-    base.userData.hoverable = true;
-    sn.add(base);
+    // (base sprite moved to a per-variant InstancedMesh built by
+    // buildBaseSpritesInstancedMeshes; the InstancedMesh is what
+    // carries userData.hoverable now, and the hover walk in map.js
+    // resolves an InstancedMesh hit's instanceId back to this sn.)
 
     if (['inhabited_dominion', 'inhabited_player'].includes(system.status)) {
       const owner = system.status === 'inhabited_dominion' ? 'dominion' : 'player';

--- a/front/src/game/map/blocks/system.js
+++ b/front/src/game/map/blocks/system.js
@@ -77,6 +77,16 @@ export default class System extends Block {
     this.hoverIndicator.position.z = config.MAP.Z_SYSTEM_NEAR_STAR - 0.01;
     this.hoverIndicator.visible = false;
     this.hoverIndicator.name = 'system-hover-indicator';
+    // Force the hover indicator to render BEFORE the per-mode base-sprite
+    // InstancedMesh. Three.js sorts InstancedMesh by its own world
+    // position (origin) for the transparent pass, not per-instance — so
+    // the sprite-instance covering the hovered system would otherwise
+    // sort as "far back", render first, write depth across its entire
+    // quad (including transparent corners), and then occlude the hover
+    // halo's pixels inside the quad. renderOrder = -1 puts the hover
+    // first in the transparent pass; the sprite then blends on top
+    // correctly and its transparent corners reveal the halo behind.
+    this.hoverIndicator.renderOrder = -1;
     this.map.scene.add(this.hoverIndicator);
 
     this.createSystems(true);

--- a/front/src/game/map/blocks/system.js
+++ b/front/src/game/map/blocks/system.js
@@ -55,6 +55,22 @@ export default class System extends Block {
       }
     });
 
+    // Single shared hover indicator. Replaces N per-system hover Meshes
+    // that were invisible 99% of the time but still bloated the scene
+    // graph (~N tree-walk hits per frame, ~N raycast AABB tests per
+    // pointer move, ~N cloned MeshBasicMaterial allocations). On hover,
+    // Map#showHover repositions and shows this one mesh; Map#hideHover
+    // sets it invisible. Lives directly on map.scene so it's
+    // independent of mode-switch and isn't affected by the per-mode
+    // group's matrix freeze (matrixAutoUpdate stays true here because
+    // this mesh DOES move every time hover transitions).
+    this.hoverIndicator = new Mesh(nearHoverDisk, this.map.materials.white.clone());
+    this.hoverIndicator.material.opacity = 0.12;
+    this.hoverIndicator.position.z = config.MAP.Z_SYSTEM_NEAR_STAR - 0.01;
+    this.hoverIndicator.visible = false;
+    this.hoverIndicator.name = 'system-hover-indicator';
+    this.map.scene.add(this.hoverIndicator);
+
     this.createSystems(true);
     this.resetRepaint();
   }
@@ -250,14 +266,9 @@ export default class System extends Block {
     const habitability = ['uninhabitable', 'uninhabited'].includes(system.status) ? 'uninhabited' : 'inhabited';
     const populationClass = store.state.game.data.population_class.find((pc) => pc.key === system.class);
 
-    // hover disk
-    const hover = new Mesh(nearHoverDisk, this.map.materials.white.clone());
-    hover.visible = false;
-    hover.position.set(system.position.x, system.position.y, config.MAP.Z_SYSTEM_NEAR_STAR - 0.01);
-    hover.material.opacity = 0.12;
-    hover.userData.hoverable = true;
-    hover.userData.showOnHover = true;
-    sn.add(hover);
+    // (per-system hover disk removed — replaced by the single shared
+    // this.hoverIndicator built in _create and managed by
+    // Map#showHover/hideHover.)
 
     // system sprite
     const base = this.map.materials.sprites.systems[system.type][habitability][visibility].clone();

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -557,10 +557,25 @@ export default class Map {
             // We intersected a single object, we want the hover to effect the whole system,
             // not just the hovered ring or child-object.
             // Search in intersected object's parents the closer 'hoverable object'.
-            let hoveredGroup = intersectedObject;
+            let hoveredGroup;
 
-            while (hoveredGroup && !('gameObject' in hoveredGroup)) {
-              hoveredGroup = hoveredGroup.parent;
+            // System base sprites are batched into InstancedMesh objects
+            // by System#buildBaseSpritesInstancedMeshes — those carry a
+            // userData.systemGroupByInstanceId map back to the per-system
+            // sn Group that holds gameObject and showOnHover children.
+            // Resolve InstancedMesh hits through that map instead of
+            // walking parents (the InstancedMesh has no gameObject and
+            // its parent is sng, also without one).
+            if (intersectedObject.isInstancedMesh
+                && intersection[intersecting].instanceId !== undefined
+                && intersectedObject.userData.systemGroupByInstanceId) {
+              hoveredGroup = intersectedObject.userData
+                .systemGroupByInstanceId[intersection[intersecting].instanceId];
+            } else {
+              hoveredGroup = intersectedObject;
+              while (hoveredGroup && !('gameObject' in hoveredGroup)) {
+                hoveredGroup = hoveredGroup.parent;
+              }
             }
 
             const stillHovering = currentlyHoveredObject && (hoveredGroup.id === currentlyHoveredObject.id);

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -671,9 +671,24 @@ export default class Map {
         obj.visible = true;
       });
 
-    if (type === 'System' && Character.canHoverPath()) {
-      const character = this.getBlockByName('Character');
-      character.hoverPathTo(hoveredGroup.gameObject.data);
+    if (type === 'System') {
+      // Reposition and reveal the single shared hover indicator built in
+      // System#_create. Replaces the per-system hover Mesh that used to
+      // live inside every sn Group with `showOnHover: true` userData.
+      const systemBlock = this.getBlockByName('System');
+      const indicator = systemBlock && systemBlock.hoverIndicator;
+      const systemPos = hoveredGroup.gameObject && hoveredGroup.gameObject.data
+        && hoveredGroup.gameObject.data.position;
+      if (indicator && systemPos) {
+        indicator.position.x = systemPos.x;
+        indicator.position.y = systemPos.y;
+        indicator.visible = true;
+      }
+
+      if (Character.canHoverPath()) {
+        const character = this.getBlockByName('Character');
+        character.hoverPathTo(hoveredGroup.gameObject.data);
+      }
     }
 
     // Track hovered system id on the shared MapData so keyboard handlers
@@ -722,6 +737,12 @@ export default class Map {
 
       if (currentlyHoveredObject.gameObject?.type === 'system') {
         this.data.hoveredSystemId = null;
+        // Hide the single shared system hover indicator (see System#_create
+        // and Map#showHover for the show side).
+        const systemBlock = this.getBlockByName('System');
+        if (systemBlock && systemBlock.hoverIndicator) {
+          systemBlock.hoverIndicator.visible = false;
+        }
       }
 
       currentlyHoveredObject = undefined;


### PR DESCRIPTION
## Summary

Hotfix-style perf work for the galaxy map render loop. After the matrix-freeze fix in v1.0.0, production profiles still showed Three.js consuming ~50% of every render frame because the cost had shifted from per-object `updateMatrix`/`compose` (now ~0) to the scene-graph walk + per-object model-view matrix work that scales linearly with Object3D count. The galaxy currently carries 2000–5000 static Object3D in the scene; collapsing the repeated ones into shared `InstancedMesh` / single-shared-Mesh objects cuts both costs in proportion to the variant count instead of the system count.

Per CLAUDE.md "Branching & releases": this is a hotfix path (master direct, not `release/1.1`) because the unpatched render cost is currently affecting playability on prod. Forward-port into `release/1.1` is the documented next step.

## Commits

- `886b16f` — **perf: instance visibility/population rings.** One `InstancedMesh` per mode covers every eligible system, shared unit-radius `RingGeometry` + per-instance scale for radius + per-instance color for faction tint. Rebuilds on ownership repaint via `createSystems`.
- `a7bf8d0` — **perf: single shared hover indicator.** Replaces N per-system invisible hover Meshes (each with its own cloned `MeshBasicMaterial`) with one Mesh attached to `map.scene`; `Map#showHover`/`hideHover` reposition + toggle visible.
- `93fb078` — **perf: instance base system sprites.** Replaces N cloned `Sprite` objects with ~one `InstancedMesh` per (`type` × `habitability` × `visibility`) variant, using `PlaneGeometry` + `MeshBasicMaterial` carrying the original texture. Hover detection in `Map.checkIntersect` special-cases `InstancedMesh` intersections and resolves `instanceId` → `sn` Group via `userData.systemGroupByInstanceId`.
- `0993f50` — **fix: hover halo visible under instanced sprites.** Sets `renderOrder = -1` on the hover indicator. Three.js sorts `InstancedMesh` by its own world position (origin) for the transparent pass, not per-instance, so the sprite InstancedMesh otherwise rendered before the hover, wrote depth across its full quad, and occluded the halo inside the quad's bounds (the visible "box cut" reported on the dev container).