### PR TITLE
fix(instance): skip News.Server in Manager start/stop/snapshot fan-outs

### DIFF
--- a/lib/game/instance/manager.ex
+++ b/lib/game/instance/manager.ex
@@ -11,7 +11,15 @@ defmodule Instance.Manager do
   alias Portal.Controllers.PortalChannel
 
   # GenServers that are not TickServers, we don't want to send them :start/:stop/:get_full_state
-  @no_tick [Spatial.Supervisor, Instance.Manager]
+  @no_tick [Spatial.Supervisor, Instance.Manager, Game.News.Server]
+
+  # Children excluded from make_snapshot's :get_full_state fan-out. Narrower
+  # than @no_tick because Spatial.Supervisor IS snapshotted (via Spatial.dump,
+  # special-cased in make_snapshot). Game.News.Server holds only ephemeral
+  # dedup/cache state and rebuilds empty on restart, so it has nothing to
+  # snapshot — and calling it with :get_full_state crashes it (plain GenServer),
+  # which poisons the Task.async_stream and takes the Manager down mid-autosave.
+  @no_snapshot [Instance.Manager, Game.News.Server]
 
   # Stage 6 Cluster E fix. Snapshot restore allow-list. Only modules
   # the snapshot pipeline legitimately spawns may be re-instantiated
@@ -716,7 +724,7 @@ defmodule Instance.Manager do
     # fetch processes data
     agents_data =
       DynamicSupervisor.which_children(supervisor_pid)
-      |> Enum.reject(fn {_, _, _, [module | _]} -> module == Instance.Manager end)
+      |> Enum.reject(fn {_, _, _, [module | _]} -> Enum.member?(@no_snapshot, module) end)
       |> Task.async_stream(
         fn {_, child_pid, _, [module | _]} ->
           state =

--- a/test/portal/controllers/instance_controller_test.exs
+++ b/test/portal/controllers/instance_controller_test.exs
@@ -901,6 +901,49 @@ defmodule Portal.InstanceControllerTest do
       conn = put(signed_in, Routes.instance_path(conn, :finish, instance.id))
       assert json_response(conn, 200)["message"] == "instance_killed_and_finished"
     end
+
+    test "autosave cycle (stop -> snapshot -> start) survives a News.Server child", %{conn: conn} do
+      # Regression: Game.News.Server is lazily started under the instance's
+      # DynamicSupervisor on the first Game.News.emit. It is a plain GenServer
+      # with no tick protocol, so the Manager's stop/make_snapshot/start
+      # fan-outs must skip it. Before the @no_tick/@no_snapshot fix, the
+      # :get_full_state call crashed it, poisoned the Task.async_stream, and
+      # took the Manager down mid-autosave — leaving the Time agent stopped
+      # while the DB still said "running" (prod instance 49, 2026-07-13).
+      %{instance: instance, account: account} = RC.ScenarioFixtures.valid_instance_fixture()
+
+      signed_in = login(conn, account)
+
+      conn = put(signed_in, Routes.instance_path(conn, :publish, instance.id))
+      assert json_response(conn, 200)["message"] == "instance_published"
+
+      conn = put(signed_in, Routes.instance_path(conn, :start, instance.id))
+      assert json_response(conn, 200)["message"] == "instance_started"
+
+      :timer.sleep(500)
+
+      # Spawn the news server exactly the way Game.News.ensure_server does.
+      {:ok, supervisor_pid} = Instance.Supervisor.get_pid(instance.id)
+
+      {:ok, news_pid} =
+        DynamicSupervisor.start_child(supervisor_pid, {Game.News.Server, instance_id: instance.id})
+
+      # The autosave sequence (see Instance.Time.Time.update_next_autosave).
+      assert {:ok, :stopped, _} = Instance.Manager.call(instance.id, :stop)
+      assert {:ok, %RC.Instances.InstanceSnapshot{}} = Instance.Manager.call(instance.id, :make_snapshot, 300_000)
+      assert {:ok, :started, _} = Instance.Manager.call(instance.id, :start)
+
+      # The news server was never crash-restarted by the fan-outs...
+      assert Process.alive?(news_pid)
+
+      # ...the snapshot has no News.Server entry to replay on restore...
+      {:ok, snapshot} = Util.Storage.load(RC.InstanceSnapshots.last(instance.id).name)
+      refute Enum.any?(snapshot.agents_data, fn %{module: module} -> module == Game.News.Server end)
+
+      # ...and the game clock is actually ticking again.
+      {:ok, time} = Game.call(instance.id, :time, :master, :get_state)
+      assert time.is_running
+    end
   end
 
   def create_instance(_) do


### PR DESCRIPTION
Game.News.Server is lazily started under each instance's DynamicSupervisor on the first Game.News.emit, but it is a plain GenServer with no tick protocol. The Manager's start/stop/make_snapshot fan-outs messaged it anyway: the :get_full_state call crashed it, poisoned the Task.async_stream ({:exit, _} into the {:ok, data} map head), and took the Manager down mid-call.

In prod (instance 49, 2026-07-13) this broke the autosave cycle (stop -> snapshot -> start): the stop landed, the snapshot crashed the Manager, and the fail-open restart died on the same call before the Time agent got its {:start, _} - leaving the game permanently frozen in-memory while the DB still said "running" (lobby offered Pause, game showed the paused headband). News.Server is :permanent, so it respawned after every crash and re-broke each subsequent autosave.

Add Game.News.Server to @no_tick and to a new @no_snapshot reject list for make_snapshot (narrower than @no_tick since Spatial.Supervisor IS snapshotted via Spatial.dump). It holds only ephemeral dedup/cache state, so there is nothing to snapshot.

Regression test drives the full autosave sequence with a News.Server child present; it reproduces the exact prod FunctionClauseError without the fix.