### PR TITLE
fix(reports), feat(reports): All report types show up in Reports.

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rc",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@appsignal/javascript": "^1.3.12",
         "@appsignal/vue": "^1.0.8",

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "engines": {
     "node": ">=20.0.0"

--- a/front/src/game/components/panel/operation/Reports.vue
+++ b/front/src/game/components/panel/operation/Reports.vue
@@ -3,6 +3,15 @@
     <div class="reports-tabs">
       <div
         class="reports-tab"
+        :class="{ 'is-active': activeTab === 'reports' }"
+        @click="activeTab = 'reports'">
+        {{ $t('panel.operations.tabs.reports') }}
+        <span
+          v-if="unreadCount > 0"
+          class="reports-tab-badge">{{ unreadCount }}</span>
+      </div>
+      <div
+        class="reports-tab"
         :class="{ 'is-active': activeTab === 'combat' }"
         @click="activeTab = 'combat'">
         {{ $t('panel.operations.tabs.combat') }}
@@ -14,9 +23,89 @@
         {{ $t('panel.operations.tabs.icon_log') }}
       </div>
     </div>
-    <v-scrollbar class="has-padding">
-      <template v-if="activeTab === 'combat'">
+    <v-scrollbar
+      class="has-padding"
+      @ps-y-reach-end="onReachEnd">
+
+      <!-- Reports: the player's own agent-action summary cards. Same card the
+           player sees pop up live / on login, now re-readable + manageable. -->
+      <template v-if="activeTab === 'reports'">
+        <div
+          v-if="events.length > 0"
+          class="reports-toolbox">
+          <div
+            class="button"
+            :class="{ 'is-disabled': unreadCount === 0 }"
+            @click="markAllRead">
+            {{ $t('panel.operations.mark_all_read') }}
+          </div>
+          <div
+            class="button"
+            @click="deleteRead">
+            {{ $t('panel.operations.delete_read') }}
+          </div>
+          <div
+            class="button is-danger"
+            @click="deleteAll">
+            {{ $t('panel.operations.delete_all') }}
+          </div>
+        </div>
+
+        <div
+          v-if="events.length === 0 && eventsLoaded"
+          class="reports-empty">
+          {{ $t('panel.operations.tabs.no_entries') }}
+        </div>
+
+        <div
+          v-for="event in events"
+          :key="`event-${event.id}`"
+          class="event-report"
+          :class="{ 'is-unread': !event.is_read, 'is-open': expandedEventId === event.id }">
+          <div
+            class="event-report-header"
+            @click="toggleEvent(event)">
+            <span
+              class="event-report-dot"
+              v-if="!event.is_read"></span>
+            <div class="event-report-icon">
+              <svgicon :name="`action/${event.key}`" />
+              <svgicon
+                v-if="event.data.side === 'defender'"
+                name="resource/defense" />
+            </div>
+            <span
+              class="event-report-title"
+              v-html="$tmd(`notification.short_box.${event.key}`, { system: event.data.system.name })"></span>
+            <span
+              class="event-report-outcome"
+              v-if="event.data.outcome">
+              <template v-if="event.key === 'fight'">
+                {{ $t(`notification.box.fight.outcome.${event.data.outcome}`) }}
+              </template>
+              <template v-else>
+                {{ $t(`notification.box.outcome.${event.data.side}.${event.data.outcome}`) }}
+              </template>
+            </span>
+            <span class="event-report-date">{{ event.inserted_at | datetime-long }}</span>
+          </div>
+          <div
+            v-if="expandedEventId === event.id"
+            class="box-notification-item">
+            <notif-dispatcher :notification="event" />
+          </div>
+        </div>
+      </template>
+
+      <!-- Combat: the legacy per-round fight log, kept reachable (e.g. the
+           "view report" deep-link) but no longer the default landing tab. -->
+      <template v-else-if="activeTab === 'combat'">
         <template v-if="!current">
+          <div
+            v-if="reports.length === 0"
+            class="reports-empty">
+            {{ $t('panel.operations.tabs.no_entries') }}
+          </div>
           <div
             class="pcb-report"
             v-for="(report, i) in reports"
@@ -73,6 +162,7 @@
 
 <script>
 import FightReport from '@/game/components/panel/operation/report/FightReport.vue';
+import NotifDispatcher from '@/game/components/box-notification/NotifDispatcher.vue';
 
 export default {
   name: 'operation-reports-panel',
@@ -84,24 +174,141 @@ export default {
   },
   data() {
     return {
+      // combat (legacy fight log)
       reports: [],
       current: null,
-      activeTab: 'combat',
+      combatLoaded: false,
+      // reports (player_events box cards)
+      events: [],
+      eventsPage: 1,
+      eventsMaxPage: 1,
+      eventsLoading: false,
+      eventsLoaded: false,
+      expandedEventId: null,
+      // icon log
       iconLogEntries: [],
       iconLogLoaded: false,
+      // A report deep-link (FightNotif "view report") lands on combat; an
+      // ordinary open lands on the new summary Reports tab.
+      activeTab: this.initial !== 0 ? 'combat' : 'reports',
     };
+  },
+  computed: {
+    // Approximate: counts unread among the events loaded so far. Good enough
+    // for the tab badge; "mark all read" clears it server-side regardless.
+    unreadCount() {
+      return this.events.filter((e) => !e.is_read).length;
+    },
   },
   watch: {
     activeTab(tab) {
-      // Lazy-load each tab on first visit. The combat report
-      // payloads can be heavy and the icon log isn't worth pulling
-      // until the player actually looks at it.
+      // Lazy-load each tab on first visit.
+      if (tab === 'reports' && !this.eventsLoaded) {
+        this.loadPlayerEvents();
+      }
+      if (tab === 'combat' && !this.combatLoaded) {
+        this.loadReports();
+      }
       if (tab === 'icon_log' && !this.iconLogLoaded) {
         this.loadIconEventLog();
       }
     },
   },
   methods: {
+    // --- Reports tab (player_events) ---
+    loadPlayerEvents() {
+      if (this.eventsLoading || this.eventsPage > this.eventsMaxPage) {
+        return;
+      }
+
+      this.eventsLoading = true;
+      this.$socket.player
+        .push('get_player_events', { page: this.eventsPage })
+        .receive('ok', (data) => {
+          // Tutorial short-circuits server-side with no `events` key.
+          if (!data || !data.events) {
+            this.eventsLoaded = true;
+            this.eventsLoading = false;
+            return;
+          }
+
+          const events = data.events.map((e) => {
+            // `data` is stored as a JSON string so the schema stays generic.
+            e.data = this.parseMetadata(e.data);
+            return e;
+          });
+
+          this.events.push(...events);
+          this.eventsPage += 1;
+          this.eventsMaxPage = data.total_pages;
+          this.eventsLoaded = true;
+          this.eventsLoading = false;
+        })
+        .receive('error', (data) => {
+          this.eventsLoading = false;
+          this.$toastError(data.reason);
+        });
+    },
+    reloadPlayerEvents() {
+      this.events = [];
+      this.eventsPage = 1;
+      this.eventsMaxPage = 1;
+      this.expandedEventId = null;
+      this.eventsLoaded = false;
+      this.loadPlayerEvents();
+    },
+    toggleEvent(event) {
+      this.expandedEventId = this.expandedEventId === event.id ? null : event.id;
+
+      // Opening a report counts as reading it.
+      if (this.expandedEventId === event.id && !event.is_read) {
+        this.markRead(event);
+      }
+    },
+    markRead(event) {
+      // Optimistic — the card is already on screen; a failed write just leaves
+      // it unread, which is harmless.
+      this.$set(event, 'is_read', true);
+      this.$socket.player.push('mark_event_read', { event_id: event.id });
+    },
+    markAllRead() {
+      if (this.unreadCount === 0) {
+        return;
+      }
+
+      this.$socket.player
+        .push('mark_all_events_read', {})
+        .receive('ok', () => {
+          this.events.forEach((e) => this.$set(e, 'is_read', true));
+        })
+        .receive('error', (data) => { this.$toastError(data.reason); });
+    },
+    deleteRead() {
+      if (!window.confirm(this.$t('panel.operations.confirm_delete_read'))) {
+        return;
+      }
+
+      this.$socket.player
+        .push('delete_read_events', {})
+        .receive('ok', () => this.reloadPlayerEvents())
+        .receive('error', (data) => { this.$toastError(data.reason); });
+    },
+    deleteAll() {
+      if (!window.confirm(this.$t('panel.operations.confirm_delete_all'))) {
+        return;
+      }
+
+      this.$socket.player
+        .push('delete_all_events', {})
+        .receive('ok', () => this.reloadPlayerEvents())
+        .receive('error', (data) => { this.$toastError(data.reason); });
+    },
+    onReachEnd() {
+      if (this.activeTab === 'reports') {
+        this.loadPlayerEvents();
+      }
+    },
+    // --- Combat tab (legacy player_report) ---
     loadReports() {
       this.$socket.player
         .push('get_reports', {})
@@ -110,10 +317,13 @@ export default {
             report.metadata = this.parseMetadata(report.metadata);
             return report;
           });
+          this.combatLoaded = true;
 
           if (this.initial !== 0) {
             const report = this.reports.find((r) => r.id === this.initial);
-            this.toggleReport(report);
+            if (report) {
+              this.toggleReport(report);
+            }
           }
         })
         .receive('error', (data) => {
@@ -215,10 +425,15 @@ export default {
     },
   },
   mounted() {
-    this.loadReports();
+    if (this.initial !== 0) {
+      this.loadReports();
+    } else {
+      this.loadPlayerEvents();
+    }
   },
   components: {
     FightReport,
+    NotifDispatcher,
   },
 };
 </script>
@@ -230,6 +445,7 @@ export default {
 }
 
 .reports-tab {
+  position: relative;
   flex: 1;
   padding: 0.5rem 0.75rem;
   text-align: center;
@@ -252,6 +468,41 @@ export default {
   }
 }
 
+.reports-tab-badge {
+  display: inline-block;
+  min-width: 1.4em;
+  margin-left: 0.3em;
+  padding: 0 0.35em;
+  border-radius: 0.7em;
+  background: rgba(180, 220, 255, 0.85);
+  color: #06121f;
+  font-size: 0.85em;
+  font-weight: 700;
+  line-height: 1.4em;
+}
+
+.reports-toolbox {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  flex-wrap: wrap;
+
+  .button {
+    flex: 1;
+    text-align: center;
+    white-space: nowrap;
+
+    &.is-disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+
+    &.is-danger {
+      color: rgba(255, 170, 170, 0.95);
+    }
+  }
+}
+
 .reports-empty {
   padding: 1.5rem 1rem;
   text-align: center;
@@ -259,11 +510,79 @@ export default {
   font-style: italic;
 }
 
-// Dedicated class on icon-log entries so the existing `.pcb-report
-// .title strong { display: block; }` rule doesn't stack our
-// "<actor> removed <target>'s …" template onto separate lines. The
-// rest of the panel uppercases its content — we let that cascade
-// through so the new tab visually matches the combat reports.
+.event-report {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+
+  &.is-unread .event-report-title {
+    color: rgba(255, 255, 255, 0.95);
+    font-weight: 700;
+  }
+
+  &.is-open {
+    background: rgba(255, 255, 255, 0.03);
+  }
+}
+
+.event-report-header {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 0.5rem;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .svg-icon {
+    width: 1.1em;
+    height: 1.1em;
+    flex-shrink: 0;
+  }
+}
+
+.event-report-dot {
+  width: 0.5em;
+  height: 0.5em;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: rgba(180, 220, 255, 0.95);
+}
+
+.event-report-icon {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  flex-shrink: 0;
+}
+
+.event-report-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(220, 220, 220, 0.75);
+
+  ::v-deep strong {
+    font-weight: 700;
+  }
+}
+
+.event-report-outcome {
+  flex-shrink: 0;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  opacity: 0.75;
+}
+
+.event-report-date {
+  flex-shrink: 0;
+  font-size: 0.78em;
+  opacity: 0.5;
+}
+
 .icon-log-entry {
   padding: 0.6rem 0.75rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);

--- a/front/src/locales/en/game.json
+++ b/front/src/locales/en/game.json
@@ -830,7 +830,12 @@
     },
     "operations": {
       "characters": "Agents",
+      "confirm_delete_all": "Permanently delete ALL your reports? This cannot be undone.",
+      "confirm_delete_read": "Permanently delete every report you have already read?",
       "delete": "Delete",
+      "delete_all": "Delete all",
+      "delete_read": "Delete read",
+      "mark_all_read": "Mark all read",
       "fight_and": "And",
       "fight_arrival": "arrive on the battlefield.",
       "fight_attacks": "attack {attack_count} times",
@@ -856,7 +861,8 @@
       "tabs": {
         "combat": "Combat",
         "icon_log": "Icon log",
-        "no_entries": "Nothing to show yet."
+        "no_entries": "Nothing to show yet.",
+        "reports": "Reports"
       }
     },
     "ranking": {

--- a/front/src/locales/fr/game.json
+++ b/front/src/locales/fr/game.json
@@ -797,7 +797,12 @@
     },
     "operations": {
       "characters": "Agents",
+      "confirm_delete_all": "Supprimer définitivement TOUS vos rapports ? Cette action est irréversible.",
+      "confirm_delete_read": "Supprimer définitivement tous les rapports déjà lus ?",
       "delete": "Supprimer",
+      "delete_all": "Tout supprimer",
+      "delete_read": "Supprimer les lus",
+      "mark_all_read": "Tout marquer comme lu",
       "fight_and": "Et",
       "fight_arrival": "arrivent sur le champ de bataille.",
       "fight_attacks": "attaquent {attack_count} fois",
@@ -823,7 +828,8 @@
       "tabs": {
         "combat": "Combat",
         "icon_log": "Journal des icônes",
-        "no_entries": "Rien à afficher pour le moment."
+        "no_entries": "Rien à afficher pour le moment.",
+        "reports": "Rapports"
       }
     },
     "ranking": {

--- a/lib/game/instance/manager.ex
+++ b/lib/game/instance/manager.ex
@@ -446,6 +446,7 @@ defmodule Instance.Manager do
         instance_id,
         metadata[:daily]
       )
+
     channel = "instance:global:#{instance_id}"
     state = Core.GenState.new(:victory, instance_id, :master, data, channel)
     DynamicSupervisor.start_child(supervisor_pid, {Instance.Victory.Agent, state: state})
@@ -616,6 +617,24 @@ defmodule Instance.Manager do
   defp start_agent_from_snapshot(supervisor_pid, instance_id, Spatial.Supervisor, state) do
     Kernel.node(supervisor_pid)
     |> :rpc.call(Spatial, :load, [state, instance_id])
+  end
+
+  # A restored Player agent has no live client sockets attached — the restart
+  # severed every WebSocket (init_from_snapshot above broadcasts :close_game to
+  # force a reconnect). `connected_clients` is therefore snapshot-stale, and if
+  # it is left > 0 it permanently breaks offline notification replay: the
+  # push_notifs handler only queues a notif for replay-on-login when
+  # `connected_clients == 0` (see Instance.Player.Agent.on_cast/2). Reset it so
+  # the count tracks reality; reconnecting clients re-increment from 0 via
+  # PlayerChannel's :after_join. We must do this here — at real process boot —
+  # and NOT in the {:start, _} tick handler, because the Time watchdog issues a
+  # Manager :stop/:start to the same long-lived processes while clients stay
+  # connected, and that path must preserve the live count. pending_notifications
+  # is intentionally untouched: those are the very notifs awaiting flush on the
+  # next reconnect.
+  defp start_agent_from_snapshot(supervisor_pid, _instance_id, Instance.Player.Agent = module, state) do
+    state = put_in(state.data.connected_clients, 0)
+    DynamicSupervisor.start_child(supervisor_pid, {module, state: state})
   end
 
   defp start_agent_from_snapshot(supervisor_pid, _instance_id, module, state) do

--- a/lib/portal/channels/controllers/player_channel.ex
+++ b/lib/portal/channels/controllers/player_channel.ex
@@ -410,6 +410,52 @@ defmodule Portal.Controllers.PlayerChannel do
     end
   end
 
+  # Reports panel — the player's OWN events only (registration-scoped). The
+  # read/delete handlers below all key off socket.assigns.registration_id, so a
+  # player can never read-mark or delete another player's reports, nor a shared
+  # faction/global row. Tutorial has no registration row, so these no-op there.
+  record("get_player_events", %{"page" => page}, socket) do
+    unless socket.assigns.is_tutorial do
+      result = RC.PlayerEvents.get_for_registration(socket.assigns.registration_id, page: page)
+      events = Enum.map(result.entries, fn e -> %{e | inserted_at: DateTime.to_string(e.inserted_at)} end)
+      {:ok, %{events: events, total_pages: result.total_pages, page_number: result.page_number}}
+    else
+      {:ok, %{}}
+    end
+  end
+
+  record("mark_event_read", %{"event_id" => event_id}, socket) do
+    unless socket.assigns.is_tutorial do
+      RC.PlayerEvents.mark_read(socket.assigns.registration_id, event_id)
+    end
+
+    :ok
+  end
+
+  record("mark_all_events_read", %{}, socket) do
+    unless socket.assigns.is_tutorial do
+      RC.PlayerEvents.mark_all_read(socket.assigns.registration_id)
+    end
+
+    :ok
+  end
+
+  record("delete_read_events", %{}, socket) do
+    unless socket.assigns.is_tutorial do
+      RC.PlayerEvents.delete_read(socket.assigns.registration_id)
+    end
+
+    :ok
+  end
+
+  record("delete_all_events", %{}, socket) do
+    unless socket.assigns.is_tutorial do
+      RC.PlayerEvents.delete_all(socket.assigns.registration_id)
+    end
+
+    :ok
+  end
+
   def broadcast_change(channel, payload) do
     Portal.Endpoint.broadcast(channel, "broadcast", payload)
   end

--- a/lib/rc/instances/player_event.ex
+++ b/lib/rc/instances/player_event.ex
@@ -3,12 +3,13 @@ defmodule RC.Instances.PlayerEvent do
 
   import Ecto.Changeset
 
-  def jason(), do: [only: [:id, :key, :type, :data, :instance_id, :registration_id, :inserted_at]]
+  def jason(), do: [only: [:id, :key, :type, :data, :is_read, :instance_id, :registration_id, :inserted_at]]
 
   schema "player_events" do
     field(:key, :string)
     field(:type, :string)
     field(:data, :string)
+    field(:is_read, :boolean, default: false)
     belongs_to(:instance, RC.Instances.Instance)
     belongs_to(:registration, RC.Instances.Registration)
     belongs_to(:faction, RC.Instances.Faction)

--- a/lib/rc/player_events.ex
+++ b/lib/rc/player_events.ex
@@ -21,4 +21,48 @@ defmodule RC.PlayerEvents do
     )
     |> RC.Repo.paginate(params)
   end
+
+  # Personal report feed for the in-game Reports panel — only the player's
+  # OWN agent-action reports: registration-scoped + type "box" (the outcome
+  # summary cards for raid/infiltration/conversion/fight/etc.). Excluded:
+  #   * shared faction/global rows — their rows are shared, so the per-player
+  #     read-state / deletion below can't apply to them;
+  #   * transient "text" pings (started/cancelled/discovered) — they stay in
+  #     the calendar EventPanel (get_for_player/2), which shows everything.
+  # All read/delete helpers use the SAME scope (report_query/1) so the Reports
+  # panel and its bulk actions operate on exactly the set the player sees.
+  def get_for_registration(registration_id, params \\ %{}) do
+    report_query(registration_id)
+    |> order_by(desc: :inserted_at)
+    |> RC.Repo.paginate(params)
+  end
+
+  def mark_read(registration_id, event_id) do
+    report_query(registration_id)
+    |> where([e], e.id == ^event_id)
+    |> Repo.update_all(set: [is_read: true])
+  end
+
+  def mark_all_read(registration_id) do
+    report_query(registration_id)
+    |> where([e], e.is_read == false)
+    |> Repo.update_all(set: [is_read: true])
+  end
+
+  def delete_read(registration_id) do
+    report_query(registration_id)
+    |> where([e], e.is_read == true)
+    |> Repo.delete_all()
+  end
+
+  def delete_all(registration_id) do
+    report_query(registration_id)
+    |> Repo.delete_all()
+  end
+
+  # Scopes every Reports-panel query to one player's own box-type events so a
+  # player can never touch a shared faction/global row or another player's data.
+  defp report_query(registration_id) do
+    from(e in PlayerEvent, where: e.registration_id == ^registration_id and e.type == "box")
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RC.MixProject do
   def project do
     [
       app: :rc,
-      version: "1.0.0",
+      version: "1.0.1",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",

--- a/priv/repo/migrations/20260624000001_add_is_read_to_player_events.exs
+++ b/priv/repo/migrations/20260624000001_add_is_read_to_player_events.exs
@@ -1,0 +1,15 @@
+defmodule RC.Repo.Migrations.AddIsReadToPlayerEvents do
+  use Ecto.Migration
+
+  # Read-state for the in-game Reports view. Events arrive unread; the
+  # player marks them read individually (on open) or in bulk ("mark all
+  # read"), and can bulk-delete read / all events. Default false so every
+  # pre-existing row shows as unread the first time the new Reports tab is
+  # opened — which is the desired behaviour (players should re-see history
+  # they may have missed while the notification-replay bug was live).
+  def change do
+    alter table(:player_events) do
+      add(:is_read, :boolean, null: false, default: false)
+    end
+  end
+end

--- a/test/game/instance/player_snapshot_lifecycle_test.exs
+++ b/test/game/instance/player_snapshot_lifecycle_test.exs
@@ -1,0 +1,116 @@
+defmodule Game.PlayerSnapshotLifecycleTest do
+  @moduledoc """
+  End-to-end guard for the notification-replay hotfix.
+
+  Drives a real instance through the actual snapshot -> destroy -> restore
+  pipeline with a player whose client connects/disconnects, and asserts that:
+
+    1. connected_clients tracks connect/disconnect on a live agent;
+    2. a snapshot taken WHILE a client is attached comes back from restore
+       with connected_clients == 0 (the fix) — the restart severed every
+       socket, so the snapshot's count is stale and must not survive; and
+    3. with the count honest again, an offline report is queued for replay
+       and flushed on the next reconnect.
+
+  Without the manager.ex fix, step 2 fails: the agent restores believing a
+  client is still attached, push_notifs never queues anything for replay,
+  and the player logs back in to an empty feed — the bug this guards.
+
+  Mirrors the proven restore round-trip in InstanceControllerTest (same
+  publish -> register -> start -> snapshot -> destroy -> restart shape, same
+  15s graceful-terminate wait). Shared-sandbox (async: false) lets the
+  instance's agent processes reach the DB.
+  """
+  use Portal.APIConnCase, async: false
+
+  import RC.Fixtures
+  import RC.ScenarioFixtures
+
+  alias RC.Accounts.Profile
+  alias RC.Instances
+  alias RC.Repo
+
+  defp connected_clients(instance_id, player_id) do
+    {:ok, player} = Game.call(instance_id, :player, player_id, :get_state)
+    player.connected_clients
+  end
+
+  defp pending_count(instance_id, player_id) do
+    {:ok, player} = Game.call(instance_id, :player, player_id, :get_state)
+    length(player.pending_notifications)
+  end
+
+  test "snapshot restore resets connected_clients; offline replay still works", %{conn: conn} do
+    %{instance: instance, account: account} = valid_instance_fixture()
+    signed_in = login(conn, account)
+
+    # publish -> register a player -> start the instance
+    assert json_response(put(signed_in, Routes.instance_path(conn, :publish, instance.id)), 200)
+
+    {:ok, profile} =
+      Repo.insert(Profile.changeset(%Profile{}, %{avatar: "x", name: account.name, account_id: account.id}))
+
+    faction = hd(instance.factions)
+
+    assert json_response(
+             post(signed_in, Routes.registration_path(conn, :join, profile.id), %{
+               instance_id: instance.id,
+               faction_id: faction.id
+             }),
+             200
+           )
+
+    :timer.sleep(100)
+    assert json_response(put(signed_in, Routes.instance_path(conn, :start, instance.id)), 200)
+    :timer.sleep(500)
+
+    player_id = profile.id
+
+    # Fresh agent: no client attached yet.
+    assert connected_clients(instance.id, player_id) == 0
+
+    # A client connects — the counter goes up.
+    Game.call(instance.id, :player, player_id, {:update_client_status, :connect})
+    assert connected_clients(instance.id, player_id) == 1
+
+    # Snapshot taken WHILE the client is attached, so the persisted count is 1.
+    assert {:ok, %RC.Instances.InstanceSnapshot{}} =
+             Instance.Manager.call(instance.id, :make_snapshot, 300_000)
+
+    # Tear the instance down — exactly what a deploy/restart does to the sockets.
+    {:ok, :killed} = Instance.Manager.destroy(instance.id)
+    :timer.sleep(15_000)
+    RC.Instances.update_instances_state_if_needed(true)
+    assert Instances.get_instance(instance.id).state == "not_running"
+
+    # Restore from the snapshot (a snapshot exists, so this goes through
+    # create_from_snapshot, not a fresh start).
+    body = json_response(put(signed_in, Routes.instance_path(conn, :start, instance.id)), 200)
+    assert body["message"] == "instance_restarted"
+    refute body["fresh_start"] == true
+    :timer.sleep(500)
+
+    # THE FIX: the snapshot held connected_clients == 1, but no socket survived
+    # the restart, so the restored agent must come back at 0.
+    assert connected_clients(instance.id, player_id) == 0
+
+    # connect/disconnect still tracks correctly after a restore.
+    Game.call(instance.id, :player, player_id, {:update_client_status, :connect})
+    assert connected_clients(instance.id, player_id) == 1
+    Game.call(instance.id, :player, player_id, {:update_client_status, :disconnect})
+    assert connected_clients(instance.id, player_id) == 0
+
+    # With the count honest, an offline report (keep? == true) is queued for
+    # replay-on-login rather than broadcast into the void...
+    notif = Notification.Notification.new(:text, :character_lvlup, true, nil, %{character: "x", level: 2}, nil)
+    Game.cast(instance.id, :player, player_id, {:push_notifs, notif})
+    assert pending_count(instance.id, player_id) == 1
+
+    # ...and the next reconnect flushes the queue.
+    Game.call(instance.id, :player, player_id, {:update_client_status, :connect})
+    assert connected_clients(instance.id, player_id) == 1
+    assert pending_count(instance.id, player_id) == 0
+
+    {:ok, :killed} = Instance.Manager.destroy(instance.id)
+  end
+end

--- a/test/rc/player_events_test.exs
+++ b/test/rc/player_events_test.exs
@@ -1,0 +1,103 @@
+defmodule RC.PlayerEventsTest do
+  @moduledoc """
+  Scoping guarantees for the in-game Reports panel. The read/delete helpers
+  are reachable from the player channel, so they MUST only ever touch the
+  caller's own personal (registration-scoped) box events — never another
+  player's reports, a shared faction/global row, or transient text pings.
+  """
+  use Portal.APIConnCase, async: false
+
+  import RC.Fixtures
+  import RC.ScenarioFixtures
+
+  alias RC.Accounts.Profile
+  alias RC.Instances.PlayerEvent
+  alias RC.PlayerEvents
+  alias RC.Registrations
+  alias RC.Repo
+
+  setup do
+    %{instance: instance} = instance_fixture()
+    owner = fixture(:user)
+
+    Machinery.transition_to(
+      Map.put(instance, :account_id, owner.id),
+      RC.Instances.InstanceStateMachine,
+      "open"
+    )
+
+    [faction | _] = instance.factions
+
+    {:ok, profile_a} =
+      Repo.insert(Profile.changeset(%Profile{}, %{avatar: "x", name: "A", account_id: owner.id}))
+
+    {:ok, profile_b} =
+      Repo.insert(Profile.changeset(%Profile{}, %{avatar: "x", name: "B", account_id: fixture(:user2).id}))
+
+    {:ok, %{registration: reg_a}} = Registrations.register_profile(faction, profile_a)
+    {:ok, %{registration: reg_b}} = Registrations.register_profile(faction, profile_b)
+
+    {:ok, instance: instance, reg_a: reg_a, reg_b: reg_b}
+  end
+
+  defp insert_event(instance_id, attrs) do
+    {:ok, event} =
+      %PlayerEvent{}
+      |> PlayerEvent.changeset(Map.merge(%{type: "box", key: "raid", data: "{}", instance_id: instance_id}, attrs))
+      |> Repo.insert()
+
+    event
+  end
+
+  # is_read isn't a cast field (set only via the read helpers in prod), so
+  # seed it directly here.
+  defp mark_read!(event), do: Repo.update!(Ecto.Changeset.change(event, is_read: true))
+
+  test "get_for_registration returns only the caller's own box events", ctx do
+    own = insert_event(ctx.instance.id, %{registration_id: ctx.reg_a.id})
+    insert_event(ctx.instance.id, %{registration_id: ctx.reg_a.id, type: "text", key: "raid_started"})
+    insert_event(ctx.instance.id, %{registration_id: ctx.reg_b.id})
+
+    insert_event(ctx.instance.id, %{
+      registration_id: nil,
+      faction_id: ctx.reg_a.faction_id,
+      type: "faction",
+      key: "new_player"
+    })
+
+    ids = ctx.reg_a.id |> PlayerEvents.get_for_registration() |> Map.fetch!(:entries) |> Enum.map(& &1.id)
+
+    assert ids == [own.id]
+  end
+
+  test "mark_all_read marks only the caller's own box events", ctx do
+    mine = insert_event(ctx.instance.id, %{registration_id: ctx.reg_a.id})
+    theirs = insert_event(ctx.instance.id, %{registration_id: ctx.reg_b.id})
+
+    assert {1, _} = PlayerEvents.mark_all_read(ctx.reg_a.id)
+    assert Repo.get(PlayerEvent, mine.id).is_read
+    refute Repo.get(PlayerEvent, theirs.id).is_read
+  end
+
+  test "delete_read removes only the caller's own read box events", ctx do
+    read_mine = ctx.instance.id |> insert_event(%{registration_id: ctx.reg_a.id}) |> mark_read!()
+    unread_mine = insert_event(ctx.instance.id, %{registration_id: ctx.reg_a.id})
+    read_theirs = ctx.instance.id |> insert_event(%{registration_id: ctx.reg_b.id}) |> mark_read!()
+
+    assert {1, _} = PlayerEvents.delete_read(ctx.reg_a.id)
+    refute Repo.get(PlayerEvent, read_mine.id)
+    assert Repo.get(PlayerEvent, unread_mine.id)
+    assert Repo.get(PlayerEvent, read_theirs.id)
+  end
+
+  test "delete_all removes the caller's box events but spares text + other players", ctx do
+    box_mine = insert_event(ctx.instance.id, %{registration_id: ctx.reg_a.id})
+    text_mine = insert_event(ctx.instance.id, %{registration_id: ctx.reg_a.id, type: "text", key: "raid_started"})
+    box_theirs = insert_event(ctx.instance.id, %{registration_id: ctx.reg_b.id})
+
+    assert {1, _} = PlayerEvents.delete_all(ctx.reg_a.id)
+    refute Repo.get(PlayerEvent, box_mine.id)
+    assert Repo.get(PlayerEvent, text_mine.id)
+    assert Repo.get(PlayerEvent, box_theirs.id)
+  end
+end


### PR DESCRIPTION
On server deploy/snapshot restore, we purge from memory existing number of connections so we don't send notifications to no one, thus enabling them to become cached until the player logs back in again.

Further, all reports now show up in the Reports screen, enabling one to see again any event that happened in the past, rather than just once when it initially fires.