### PR TITLE
fix(about): attribute asset copyrights to individual authors

### DIFF
--- a/lib/portal/live/public/about_live.html.leex
+++ b/lib/portal/live/public/about_live.html.leex
@@ -52,11 +52,12 @@
 
       <h2>Images, art &amp; music</h2>
       <p>
-        All visual assets and audio shipped with the game remain the
-        copyright of <strong>Black Flag Games</strong> (Copyright 2021
-        Clément Chassot / Loïc Lebas). They are used here under the
+        All visual assets shipped with the game are Copyright 2021
+        <strong>Clément Chassot</strong> and <strong>Loïc Lebas</strong>.
+        All music and sound assets are Copyright 2021
+        <strong>Jérôme Clavien</strong>. Both are used here under the
         <a target="_blank" rel="noopener" href="https://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)</a>
-        license that Black Flag Games granted.
+        license granted by their respective authors.
       </p>
 
       <h2>Game code</h2>
@@ -110,12 +111,13 @@
 
       <h2>Images, illustrations &amp; musique</h2>
       <p>
-        Tous les éléments visuels et audio livrés avec le jeu restent la
-        propriété de <strong>Black Flag Games</strong> (Copyright 2021
-        Clément Chassot / Loïc Lebas). Ils sont utilisés ici sous la
+        Tous les éléments visuels livrés avec le jeu sont Copyright 2021
+        <strong>Clément Chassot</strong> et <strong>Loïc Lebas</strong>.
+        La musique et les éléments sonores sont Copyright 2021
+        <strong>Jérôme Clavien</strong>. Ils sont utilisés ici sous la
         licence
         <a target="_blank" rel="noopener" href="https://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution - Pas d'Utilisation Commerciale 4.0 International (CC BY-NC 4.0)</a>
-        accordée par Black Flag Games.
+        accordée par leurs auteurs respectifs.
       </p>
 
       <h2>Code du jeu</h2>


### PR DESCRIPTION
The Licensing section credited Black Flag Games as the copyright holder of all visual and audio assets. The actual copyright notices name individuals: visuals are Copyright 2021 Clement Chassot / Loic Lebas, and music/sound is Copyright 2021 Jerome Clavien, who was missing from the page entirely. Fix both the English and French sections to match the README's license attributions.