### PR TITLE
fix(agents): floor seduction defense at zero

### DIFF
--- a/lib/game/instance/character/actions/conversion.ex
+++ b/lib/game/instance/character/actions/conversion.ex
@@ -48,6 +48,11 @@ defmodule Instance.Character.Actions.Conversion do
         do: target.determination + system.happiness.value,
         else: target.determination
 
+    # deeply negative happiness can push the defense below zero, which
+    # Core.Dice.roll rejects (defender >= 0 guard) — floor it like
+    # encourage_hate/make_dominion already do
+    defense = Enum.max([defense, 0])
+
     attack = character.speaker.conversion_coef.value
     {result, {ratio, min, max, value}} = Core.Dice.roll(character.instance_id, attack, character.level, defense)
 


### PR DESCRIPTION
Deeply negative system happiness (e.g. stacked encourage-hate penalties) can push a same-faction target's conversion defense below zero, which trips Core.Dice.roll's defender >= 0 guard: the action raises FunctionClauseError at start and is silently aborted by the orchestrator. Seen on instance 49 (char 655 "Bori Miril" vs system Alas, happiness -116, defense -36.4). Floor the defense like encourage_hate/make_dominion already do — defense 0 gives the attacker the intended best-case odds.