### PR TITLE
fix(discord): mark match active before bulk sync, not after

### DIFF
--- a/lib/rc/discord/role_sync.ex
+++ b/lib/rc/discord/role_sync.ex
@@ -243,8 +243,12 @@ defmodule RC.Discord.RoleSync do
           "(opening_date #{match.instance.opening_date}); doing bulk sync"
       )
 
-      bulk_sync_match(match)
+      # mark_active MUST run before bulk_sync_match. reconcile_account_in_instance/2
+      # gates on `role_assignment_active = true` (re-queried from the DB), so if we
+      # bulk-synced first every reconcile would silently no-op and only players who
+      # registered AFTER this tick would get their roles via the event-driven path.
       mark_active(match, true)
+      bulk_sync_match(match)
     end
   end
 


### PR DESCRIPTION
activate_due_matches/0 was calling bulk_sync_match/1 before mark_active/2. Every reconcile_account_in_instance/2 inside the bulk sync re-queries the match with role_assignment_active = true and returns :ok early when nil, so the activation tick was a silent no-op for every account already registered when /promote ran. Only players who registered after activation got their roles, via the event-driven sync_for_registration/1 path.

Swap the order so the flag is true before the first reconcile fires.