### PR TITLE
feat(ops): snapshot on every graceful shutdown + auto-restore on boot

### DIFF
--- a/deploy/systemd/rc.service
+++ b/deploy/systemd/rc.service
@@ -1,9 +1,13 @@
 [Unit]
 Description=Tetrarchy Falls (Phoenix release; formerly Rising Constellation)
 Documentation=https://github.com/your-org/rising-constellation
-Wants=network-online.target
+Wants=network-online.target rc-fetch-secrets.service
 After=network-online.target rc-fetch-secrets.service postgresql.service
-Requires=rc-fetch-secrets.service
+# Deliberately Wants= (NOT Requires=) on rc-fetch-secrets: systemd
+# propagates restarts through Requires=, so a `systemctl restart
+# rc-fetch-secrets` would bare-restart the game server — which is
+# exactly how the 2026-07-14 instance-49 outage happened. Wants= +
+# After= keeps the boot ordering without the propagation hazard.
 
 # Run rc-failure-log.service whenever this unit fails. Captures journal
 # context to /var/log/rc/ before systemd restarts us. See
@@ -25,6 +29,11 @@ EnvironmentFile=/etc/rc/env
 # bundled erts-XX/bin/erl.
 ExecStart=/home/rc/rc/bin/rc start
 ExecStop=/home/rc/rc/bin/rc stop
+
+# RC.ShutdownSnapshots snapshots every live instance during graceful
+# shutdown (child shutdown budget 600s). Give systemd more than that
+# before it escalates to SIGKILL, or a slow snapshot gets truncated.
+TimeoutStopSec=630
 
 # BEAM crashes / OOMs should bring the unit back up. Wait 10s between
 # attempts to avoid restart storms.

--- a/lib/rc/application.ex
+++ b/lib/rc/application.ex
@@ -69,6 +69,25 @@ defmodule RC.Application do
               restart: :temporary,
               shutdown: 15_000
             },
+            # Restore real-player instances that were alive at the
+            # previous shutdown from their latest snapshot — the boot
+            # counterpart to RC.ShutdownSnapshots; together they make a
+            # plain `systemctl restart` self-healing. Sequenced after
+            # the status fixer + bot restart with its own headroom.
+            %{
+              type: :worker,
+              id: :instance_boot_restore,
+              start:
+                {Task, :start_link,
+                 [
+                   fn ->
+                     Process.sleep(12_000)
+                     RC.InstanceBootRestore.run()
+                   end
+                 ]},
+              restart: :temporary,
+              shutdown: 15_000
+            },
             # Periodic cleanup of stale bot_events rows. Skipped in :test
             # because the test DB is wiped per-run anyway.
             RC.BotMonitoring.Pruner
@@ -76,6 +95,13 @@ defmodule RC.Application do
         else
           []
         end
+
+    # LAST on purpose: children stop in reverse start order, so at
+    # shutdown this terminates FIRST — while Game + Repo higher in the
+    # list are still alive — and snapshots every live instance before
+    # the BEAM exits. Self-gated off in :test and via
+    # RC_SHUTDOWN_SNAPSHOT_DISABLED. See the module doc.
+    children = children ++ [RC.ShutdownSnapshots]
 
     # Stage 7 F14: explicit max_restarts/max_seconds. RC.Supervisor
     # sits above Phoenix.Endpoint + RC.Repo + Game + PubSub + Presence

--- a/lib/rc/instance_boot_restore.ex
+++ b/lib/rc/instance_boot_restore.ex
@@ -1,0 +1,151 @@
+defmodule RC.InstanceBootRestore do
+  @moduledoc """
+  At rc.service boot, restores real-player instances that were alive
+  at the previous shutdown from their most recent snapshot.
+
+  Counterpart to `RC.ShutdownSnapshots`: together they make a plain
+  `systemctl restart rc.service` self-healing — snapshot on the way
+  down, restore on the way up — instead of requiring the deploy
+  script's out-of-band rpc dance or manual operator recovery.
+
+  ## Candidate selection
+
+  `RC.Instances.update_instances_state_if_needed(true)` (the boot
+  status fixer, sequenced before this task) rewrites instances the DB
+  thought were running/paused to "not_running" when their agents are
+  gone. We restore exactly the instances that fixer just demoted:
+
+    * current state "not_running", AND
+    * that not_running row was written within the last few minutes
+      (i.e. by THIS boot — an instance an admin stopped last week has
+      an old row and stays down), AND
+    * the state before it was "running" or "paused", AND
+    * not bot-only (those rebuild from model via
+      `RC.BotOnlyInstanceRestart` — cheaper and always safe), AND
+    * a snapshot exists.
+
+  Restoration reuses `RC.Instances.restore_instance/2`, whose
+  running/paused branches are the battle-tested snapshot-load path.
+  The guard on previous-state protects us from its known
+  CaseClauseError on maintenance-state history.
+
+  Escape hatch: set `RC_BOOT_RESTORE_DISABLED=1` to keep the old
+  manual behavior. Also skipped in `:test`.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  @disable_env "RC_BOOT_RESTORE_DISABLED"
+
+  # A not_running row older than this predates the current boot and
+  # means "an operator stopped this on purpose" — leave it down.
+  @boot_window_minutes 10
+
+  def run do
+    if enabled?() do
+      # Snapshot deserialization uses safe binary_to_term, which
+      # rejects atoms not yet interned in this VM. Releases preload
+      # every module at boot (embedded mode), but dev's interactive
+      # mode loads lazily — and even a release is safer with this
+      # belt-and-braces. Load the app's modules so their atoms exist
+      # before any snapshot is decoded.
+      preload_modules()
+
+      candidates = candidate_ids()
+
+      if candidates == [] do
+        Logger.info("[boot_restore] no real-player instances to restore")
+      else
+        Logger.warning("[boot_restore] restoring #{length(candidates)} instance(s): #{inspect(candidates)}")
+        Enum.each(candidates, &restore_one/1)
+      end
+    else
+      Logger.info("[boot_restore] disabled — skipping")
+    end
+  end
+
+  @doc """
+  Instance ids eligible for boot restore. Public for tests.
+  """
+  def candidate_ids(now \\ DateTime.utc_now()) do
+    cutoff = DateTime.add(now, -@boot_window_minutes * 60, :second)
+
+    from(i in RC.Instances.Instance,
+      where: i.state == "not_running" and i.is_bot_only == false,
+      select: i.id
+    )
+    |> RC.Repo.all()
+    |> Enum.filter(fn id ->
+      fresh_shutdown?(id, cutoff) and has_snapshot?(id) and
+        Instance.Manager.get_status(id) == :not_instantiated
+    end)
+  end
+
+  # True when the newest instance_states row is a not_running written
+  # inside the boot window AND the state before it was running/paused.
+  defp fresh_shutdown?(instance_id, cutoff) do
+    rows =
+      from(s in RC.Instances.InstanceState,
+        where: s.instance_id == ^instance_id,
+        order_by: [desc: s.inserted_at, desc: s.id],
+        limit: 2,
+        select: {s.state, s.inserted_at}
+      )
+      |> RC.Repo.all()
+
+    case rows do
+      # inserted_at is utc_datetime_usec — already a DateTime.
+      [{"not_running", %DateTime{} = stamped_at}, {previous, _}] when previous in ["running", "paused"] ->
+        DateTime.compare(stamped_at, cutoff) == :gt
+
+      _ ->
+        false
+    end
+  end
+
+  defp has_snapshot?(instance_id), do: RC.InstanceSnapshots.last(instance_id) != nil
+
+  defp restore_one(instance_id) do
+    instance = RC.Instances.get_instance(instance_id)
+
+    case RC.Instances.restore_instance(instance, instance.account_id) do
+      {:ok, _} ->
+        Logger.warning("[boot_restore] restored instance ##{instance_id} (#{instance.name})")
+
+      other ->
+        Logger.error("[boot_restore] restore of ##{instance_id} FAILED: #{inspect(other)}")
+    end
+  rescue
+    e ->
+      Logger.error("[boot_restore] restore of ##{instance_id} crashed: #{inspect(e)}")
+  end
+
+  defp enabled? do
+    Application.get_env(:rc, :environment) != :test and
+      System.get_env(@disable_env) in [nil, "", "0", "false"]
+  end
+
+  defp preload_modules do
+    {time_us, _} =
+      :timer.tc(fn ->
+        # ALL loaded applications, not just :rc — agent state embeds
+        # dependency structs (Horde registries, MerkleMap, queues…)
+        # whose module atoms must also be interned for the safe
+        # decode. Verified: :rc-only preload still trips
+        # :unsafe_snapshot; the full sweep passes.
+        for {app, _desc, _vsn} <- Application.loaded_applications() do
+          app |> Application.spec(:modules) |> Kernel.||([]) |> Enum.each(&Code.ensure_loaded/1)
+        end
+      end)
+
+    # warning-level on purpose: dev's logger level hides :info, and an
+    # operator debugging a failed boot restore needs to see whether the
+    # preload ran (see the :unsafe_snapshot decode gotcha in the run/0
+    # comment).
+    Logger.warning("[boot_restore] preloaded modules of all loaded apps in #{div(time_us, 1000)}ms")
+  rescue
+    e -> Logger.warning("[boot_restore] module preload failed (continuing): #{inspect(e)}")
+  end
+end

--- a/lib/rc/shutdown_snapshots.ex
+++ b/lib/rc/shutdown_snapshots.ex
@@ -1,0 +1,139 @@
+defmodule RC.ShutdownSnapshots do
+  @moduledoc """
+  Snapshots every live game instance when the node shuts down
+  gracefully — SIGTERM, `systemctl stop/restart` (including restarts
+  propagated through unit dependencies), `:init.stop`, deploys.
+
+  ## Why
+
+  In-memory instance state does not survive a BEAM restart on a
+  single-node deployment: the Horde-CRDT handoff the agents write in
+  their terminate callbacks dies with the node. Historically the only
+  shutdown-time persistence was the deploy script's *pre-stop* rpc —
+  protection bolted onto one stop path. Every other stop (a stray
+  `systemctl restart`, an operator mistake, a host reboot) lost up to
+  one autosave interval (~15–19 min) of gameplay. This module makes
+  the invariant hold for ALL graceful stops: the BEAM does not exit
+  before running instances are snapshotted.
+
+  ## How
+
+  Started LAST in `RC.Application`'s children, so at shutdown it
+  terminates FIRST — while `Game`, `RC.Repo`, and the rest of the
+  tree are still fully alive. `terminate/2` walks every instance the
+  DB considers running/paused that actually has live agents, and runs
+  the same `stop → make_snapshot` sequence the periodic autosave uses
+  (skipping the restart — the node is going down). Instances are
+  snapshotted sequentially; a failure on one never blocks the others.
+
+  The child spec's `shutdown:` budget and systemd's `TimeoutStopSec`
+  (see deploy/systemd/rc.service) are sized so a slow snapshot is not
+  killed mid-write. A SIGKILL still bypasses everything — that's what
+  the periodic autosave remains for.
+
+  ## Escape hatch
+
+  If snapshotting ITSELF ever misbehaves (hangs, corrupt writes) and
+  is blocking shutdowns, set `RC_SHUTDOWN_SNAPSHOT_DISABLED=1` in the
+  environment and restart: this module then no-ops. Also disabled in
+  `:test`.
+  """
+
+  use GenServer
+
+  require Logger
+
+  import Ecto.Query
+
+  # Generous per-call budgets, mirroring the periodic autosave's. The
+  # supervisor-facing total budget lives in child_spec/1 below.
+  @stop_timeout 120_000
+  @snapshot_timeout 300_000
+
+  @disable_env "RC_SHUTDOWN_SNAPSHOT_DISABLED"
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      # The whole point is doing work in terminate/2 — give it room.
+      # Must stay below systemd's TimeoutStopSec (630s in the unit).
+      shutdown: 600_000
+    }
+  end
+
+  @impl true
+  def init(_opts) do
+    Process.flag(:trap_exit, true)
+    {:ok, %{}}
+  end
+
+  @impl true
+  def terminate(reason, _state) do
+    if enabled?() do
+      ids = live_instance_ids()
+
+      if ids != [] do
+        Logger.warning(
+          "[RC.ShutdownSnapshots] node stopping (#{inspect(reason)}) — snapshotting #{length(ids)} instance(s): #{inspect(ids)}"
+        )
+
+        Enum.each(ids, &snapshot_one/1)
+      end
+    end
+
+    :ok
+  end
+
+  ## Internals
+
+  defp enabled? do
+    Application.get_env(:rc, :environment) != :test and
+      System.get_env(@disable_env) in [nil, "", "0", "false"]
+  end
+
+  # Instances the DB considers in-play AND that actually have live
+  # agents on this node. Bot-only instances are included — their
+  # progress is worth the file too, and the boot path decides how to
+  # bring each kind back.
+  defp live_instance_ids do
+    from(i in RC.Instances.Instance,
+      where: i.state in ["running", "paused"],
+      select: i.id
+    )
+    |> RC.Repo.all()
+    |> Enum.filter(fn id -> Instance.Manager.get_status(id) in [:running, :instantiated] end)
+  rescue
+    e ->
+      Logger.error("[RC.ShutdownSnapshots] instance scan failed: #{inspect(e)}")
+      []
+  end
+
+  # Same sequence as the periodic autosave in Instance.Time, minus the
+  # restart: stop ticking so the dump is consistent, then snapshot.
+  defp snapshot_one(instance_id) do
+    case Instance.Manager.call(instance_id, :stop, @stop_timeout) do
+      {:ok, :stopped, _} -> :ok
+      other -> Logger.warning("[RC.ShutdownSnapshots] stop of ##{instance_id} returned #{inspect(other)}")
+    end
+
+    case Instance.Manager.call(instance_id, :make_snapshot, @snapshot_timeout) do
+      {:ok, _snapshot} ->
+        Logger.warning("[RC.ShutdownSnapshots] snapshotted instance ##{instance_id}")
+
+      other ->
+        Logger.error("[RC.ShutdownSnapshots] snapshot of ##{instance_id} FAILED: #{inspect(other)}")
+    end
+  rescue
+    e ->
+      Logger.error("[RC.ShutdownSnapshots] snapshot of ##{instance_id} crashed: #{inspect(e)}")
+  catch
+    kind, payload ->
+      Logger.error("[RC.ShutdownSnapshots] snapshot of ##{instance_id} exited: #{inspect({kind, payload})}")
+  end
+end

--- a/test/rc/instance_boot_restore_test.exs
+++ b/test/rc/instance_boot_restore_test.exs
@@ -1,0 +1,111 @@
+defmodule RC.InstanceBootRestoreTest do
+  @moduledoc """
+  Candidate selection for boot-time instance restore. The selection
+  predicate is where the risk lives: restoring an instance an operator
+  stopped on purpose, or one without a snapshot, would be worse than
+  the outage it prevents. The restore action itself reuses the
+  battle-tested RC.Instances.restore_instance/2 path.
+  """
+
+  use RC.DataCase
+
+  import Ecto.Query
+
+  alias RC.InstanceBootRestore
+
+  defp make_instance(_) do
+    %{instance: instance, account: account} = RC.ScenarioFixtures.instance_fixture()
+    %{instance: instance, account: account}
+  end
+
+  # Simulates the boot status-fixer's demotion: a running-history row,
+  # then a not_running row stamped `ago_seconds` in the past.
+  # create_instance_state/1 also syncs instances.state via its Multi.
+  defp demote(%{instance: instance, account: account}, previous_state, ago_seconds) do
+    # The fixture's instance creation writes its own state rows stamped
+    # "now" — push everything pre-existing into the past so the two
+    # rows we add below are genuinely the newest, as they are in prod.
+    now = DateTime.utc_now()
+
+    from(s in RC.Instances.InstanceState, where: s.instance_id == ^instance.id)
+    |> RC.Repo.update_all(set: [inserted_at: DateTime.add(now, -ago_seconds - 300, :second)])
+
+    {:ok, %{instance_state: prev}} =
+      RC.Instances.create_instance_state(%{
+        instance_id: instance.id,
+        state: previous_state,
+        account_id: account.id
+      })
+
+    {:ok, %{instance_state: ns}} =
+      RC.Instances.create_instance_state(%{
+        instance_id: instance.id,
+        state: "not_running",
+        account_id: account.id
+      })
+
+    # Keep chronology consistent with reality: the previous state
+    # strictly precedes the demotion row.
+    prev_stamp = DateTime.add(now, -ago_seconds - 60, :second)
+    ns_stamp = DateTime.add(now, -ago_seconds, :second)
+
+    from(s in RC.Instances.InstanceState, where: s.id == ^prev.id)
+    |> RC.Repo.update_all(set: [inserted_at: prev_stamp])
+
+    from(s in RC.Instances.InstanceState, where: s.id == ^ns.id)
+    |> RC.Repo.update_all(set: [inserted_at: ns_stamp])
+  end
+
+  defp add_snapshot(instance) do
+    {:ok, _} = RC.InstanceSnapshots.insert(%{name: "snapshot-test-#{instance.id}", size: 1, instance_id: instance.id})
+  end
+
+  describe "candidate_ids/1" do
+    setup [:make_instance]
+
+    test "freshly demoted running instance with a snapshot is a candidate", %{instance: instance} = ctx do
+      demote(ctx, "running", 30)
+      add_snapshot(instance)
+
+      assert instance.id in InstanceBootRestore.candidate_ids()
+    end
+
+    test "previously paused instances are candidates too", %{instance: instance} = ctx do
+      demote(ctx, "paused", 30)
+      add_snapshot(instance)
+
+      assert instance.id in InstanceBootRestore.candidate_ids()
+    end
+
+    test "an instance stopped long ago stays down", %{instance: instance} = ctx do
+      demote(ctx, "running", 2 * 60 * 60)
+      add_snapshot(instance)
+
+      refute instance.id in InstanceBootRestore.candidate_ids()
+    end
+
+    test "maintenance-history instances are excluded (restore_instance CaseClauseError guard)",
+         %{instance: instance} = ctx do
+      demote(ctx, "maintenance", 30)
+      add_snapshot(instance)
+
+      refute instance.id in InstanceBootRestore.candidate_ids()
+    end
+
+    test "no snapshot, no restore", %{instance: instance} = ctx do
+      demote(ctx, "running", 30)
+
+      refute instance.id in InstanceBootRestore.candidate_ids()
+    end
+
+    test "bot-only instances are left to RC.BotOnlyInstanceRestart", %{instance: instance} = ctx do
+      demote(ctx, "running", 30)
+      add_snapshot(instance)
+
+      from(i in RC.Instances.Instance, where: i.id == ^instance.id)
+      |> RC.Repo.update_all(set: [is_bot_only: true])
+
+      refute instance.id in InstanceBootRestore.candidate_ids()
+    end
+  end
+end


### PR DESCRIPTION
The deploy script's pre-stop snapshot only protected ONE stop path. Any other graceful stop — a stray systemctl restart (see 2026-07-14 instance-49 outage: a restart propagated through Requires= from rc-fetch-secrets), a host reboot, an operator mistake — lost up to one autosave interval of live game state. This makes the invariant universal: the BEAM does not exit gracefully without persisting running instances, and boots heal what the previous stop saved.

RC.ShutdownSnapshots (new):
- Last child in RC.Application, so it terminates FIRST at shutdown while Game + Repo are still alive. terminate/2 runs the autosave's proven stop -> make_snapshot sequence for every instance the DB considers running/paused that has live agents; failures are per-instance and logged, never raised. 600s child budget.
- Escape hatch RC_SHUTDOWN_SNAPSHOT_DISABLED=1 for the day the snapshot path itself misbehaves; off in :test. SIGKILL still bypasses everything — that's what the periodic autosave covers.

RC.InstanceBootRestore (new):
- Boot task (sequenced after the status fixer + bot restart) restoring real-player instances the fixer just demoted: newest state row is a not_running written within the boot window (an instance an operator stopped last week stays down), preceded by running/paused, not bot-only, snapshot available. Reuses RC.Instances.restore_instance/2; the previous-state guard keeps us out of its known maintenance-history CaseClauseError.
- Preloads modules of ALL loaded applications first: snapshot decoding uses safe binary_to_term, which rejects atoms not yet interned — dependency structs (Horde, MerkleMap, ...) inside agent state make an :rc-only preload insufficient (verified both ways). Releases are embedded-mode so this is nearly free in prod.
- Escape hatch RC_BOOT_RESTORE_DISABLED=1; off in :test.

systemd unit:
- Requires= -> Wants= on rc-fetch-secrets (restart propagation is how the outage started; After= alone keeps the boot ordering).
- TimeoutStopSec=630 so systemd outwaits the snapshot budget before escalating to SIGKILL.

Live-fired in the dev container: graceful VM stop snapshotted the running instance ("snapshotted instance #1"); the following boot auto-restored it ("restored instance #1", DB back to running). Candidate selection covered by 6 new tests; 52/52 across the touched suites; mix format clean.