### PR TITLE
fix(market): stop deck-agent sale from wiping the seller to genesis

### DIFF
--- a/lib/game/core/tick_server.ex
+++ b/lib/game/core/tick_server.ex
@@ -126,6 +126,13 @@ defmodule Core.TickServer do
         Horde.Registry.register(Game.Registry, name_tuple, self())
 
         case Data.GenServerState.retrieve_delete(name_tuple) do
+          # A crash left a recovery marker (see discard_crash_state). Recover
+          # this agent's domain data from the latest instance snapshot rather
+          # than falling back to the frozen join-time genesis child-spec args
+          # (which would wipe the player back to starting resources).
+          {:ok, %{state: :crash_recover_from_snapshot}} ->
+            Core.TickServer.recover_from_snapshot(state)
+
           {:ok, %{state: state_to_restore}} ->
             state_to_restore
 
@@ -188,15 +195,80 @@ defmodule Core.TickServer do
     safe_apply(fn ->
       name_tuple = Core.GenState.registry_name(state)
       Horde.Registry.unregister(Game.Registry, name_tuple)
-      # If a previous graceful terminate or save_state had cached a
-      # value, drop it so the next restart doesn't pick up *that* one
-      # either. We can't tell whether it was graceful-good or
-      # crash-poisoned at this point — the safer default is to start
-      # the new process from a clean slate.
-      Data.GenServerState.delete(name_tuple)
+      # Do NOT save the dying state for handoff — replaying it on restart was
+      # the Stage-7 poison pill. But dropping *everything* reverted the agent
+      # to its frozen join-time genesis child-spec args, wiping all progress
+      # (see the instance-49 player-reset incident). Instead leave a small
+      # marker so the restart recovers this agent's data from the latest
+      # instance snapshot. The marker is consumed (retrieve_delete) on the
+      # very next restart, and snapshot states are older, tick-tested good
+      # states — so this cannot poison-loop the way replaying the crash-state
+      # did.
+      Data.GenServerState.save(name_tuple, :crash_recover_from_snapshot, module)
     end)
 
     :ok
+  end
+
+  @doc """
+  Recover an agent's domain `data` from the most recent instance snapshot.
+
+  Used by the crash-restart path (`load_state`, when it finds a
+  `:crash_recover_from_snapshot` marker) so a single agent crash reverts to
+  the last autosave snapshot rather than to the frozen join-time genesis
+  state. Keeps the freshly-built GenState wrapper (tick/channel/speed) and
+  only swaps in the recovered `data`. Falls back to the given genesis state
+  if no snapshot slice can be loaded. Never raises.
+  """
+  def recover_from_snapshot(state) do
+    with {instance_id, type, agent_id} <- Core.GenState.registry_name(state),
+         {:ok, data} <- snapshot_data(instance_id, type, agent_id) do
+      safe_apply(fn ->
+        require Logger
+
+        Logger.warning("TickServer recovered agent from snapshot after crash",
+          state_type: type,
+          agent_id: agent_id,
+          instance_id: instance_id
+        )
+      end)
+
+      %{state | data: data}
+    else
+      _ ->
+        safe_apply(fn ->
+          require Logger
+
+          Logger.error("TickServer crash-recovery found no snapshot slice — starting from genesis",
+            state: inspect(Map.get(state, :type)),
+            agent_id: inspect(Map.get(state, :agent_id)),
+            instance_id: inspect(Map.get(state, :instance_id))
+          )
+        end)
+
+        state
+    end
+  end
+
+  # Pull one agent's snapshot slice ({type, agent_id}) out of the latest
+  # instance snapshot. Guarded so a missing/corrupt snapshot yields :error
+  # (→ genesis fallback) rather than raising inside the restart continue.
+  defp snapshot_data(instance_id, type, agent_id) do
+    with %{name: name} <- RC.InstanceSnapshots.last(instance_id),
+         {:ok, %{agents_data: agents}} <- Util.Storage.load(name),
+         %{state: %{data: data}} <-
+           Enum.find(agents, fn
+             %{state: %{type: ^type, agent_id: ^agent_id}} -> true
+             _ -> false
+           end) do
+      {:ok, data}
+    else
+      _ -> :error
+    end
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
   end
 
   # Tiny helper: terminate callbacks must not themselves raise (raising

--- a/lib/game/instance/player/market.ex
+++ b/lib/game/instance/player/market.ex
@@ -4,14 +4,44 @@ defmodule Instance.Player.Market do
   alias Instance.Player.Player
   alias Instance.Character.Character
 
-  def create_offer(state, %{
-        "type" => type,
-        "data" => data,
-        "price" => price,
-        "allowed_players" => allowed_players,
-        "allowed_factions" => allowed_factions
-      })
-      when price >= 0 do
+  def create_offer(state, %{"price" => price} = args) when price >= 0 do
+    # Final safety net around the whole placement flow. `place_offer` and
+    # the offer-persistence steps run inside the seller's Player.Agent; an
+    # uncaught raise/exit here used to crash that agent and revert the
+    # player to their genesis state. Any unexpected failure now surfaces as
+    # an error tuple and leaves the agent (and the player's progress) alive.
+    try do
+      do_create_offer(state, args)
+    rescue
+      e ->
+        Logger.error(
+          "create_offer crashed mid-flight, aborting",
+          error: Exception.message(e),
+          stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+        )
+
+        {:error, :internal_error}
+    catch
+      kind, reason ->
+        Logger.error(
+          "create_offer exited mid-flight, aborting",
+          kind: kind,
+          reason: inspect(reason)
+        )
+
+        {:error, :internal_error}
+    end
+  end
+
+  def create_offer(_state, _args), do: {:error, :bad_argument}
+
+  defp do_create_offer(state, %{
+         "type" => type,
+         "data" => data,
+         "price" => price,
+         "allowed_players" => allowed_players,
+         "allowed_factions" => allowed_factions
+       }) do
     case place_offer(state, type, data) do
       {:ok, state, data, internal, value} ->
         price = Enum.max([price, 0])
@@ -45,9 +75,7 @@ defmodule Instance.Player.Market do
     end
   end
 
-  def create_offer(_state, _args) do
-    {:error, :bad_argument}
-  end
+  defp do_create_offer(_state, _args), do: {:error, :bad_argument}
 
   # Stage 4 #C4 fix.
   #
@@ -203,10 +231,21 @@ defmodule Instance.Player.Market do
   end
 
   defp place_offer(state, "character_deck", data) do
+    # A deck card carries a cooldown that is `nil` (never deployed) OR a
+    # %Core.CooldownValue{} once it has been deployed and recalled — the
+    # recall cooldown ticks down to `value: 0` but is never reset back to
+    # `nil` (see Player.next_tick). The old code hard-matched
+    # `%{cooldown: nil, character: character} = card`, which RAISED a
+    # MatchError for any previously-deployed card, crashing the seller's
+    # Player.Agent (and, via the crash path, wiping the player back to
+    # their join-time genesis state). Treat a card as sellable when its
+    # cooldown is nil or expired, and reject a still-locked card cleanly.
     with true <- Map.has_key?(data, "character_id"),
          character_id <- Map.get(data, "character_id"),
-         character <- Enum.find(state.character_deck, fn %{character: c} -> c.id == character_id end) do
-      %{cooldown: nil, character: character} = character
+         %{character: character} = card <-
+           Enum.find(state.character_deck, fn %{character: c} -> c.id == character_id end) ||
+             :character_unavailable,
+         false <- deck_card_locked?(card) do
       value = character.level * 50_000
       data = Map.put(data, "character", character)
 
@@ -220,9 +259,17 @@ defmodule Instance.Player.Market do
       state = %{state | character_deck: character_deck}
       {:ok, state, Jason.encode!(data), :erlang.term_to_binary(character), value}
     else
+      :character_unavailable -> {:error, :character_unavailable}
+      true -> {:error, :character_on_cooldown}
       _ -> {:error, :error}
     end
   end
+
+  # A deck card is free to be listed when it has no cooldown or its recall
+  # cooldown has fully ticked down (value 0). A card still on cooldown is not.
+  defp deck_card_locked?(%{cooldown: nil}), do: false
+  defp deck_card_locked?(%{cooldown: %Core.CooldownValue{} = cd}), do: Core.CooldownValue.locked?(cd)
+  defp deck_card_locked?(_), do: false
 
   defp place_offer(state, "board_character", data) do
     with true <- Map.has_key?(data, "character_id"),

--- a/lib/game/instance/supervisor.ex
+++ b/lib/game/instance/supervisor.ex
@@ -117,6 +117,18 @@ defmodule Instance.Supervisor do
   defp safe_restore_one(supervisor_pid, name_tuple) do
     try do
       case Data.GenServerState.retrieve_delete(name_tuple) do
+        {:ok, %{state: :crash_recover_from_snapshot}} ->
+          # A hard BEAM restart caught a transient per-agent crash-recovery
+          # marker (normally consumed on the immediate single-agent restart).
+          # There is nothing to restore from the CRDT here; drop it. The
+          # agent, if it still needs to exist, is rebuilt from the snapshot on
+          # the normal boot path.
+          Logger.warning("Instance.Supervisor.continue: dropping stale crash-recovery marker",
+            name_tuple: inspect(name_tuple)
+          )
+
+          false
+
         {:ok, %{state: state, module: module}} ->
           result =
             if Enum.member?([Spatial.Supervisor, Spatial.Handoff], module) do

--- a/test/security/genserver_resilience_test.exs
+++ b/test/security/genserver_resilience_test.exs
@@ -31,22 +31,22 @@ defmodule RC.Security.GenServerResilienceTest do
 
   alias Portal.ChannelWatcher
 
-  describe "Stage 7 F11 — TickServer terminate discards crash state" do
-    test "the discard_crash_state helper deletes any saved entry for the dying agent" do
-      # We synthesize a saved entry under the same name_tuple shape
-      # `Core.GenState.registry_name/1` produces — namely
-      # `{instance_id, type, agent_id}` — then call
-      # discard_crash_state and verify the cached entry is gone.
+  describe "TickServer crash path — no poison pill, snapshot-recovery marker" do
+    test "discard_crash_state does NOT keep the dying state, and marks the agent for snapshot recovery" do
+      # Stage 7 F11 still holds: the dying state must never be replayed on
+      # restart. But dropping *everything* reverted the agent to its frozen
+      # join-time genesis child-spec args, wiping all progress (the instance-49
+      # player-reset incident). The crash path now leaves a tiny
+      # `:crash_recover_from_snapshot` marker so the restart recovers the agent
+      # from the latest instance snapshot instead of from genesis.
       instance_id = :erlang.unique_integer([:positive])
       state = %{type: :stage7_test_agent, agent_id: 0, instance_id: instance_id}
       name_tuple = Core.GenState.registry_name(state)
 
       # Pretend a graceful save had previously happened, then crash.
       Data.GenServerState.save(name_tuple, state, __MODULE__)
-      assert {:ok, _} = Data.GenServerState.retrieve(name_tuple)
+      assert {:ok, %{state: ^state}} = Data.GenServerState.retrieve(name_tuple)
 
-      # Stage 7 F11: crash path discards the cached state instead of
-      # leaving it for the next start to pick up.
       result =
         Core.TickServer.discard_crash_state(
           {:badarith, []},
@@ -55,7 +55,13 @@ defmodule RC.Security.GenServerResilienceTest do
         )
 
       assert result == :ok
-      assert :error == Data.GenServerState.retrieve(name_tuple)
+      # The dying state is gone — it is never replayed on restart ...
+      refute match?({:ok, %{state: ^state}}, Data.GenServerState.retrieve(name_tuple))
+      # ... it is replaced by the snapshot-recovery marker.
+      assert {:ok, %{state: :crash_recover_from_snapshot}} =
+               Data.GenServerState.retrieve(name_tuple)
+
+      Data.GenServerState.delete(name_tuple)
     end
   end
 
@@ -66,6 +72,13 @@ defmodule RC.Security.GenServerResilienceTest do
       # exported and arity 2 — the macro-using modules delegate to
       # it via __MODULE__ at runtime, so its public visibility is
       # part of the contract.
+      #
+      # `function_exported?/3` returns false for a module that simply
+      # hasn't been loaded yet, so ensure it's loaded first — otherwise
+      # this test is order-dependent (flaky when run before any test
+      # that references Core.TickServer).
+      {:module, Core.TickServer} = Code.ensure_loaded(Core.TickServer)
+
       assert function_exported?(Core.TickServer, :graceful_terminate, 2)
       assert function_exported?(Core.TickServer, :discard_crash_state, 3)
     end
@@ -150,7 +163,9 @@ defmodule RC.Security.GenServerResilienceTest do
       state = :sys.get_state(RC.Supervisor)
       # The supervisor state record fields differ slightly between
       # OTP versions; we read intensity/period defensively.
-      {:state, _name, _strategy, _children, _dynamics, intensity, period, _restarts, _dynamic_restarts, _auto_shutdown, _module, _args} =
+      {:state, _name, _strategy, _children, _dynamics, intensity, period, _restarts, _dynamic_restarts, _auto_shutdown,
+       _module,
+       _args} =
         case state do
           t when tuple_size(t) == 12 -> t
           t when tuple_size(t) == 11 -> Tuple.append(t, nil)
@@ -192,6 +207,7 @@ defmodule RC.Security.GenServerResilienceTest do
     setup do
       name = :"stage7_channel_watcher_#{:erlang.unique_integer([:positive])}"
       {:ok, watcher_pid} = ChannelWatcher.start_link(name)
+
       on_exit(fn ->
         if Process.alive?(watcher_pid), do: Process.exit(watcher_pid, :kill)
       end)
@@ -203,13 +219,15 @@ defmodule RC.Security.GenServerResilienceTest do
          %{watcher: watcher, name: name} do
       # Spawn a sacrificial pid that the watcher will monitor.
       parent = self()
-      victim = spawn(fn ->
-        send(parent, :victim_ready)
 
-        receive do
-          :die -> :ok
-        end
-      end)
+      victim =
+        spawn(fn ->
+          send(parent, :victim_ready)
+
+          receive do
+            :die -> :ok
+          end
+        end)
 
       assert_receive :victim_ready, 500
       :ok = ChannelWatcher.monitor(name, victim, {Kernel, :is_atom, [:noop]})

--- a/test/security/player_market_deck_cooldown_test.exs
+++ b/test/security/player_market_deck_cooldown_test.exs
@@ -1,0 +1,102 @@
+defmodule RC.Security.PlayerMarketDeckCooldownTest do
+  @moduledoc """
+  Regression test for the instance-49 player-reset incident.
+
+  Selling a *deck* character via `Instance.Player.Market` used to run
+
+      %{cooldown: nil, character: character} = card
+
+  in `place_offer(state, "character_deck", _)`. That hard match only accepts
+  a card whose cooldown is `nil` (a character never deployed). A card that had
+  been deployed and recalled carries a `%Core.CooldownValue{}` whose `value`
+  ticks down to 0 but is never reset back to `nil` — so listing such a card
+  raised a `MatchError`, crashed the seller's `Player.Agent`, and (via the
+  crash-restart path) reverted the whole player to their join-time genesis
+  state (starting resources, no systems).
+
+  The fix treats a card as sellable when its cooldown is `nil` OR has expired
+  (`value == 0`), rejects a still-locked card with a clean error tuple, and
+  wraps `create_offer/2` in a try/rescue safety net so no offer-placement path
+  can crash the agent.
+
+  These tests drive `create_offer/2` with a synthetic map-state, so they need
+  no running game instance / Repo. The success path (a real offer row) is out
+  of scope here — in the unit env the DB insert simply fails and is caught,
+  which is exactly the safety net we want to prove.
+  """
+  use ExUnit.Case, async: true
+
+  alias Instance.Player.Market
+  alias Instance.Character.Character
+
+  defp deck_offer_args(character_id) do
+    %{
+      "type" => "character_deck",
+      "data" => %{"character_id" => character_id},
+      "price" => 20,
+      "allowed_players" => [],
+      "allowed_factions" => []
+    }
+  end
+
+  # struct/2 bypasses @enforce_keys so we can build a minimal Character
+  # without dragging Data.Querier into the test.
+  defp char(id) do
+    struct(Character,
+      id: id,
+      status: :in_deck,
+      type: :speaker,
+      specialization: :agitator,
+      second_specialization: :proselyte,
+      skills: [1, 3, 2, 1, 1, 1],
+      name: "Erikson Valseciel",
+      level: 4,
+      experience: %Core.DynamicValue{value: 59.0, change: 0.05, details: %{}},
+      protection: 56,
+      determination: 68,
+      credit_cost: 0,
+      technology_cost: 420,
+      ideology_cost: 652,
+      owner: nil,
+      on_sold: false,
+      instance_id: 1
+    )
+  end
+
+  defp state(deck), do: %{id: 5, instance_id: 1, character_deck: deck}
+
+  test "a deck card still on its recall cooldown is rejected cleanly, not crashed" do
+    s = state([%{cooldown: %Core.CooldownValue{initial: 40, value: 12}, character: char(25)}])
+
+    assert {:error, :character_on_cooldown} = Market.create_offer(s, deck_offer_args(25))
+  end
+
+  test "listing an unknown deck card returns :character_unavailable" do
+    s = state([%{cooldown: nil, character: char(25)}])
+
+    assert {:error, :character_unavailable} = Market.create_offer(s, deck_offer_args(999))
+  end
+
+  test "a never-deployed deck card (cooldown nil) is sellable — no crash" do
+    s = state([%{cooldown: nil, character: char(25)}])
+
+    result = Market.create_offer(s, deck_offer_args(25))
+    refute match?({:error, :character_on_cooldown}, result)
+    refute match?({:error, :character_unavailable}, result)
+  end
+
+  test "a previously-deployed deck card (expired cooldown, value 0) is sellable, NOT a MatchError crash" do
+    # This is the exact incident shape: cooldown is a %CooldownValue{} that has
+    # ticked to 0. The old code raised a MatchError here.
+    s = state([%{cooldown: %Core.CooldownValue{initial: 40, value: 0}, character: char(25)}])
+
+    result = Market.create_offer(s, deck_offer_args(25))
+
+    # Must not be rejected as on-cooldown, and must not raise. In the unit env
+    # the downstream DB insert fails and is caught by the create_offer safety
+    # net, yielding {:error, :internal_error}; with a real instance it would be
+    # {:ok, state}. Either outcome proves the crash is gone.
+    refute match?({:error, :character_on_cooldown}, result)
+    assert match?({:ok, _}, result) or match?({:error, :internal_error}, result)
+  end
+end


### PR DESCRIPTION
Observed live on instance 49 (player "Alrua"): selling a previously-deployed deck agent crashed the seller's Player.Agent and reverted the whole player to their join-time genesis state (starting resources, no systems).

The severity is a REGRESSION, not a new bug. Git history:

* The trigger is ancient. place_offer("character_deck") has hard-matched `%{cooldown: nil, character: _}` since 37a6a26 "Public release" (2022-09-22), as has the recall path that puts a %CooldownValue{} on a deck card. A card that was deployed and recalled keeps a cooldown whose value ticks to 0 but is never reset to nil, so listing it raised a MatchError and crashed the Player.Agent. Latent for ~4 years.

* It used to self-heal. The 2022 catch-all `terminate(_reason, state)` saved the good pre-crash state on ANY reason (crash included); load_state restored it on restart and the bad message was not redelivered. Crash -> save -> restore.

* f03ef4e "Security: Stage 7 Tier 1 + 2 (GenServer crash resilience)" (2026-06-01) split terminate by reason and routed crash reasons to discard_crash_state, which deletes the handoff entry and saves nothing (to stop a poison-loop, F11). That removed graceful recovery for ALL crashes, so a crash now restarts from the frozen genesis child-spec args = total wipe. It affects every TickServer agent, not just the market.

Fixes:

1. place_offer("character_deck") no longer hard-matches cooldown: nil. A nil-or-expired cooldown is sellable; a still-locked card returns {:error, :character_on_cooldown}. create_offer is wrapped in try/rescue (like buy_offer) so no placement path can crash the agent. (Repairs the ancient trigger.)

2. Restore graceful crash recovery without the f03ef4e poison-loop: on crash, discard_crash_state leaves a :crash_recover_from_snapshot marker; load_state recovers the agent's data from the latest instance snapshot (an older, tick-tested good state) instead of genesis. Gated so the deploy/handoff restore path is unchanged. (Repairs the regression that made the trigger catastrophic.)

Tests: new player_market_deck_cooldown_test.exs covers the incident trigger; genserver_resilience_test updated for the new crash-marker behaviour.