### PR TITLE
fix(agents): a blown Erased cancels its action queue and idles

### DIFF
--- a/lib/game/instance/character/character.ex
+++ b/lib/game/instance/character/character.ex
@@ -587,31 +587,50 @@ defmodule Instance.Character.Character do
         {change, notifs, state}
       end
 
-    if ActionQueue.empty?(state.actions) do
-      case state.type do
-        :admiral ->
-          army = Character.Army.repair(state.army, state.instance_id, elapsed_time)
-          {change, notifs, compute_bonus(%{state | army: army})}
+    cond do
+      ActionQueue.empty?(state.actions) ->
+        case state.type do
+          :admiral ->
+            army = Character.Army.repair(state.army, state.instance_id, elapsed_time)
+            {change, notifs, compute_bonus(%{state | army: army})}
 
-        :spy ->
-          {spy, has_changed} = Character.Spy.increase_cover(state.spy, state.instance_id, elapsed_time)
+          :spy ->
+            {spy, has_changed} = Character.Spy.increase_cover(state.spy, state.instance_id, elapsed_time)
 
-          change =
-            if has_changed do
-              change
-              |> MapSet.put(:player_update)
-              |> MapSet.put(:system_update)
-            else
-              change
-            end
+            change =
+              if has_changed do
+                change
+                |> MapSet.put(:player_update)
+                |> MapSet.put(:system_update)
+              else
+                change
+              end
 
-          {change, notifs, compute_bonus(%{state | spy: spy})}
+            {change, notifs, compute_bonus(%{state | spy: spy})}
 
-        _ ->
-          {change, notifs, state}
-      end
-    else
-      process_action_queue({change, notifs, state}, elapsed_time, cumulated_pauses)
+          _ ->
+            {change, notifs, state}
+        end
+
+      # A blown Erased cannot keep acting. The moment cover is below the
+      # discovery threshold, cancel its entire action queue so it idles and
+      # its cover can recover (increase_cover only runs on an empty queue).
+      # Without this a discovered spy grinds queued infiltrations forever,
+      # never regaining cover and unable to move (Charden/Janus, instance 20,
+      # 2026-06-18). `lose_cover` already clears on the *transition* into
+      # discovered; this also catches anything queued while already discovered
+      # (the path that produced the stuck state).
+      state.type == :spy and Character.Spy.discovered?(state.spy.cover.value, state.instance_id) ->
+        cancelled =
+          state
+          |> clear_actions()
+          |> set_virtual_position(state.system)
+          |> idle()
+
+        {MapSet.put(change, :player_update), notifs, cancelled}
+
+      true ->
+        process_action_queue({change, notifs, state}, elapsed_time, cumulated_pauses)
     end
   end
 

--- a/test/game/instance/character/character_test.exs
+++ b/test/game/instance/character/character_test.exs
@@ -75,6 +75,42 @@ defmodule Character.CharacterTest do
     end
   end
 
+  describe "blown Erased cancels its queue on tick" do
+    setup do
+      iid = Test.FleetScenario.unique_instance_id()
+      Test.FleetScenario.load_game_data(iid)
+      %{iid: iid}
+    end
+
+    # 2026-06-18 (Charden/Janus, instance 20): a discovered spy that still held
+    # a queue ground its infiltrations forever, never regaining cover (cover
+    # only recovers on an empty queue) and unable to move. A blown Erased must
+    # cancel everything and idle so cover can recover.
+    test "a discovered spy with a queue is cancelled to idle", %{iid: iid} do
+      spy =
+        struct(Character, %{
+          id: 1,
+          type: :spy,
+          status: :on_board,
+          system: 5,
+          action_status: :infiltration,
+          instance_id: iid,
+          on_strike: false,
+          spy: struct(Instance.Character.Spy, %{cover: Core.DynamicValue.new(0.0)}),
+          actions: %ActionQueue{
+            virtual_position: 5,
+            queue: Queue.new([Action.new({:infiltrate, %{"target" => 5}, :unknown_yet})])
+          }
+        })
+
+      {_change, _notifs, after_tick} = Character.next_tick(spy, 1, 0)
+
+      assert after_tick.action_status == :idle
+      assert ActionQueue.empty?(after_tick.actions)
+      assert after_tick.actions.virtual_position == 5
+    end
+  end
+
   defp moving_character(opts) do
     queue =
       opts


### PR DESCRIPTION
Charden/Janus (instance 20, 2026-06-18): a discovered spy (cover below the discovery threshold) kept grinding a queue of infiltrations. Because cover only regenerates on an EMPTY queue (Character.update's spy branch), it could never recover — staying discovered, unable to move (jump is blocked for discovered spies), and unable to act. lose_cover already clears the queue on the *transition* into discovered, but anything queued while ALREADY discovered slipped past that and ground forever.

Per the design rule "a blown Erased cannot keep acting": in the on-board spy tick, if the spy is discovered and still holds a queue, cancel the whole queue and idle it (virtual_position pinned to its current system so it can re-issue once cover recovers). With an empty queue, increase_cover resumes and the spy can eventually move again. Test covers the cancel path.

This neutralizes the live symptom regardless of how the queue got populated (the player reported ~4 enqueued but 11 present, and a galaxy-preview vs selection-view pip mismatch — a separate enqueue/UI discrepancy still worth chasing, but a blown spy now clears either way).