### PR TITLE
fix(systems): lift the under-attack pulse when a propaganda aborts mid-…

### DIFF
--- a/lib/game/instance/character/actions/fight.ex
+++ b/lib/game/instance/character/actions/fight.ex
@@ -289,6 +289,10 @@ defmodule Instance.Character.Actions.Fight do
     do: nil
 
   defp kill_character({%Character{} = character, true}) do
+    # a character dying mid-conquest never reaches MakeDominion.finish —
+    # lift the target owner's under-attack mark (no-op for everyone else)
+    Instance.Character.Actions.MakeDominion.unmark_if_interrupted(character)
+
     # clean dead character...
     {:ok, _system} =
       Game.call(character.instance_id, :stellar_system, character.system, {:remove_character, character, :on_board})

--- a/lib/game/instance/character/actions/make_dominion.ex
+++ b/lib/game/instance/character/actions/make_dominion.ex
@@ -65,6 +65,34 @@ defmodule Instance.Character.Actions.MakeDominion do
     {MapSet.new([:player_update]), [notif], character}
   end
 
+  @doc """
+  Lift the under-attack mark if `character` is dropped mid-conquest.
+
+  `start/2` marks the target dominion's owner and `finish/2` unmarks —
+  but an in-progress make_dominion can also end without finishing: the
+  owner clears the Siderian's action queue, or the Siderian is
+  assassinated/converted mid-action. Those paths used to leave the
+  owner's dominion pulsing "under attack" forever (Preid, instance 49).
+  Call this from any abort path; it no-ops unless the character's
+  current action is a started make_dominion. The queue peek comes first
+  so the common case costs no Game.call.
+  """
+  def unmark_if_interrupted(%Character{} = character) do
+    # `actions` can be nil on some live characters (governors, older
+    # snapshots) — this helper runs inside player-agent handlers, where a
+    # crash means a state reset, so every step must be a soft match.
+    with %{queue: queue} <- character.actions,
+         %Action{type: :make_dominion, started_at: started_at} when not is_nil(started_at) <-
+           Queue.peek(queue),
+         system_id when not is_nil(system_id) <- character.system,
+         {:ok, system} <- Game.call(character.instance_id, :stellar_system, system_id, :get_state),
+         %{owner: %{id: owner_id}} <- system do
+      Game.cast(character.instance_id, :player, owner_id, {:unmark_dominion_under_attack, system_id})
+    else
+      _ -> :ok
+    end
+  end
+
   def finish(%Character{} = character, %Action{} = _action) do
     iid = character.instance_id
     prev_character = character

--- a/lib/game/instance/character/agent.ex
+++ b/lib/game/instance/character/agent.ex
@@ -203,6 +203,12 @@ defmodule Instance.Character.Agent do
 
   @decorate tick()
   def on_cast({:clear_actions, index}, state) do
+    # clearing from index 0 drops the in-progress action too — if that's a
+    # running make_dominion, lift the target owner's under-attack mark
+    if index == 0 do
+      Instance.Character.Actions.MakeDominion.unmark_if_interrupted(state.data)
+    end
+
     data = Character.clear_actions_after(state.data, index)
     Game.cast(state.instance_id, :player, data.owner.id, {:update_character, data})
 

--- a/lib/game/instance/player/agent.ex
+++ b/lib/game/instance/player/agent.ex
@@ -602,6 +602,9 @@ defmodule Instance.Player.Agent do
                  character.system,
                  {:remove_character, character, character.status}
                ) do
+          # a Siderian killed mid-conquest never reaches MakeDominion.finish;
+          # lift the target owner's under-attack mark before the agent dies
+          Instance.Character.Actions.MakeDominion.unmark_if_interrupted(character)
           Instance.Manager.kill_child(state.instance_id, {state.instance_id, :character, character.id})
           data = Player.update_stellar_system(data, system)
 
@@ -1012,6 +1015,9 @@ defmodule Instance.Player.Agent do
     with {:ok, character} <- Game.call(state.instance_id, :character, character_id, :get_state),
          mode = character.status,
          system_id = character.system,
+         # deactivation kills the agent, so a running make_dominion never
+         # reaches finish — lift the target owner's under-attack mark
+         _ = Instance.Character.Actions.MakeDominion.unmark_if_interrupted(character),
          {:ok, data, character} <- Player.deactivate_character(state.data, character),
          state = %{state | data: data},
          :ok <- Instance.Manager.kill_child(state.instance_id, {state.instance_id, :character, character.id}),

--- a/test/game/instance/character/make_dominion_abort_test.exs
+++ b/test/game/instance/character/make_dominion_abort_test.exs
@@ -1,0 +1,147 @@
+defmodule Character.Actions.MakeDominionAbortTest do
+  @moduledoc """
+  Locks the under-attack unmark on conquest abort paths.
+
+  `MakeDominion.start/2` marks the target dominion's owner
+  (`dominions_under_attack` drives the red pulse on their side panel) and
+  `finish/2` unmarks — but an in-progress conquest can also end without
+  finishing: the Siderian's owner clears the action queue, or the
+  Siderian is assassinated/converted/killed. Those paths route through
+  `MakeDominion.unmark_if_interrupted/1`; without it the owner's dominion
+  pulsed "under attack" forever (observed in prod: Preid, instance 49,
+  ~10 hours after the attacker was gone).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Instance.Character.Actions.MakeDominion
+  alias Test.FleetScenario
+
+  @system_id 344
+  @owner_id 7
+
+  defp owner_struct do
+    %Instance.StellarSystem.Player{
+      id: @owner_id,
+      avatar: "",
+      name: "owner",
+      faction: :ark,
+      faction_id: 1
+    }
+  end
+
+  defp speaker_with_action(iid, action) do
+    speaker =
+      FleetScenario.build_character(
+        character_id: 501,
+        instance_id: iid,
+        faction: :myrmezir,
+        faction_id: 2,
+        type: :speaker,
+        has_ships?: false,
+        system: @system_id
+      )
+
+    %{speaker | actions: %{speaker.actions | queue: Queue.insert(speaker.actions.queue, action)}}
+  end
+
+  setup do
+    instance_id = FleetScenario.unique_instance_id()
+
+    {_system, _pid} =
+      FleetScenario.spawn_fake_stellar_system(self(),
+        instance_id: instance_id,
+        system_id: @system_id,
+        owner: owner_struct(),
+        status: :inhabited_dominion
+      )
+
+    {_player, player_pid} =
+      FleetScenario.spawn_fake_player(self(),
+        instance_id: instance_id,
+        player_id: @owner_id,
+        faction: :ark
+      )
+
+    {:ok, instance_id: instance_id, player_pid: player_pid}
+  end
+
+  test "a started make_dominion being dropped unmarks the dominion owner",
+       %{instance_id: iid, player_pid: player_pid} do
+    action = FleetScenario.build_action(:make_dominion, %{"target" => @system_id}, started_at: 123)
+    MakeDominion.unmark_if_interrupted(speaker_with_action(iid, action))
+
+    assert FleetScenario.get_under_attack_casts(player_pid) ==
+             [{:unmark_dominion_under_attack, @system_id}]
+  end
+
+  test "a make_dominion that never started does not unmark (start/2 never marked)",
+       %{instance_id: iid, player_pid: player_pid} do
+    action = FleetScenario.build_action(:make_dominion, %{"target" => @system_id})
+    MakeDominion.unmark_if_interrupted(speaker_with_action(iid, action))
+
+    assert FleetScenario.get_under_attack_casts(player_pid) == []
+  end
+
+  test "other in-progress actions do not unmark", %{instance_id: iid, player_pid: player_pid} do
+    action =
+      FleetScenario.build_action(:jump, %{"source" => @system_id, "target" => 1}, started_at: 123)
+
+    MakeDominion.unmark_if_interrupted(speaker_with_action(iid, action))
+
+    assert FleetScenario.get_under_attack_casts(player_pid) == []
+  end
+
+  test "an empty action queue does not unmark", %{instance_id: iid, player_pid: player_pid} do
+    speaker =
+      FleetScenario.build_character(
+        character_id: 501,
+        instance_id: iid,
+        faction: :myrmezir,
+        faction_id: 2,
+        type: :speaker,
+        has_ships?: false,
+        system: @system_id
+      )
+
+    MakeDominion.unmark_if_interrupted(speaker)
+
+    assert FleetScenario.get_under_attack_casts(player_pid) == []
+  end
+
+  test "nil actions (governors, older snapshots) neither crash nor unmark",
+       %{instance_id: iid, player_pid: player_pid} do
+    # this helper runs inside player-agent handlers — a crash there resets
+    # the player's state, so nil-tolerance is load-bearing
+    speaker =
+      FleetScenario.build_character(
+        character_id: 501,
+        instance_id: iid,
+        faction: :myrmezir,
+        faction_id: 2,
+        type: :speaker,
+        has_ships?: false,
+        system: @system_id
+      )
+
+    assert :ok = MakeDominion.unmark_if_interrupted(%{speaker | actions: nil})
+    assert FleetScenario.get_under_attack_casts(player_pid) == []
+  end
+
+  test "an unowned target system unmarks nobody", %{player_pid: player_pid} do
+    iid = FleetScenario.unique_instance_id()
+
+    {_system, _pid} =
+      FleetScenario.spawn_fake_stellar_system(self(),
+        instance_id: iid,
+        system_id: @system_id,
+        owner: nil,
+        status: :inhabited_neutral
+      )
+
+    action = FleetScenario.build_action(:make_dominion, %{"target" => @system_id}, started_at: 123)
+    MakeDominion.unmark_if_interrupted(speaker_with_action(iid, action))
+
+    assert FleetScenario.get_under_attack_casts(player_pid) == []
+  end
+end

--- a/test/support/fleet_scenario.ex
+++ b/test/support/fleet_scenario.ex
@@ -488,6 +488,16 @@ defmodule Test.FleetScenario do
     GenServer.call(player_pid, :get_system_updates)
   end
 
+  @doc """
+  Pull the ordered list of
+  `{:mark_dominion_under_attack | :unmark_dominion_under_attack, system_id}`
+  casts the fake player received — the refcount channel behind the
+  dominion "under attack" pulse.
+  """
+  def get_under_attack_casts(player_pid) do
+    GenServer.call(player_pid, :get_under_attack_casts)
+  end
+
   ## Internal helpers
 
   defp build_system(opts) do
@@ -696,7 +706,8 @@ defmodule Test.FleetScenario do
     use GenServer
 
     @impl true
-    def init(player), do: {:ok, %{player: player, fight_callbacks: [], notifs: [], system_updates: []}}
+    def init(player),
+      do: {:ok, %{player: player, fight_callbacks: [], notifs: [], system_updates: [], under_attack_casts: []}}
 
     @impl true
     def handle_call(:get_state, _from, state), do: {:reply, {:ok, state.player}, state}
@@ -721,6 +732,10 @@ defmodule Test.FleetScenario do
       do: {:reply, Enum.reverse(state.system_updates), state}
 
     @impl true
+    def handle_call(:get_under_attack_casts, _from, state),
+      do: {:reply, Enum.reverse(state.under_attack_casts), state}
+
+    @impl true
     def handle_cast({:push_notifs, notif}, state) do
       additions = List.wrap(notif)
       {:noreply, %{state | notifs: Enum.reverse(additions) ++ state.notifs}}
@@ -729,6 +744,12 @@ defmodule Test.FleetScenario do
     @impl true
     def handle_cast({kind, system}, state) when kind in [:update_system, :update_dominion] do
       {:noreply, %{state | system_updates: [{kind, system} | state.system_updates]}}
+    end
+
+    @impl true
+    def handle_cast({kind, system_id}, state)
+        when kind in [:mark_dominion_under_attack, :unmark_dominion_under_attack] do
+      {:noreply, %{state | under_attack_casts: [{kind, system_id} | state.under_attack_casts]}}
     end
   end
 end


### PR DESCRIPTION
…action

The dominion under-attack mark (the red pulse on the owner's side panel, unrelated to the agent dots) is set by MakeDominion.start and removed by MakeDominion.finish — but an in-progress propaganda can end without finishing: the Siderian's owner clears its action queue, or the Siderian is assassinated, converted, or killed. Every one of those paths silently dropped the action and left the owner's dominion pulsing forever (observed in prod: Preid, instance 49, ~10h after the attacker was gone; repaired in place, and a sweep found no other stale flags — one other system is under a genuine active propaganda).

New MakeDominion.unmark_if_interrupted/1 no-ops unless the character's current action is a started make_dominion, and is wired into the four abort choke points: clear_actions from index 0, assassination, deactivation, and battle death. It tolerates nil action queues (governors, older snapshots) because it runs inside player-agent handlers where a crash would reset the player's state.

Six tests cover the unmark-on-abort contract, including the nil-actions guard and the not-yet-started / wrong-action / unowned-system no-ops.