### PR TITLE
fix(daily): end daily challenges on the timer only, never on victory …

### DIFF
--- a/lib/game/instance/manager.ex
+++ b/lib/game/instance/manager.ex
@@ -434,7 +434,18 @@ defmodule Instance.Manager do
     DynamicSupervisor.start_child(supervisor_pid, {Instance.Galaxy.Agent, state: state})
 
     # Spawn victory manager
-    data = Instance.Victory.Victory.new(time_left, victory_points, inhabitable_systems, sectors, factions, instance_id)
+    # `metadata[:daily]` → time_only: a daily ends only on its timer, never on
+    # the points-based victory track (see Instance.Victory.Victory).
+    data =
+      Instance.Victory.Victory.new(
+        time_left,
+        victory_points,
+        inhabitable_systems,
+        sectors,
+        factions,
+        instance_id,
+        metadata[:daily]
+      )
     channel = "instance:global:#{instance_id}"
     state = Core.GenState.new(:victory, instance_id, :master, data, channel)
     DynamicSupervisor.start_child(supervisor_pid, {Instance.Victory.Agent, state: state})

--- a/lib/game/instance/victory/victory.ex
+++ b/lib/game/instance/victory/victory.ex
@@ -8,7 +8,7 @@ defmodule Instance.Victory.Victory do
   @final_unit_days 200
   @next_update_unit_days 20
 
-  def jason(), do: [except: [:instance_id, :next_update]]
+  def jason(), do: [except: [:instance_id, :next_update, :time_only]]
 
   typedstruct enforce: true do
     field(:ut_time_left, float())
@@ -19,9 +19,15 @@ defmodule Instance.Victory.Victory do
     field(:winner, nil | atom())
     field(:instance_id, integer())
     field(:next_update, %Core.DynamicValue{})
+    # When true the game can end *only* on the clock — the points-based win
+    # (victory_points >= 14) is ignored. Set for daily challenges, which reuse
+    # this agent but must run their full timer. Defaults to false / optional so
+    # a pre-field snapshot (a multiplayer instance restored across this change)
+    # deserializes cleanly and keeps the normal points-win behaviour.
+    field(:time_only, boolean(), default: false, enforce: false)
   end
 
-  def new(ut_time_left, victory_points, inhabitable_systems, sectors, factions, instance_id) do
+  def new(ut_time_left, victory_points, inhabitable_systems, sectors, factions, instance_id, time_only \\ false) do
     next_update = Core.DynamicValue.new(0, :misc, Core.ValuePart.new(:default, 1))
 
     %Victory.Victory{
@@ -32,7 +38,8 @@ defmodule Instance.Victory.Victory do
       sectors: Enum.map(sectors, &Victory.Sector.convert/1),
       winner: nil,
       instance_id: instance_id,
-      next_update: next_update
+      next_update: next_update,
+      time_only: time_only
     }
   end
 
@@ -145,7 +152,15 @@ defmodule Instance.Victory.Victory do
     # check victory
     current_rankings = rank_factions(state)
     leader = List.first(current_rankings)
-    has_winner = leader.victory_points >= 14
+
+    # Daily challenges (time_only) end *only* when the clock runs out: they
+    # reuse this agent but must ignore the points-based win. A solo player on a
+    # single-system daily trips `victory_points >= 14` almost for free — owning
+    # the lone sector already maxes the conquest track (10 pts), so a little
+    # population growth (+5) ends the run minutes before the deadline. Map.get
+    # keeps a pre-field snapshot defaulting to the normal points-win behaviour.
+    # See lib/daily + docs/daily-challenge.md.
+    has_winner = not Map.get(state, :time_only, false) and leader.victory_points >= 14
 
     victory_type =
       cond do

--- a/test/game/instance/victory/victory_test.exs
+++ b/test/game/instance/victory/victory_test.exs
@@ -164,4 +164,70 @@ defmodule Instance.Victory.VictoryTest do
       assert_in_delta Victory.tie_break_score(tet, s), 5 / 30, 1.0e-9
     end
   end
+
+  describe "next_tick/2 time_only (daily challenges)" do
+    # A single, already-scored faction. We build the real Victory struct via
+    # new/7 (so next_update is a valid DynamicValue) then override :factions
+    # with a plain scored map — check_for_victory only reads victory_points off
+    # the leader, and rank_factions never invokes the comparator for one
+    # faction, so this is enough to drive the win decision without the
+    # PopulationClass data loader.
+    defp single_faction_victory(vp, ut_time_left, time_only) do
+      v = Victory.new(ut_time_left, 14, 1, [], [], 999, time_only)
+
+      %{
+        v
+        | factions: [
+            %{
+              id: 1,
+              key: :tetrarchy,
+              victory_points: vp,
+              possession_count: 1,
+              population_value: 0.0,
+              visibility_count: 0
+            }
+          ]
+      }
+    end
+
+    test "ignores the points-based win when time_only is set" do
+      # 20 VP (>= 14) but the clock is nowhere near zero: a normal game would
+      # declare victory_track here; a daily must not.
+      state = single_faction_victory(20, 500.0, true)
+      {change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == nil
+      refute MapSet.member?(change, :victory)
+      assert export == nil
+    end
+
+    test "non-daily games still win on points (time_only defaults to false)" do
+      state = single_faction_victory(20, 500.0, false)
+      {change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == :tetrarchy
+      assert MapSet.member?(change, :victory)
+      assert export.victory_type == "victory_track"
+    end
+
+    test "a daily still ends when its timer runs out, never as victory_track" do
+      # 20 VP *and* the clock crosses zero this tick. time_is_up takes
+      # precedence in the cond, so even without the time_only gate this would be
+      # win_on_time — but asserting it here guards that suppressing the points
+      # win doesn't strand a finished daily with no winner.
+      state = single_faction_victory(20, 0.5, true)
+      {change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == :tetrarchy
+      assert MapSet.member?(change, :victory)
+      assert export.victory_type == "win_on_time"
+      # victory resets the clock to the post-game window
+      assert new_state.ut_time_left == 200
+    end
+
+    test "new/6 still works and defaults time_only to false" do
+      v = Victory.new(100.0, 14, 1, [], [], 999)
+      assert v.time_only == false
+    end
+  end
 end


### PR DESCRIPTION
…points

A daily reuses the standard Instance.Victory agent, which declares a winner on EITHER the timer (time_is_up) OR a points-based track win (victory_points >= 14). On a single-system daily that points win is almost free: owning the lone sector maxes the conquest track (10 pts), so a little population growth (+5) trips 14 and ends the run minutes before the 30-minute deadline — the player sees a frozen game with time still on the clock.

Add a time_only flag to the Victory struct (default false, read via Map.get for snapshot tolerance) that suppresses the points-based win. Instance.Manager sets it from metadata[:daily], so only dailies are affected; multiplayer games keep the normal victory track. The time_is_up branch is unchanged, so a daily still ends (as win_on_time) when its clock runs out.

Diagnosed in prod 2026-06-23: player Shareels' daily ended at 25m33s of 30min.