### PR TITLE
fix(victory): make final conquest/shadows milestones reachable in 2-f…

### DIFF
--- a/lib/game/instance/victory/victory.ex
+++ b/lib/game/instance/victory/victory.ex
@@ -295,9 +295,22 @@ defmodule Instance.Victory.Victory do
           [0.0, 0.25, 0.6, 0.95]
           |> Enum.with_index()
           |> Enum.map(fn {coeff, index} ->
-            threshold = Float.round(coeff * total_sector_points * 2 * (1 / total_faction_count) * faction_weighting)
-            threshold = Enum.max([threshold, index])
-            Enum.min([threshold, total_sector_points])
+            raw = coeff * total_sector_points * 2 * (1 / total_faction_count) * faction_weighting
+
+            if index == 3 do
+              # Final tier: round *down*, and hard-cap at 95% of all sector
+              # points — no faction weighting may push it up to total
+              # conquest, so the cap also stays at least one point short of
+              # the total. The outer floor of 1 keeps the milestone
+              # owned-not-free on maps whose total is so small the cap would
+              # otherwise reach 0 (the 1-sector daily).
+              threshold = Enum.max([Float.floor(raw), index])
+              cap = Enum.max([Enum.min([Float.floor(0.95 * total_sector_points), total_sector_points - 1]), 1])
+              Enum.min([threshold, cap])
+            else
+              threshold = Enum.max([Float.round(raw), index])
+              Enum.min([threshold, total_sector_points])
+            end
           end)
 
         # population
@@ -319,12 +332,26 @@ defmodule Instance.Victory.Victory do
         max_visibility_points = foreign_possessions * 5
 
         visibility_thresholds =
-          [0.0, 0.3, 0.8, 0.98]
+          [0.0, 0.3, 0.6, 0.95]
           |> Enum.with_index()
           |> Enum.map(fn {coeff, index} ->
-            threshold = Float.round(coeff * max_visibility_points * 2 * (1 / total_faction_count) * faction_weighting)
-            threshold = Enum.max([threshold, index])
-            Enum.min([threshold, max_visibility_points + index])
+            raw = coeff * max_visibility_points * 2 * (1 / total_faction_count) * faction_weighting
+
+            if index == 3 do
+              # Final tier: hard-cap at 95% of the achievable max
+              # (5 contacts x every enemy-owned system). The old
+              # `max + index` cap sat *above* that ceiling, so any faction
+              # at or above average headcount in a 2-faction game got a
+              # mathematically unreachable milestone. The index floor keeps
+              # it unreachable-not-free when there is nothing to infiltrate
+              # (max = 0).
+              threshold = Enum.max([Float.round(raw), index])
+              cap = Enum.max([Float.floor(0.95 * max_visibility_points), index])
+              Enum.min([threshold, cap])
+            else
+              threshold = Enum.max([Float.round(raw), index])
+              Enum.min([threshold, max_visibility_points + index])
+            end
           end)
 
         # final points

--- a/test/game/instance/victory/victory_test.exs
+++ b/test/game/instance/victory/victory_test.exs
@@ -3,6 +3,9 @@ defmodule Instance.Victory.VictoryTest do
   # factions land on the same integer victory_points score — which happens
   # almost every time a game ends on `win_on_time` (only 12 distinct values
   # in [0, 27] across all three tracks, so cluster collisions are routine).
+  # Also covers the milestone-threshold math in update_tracks/1, in
+  # particular the final-tier hard caps (95% of the achievable ceiling) that
+  # keep 2-faction games winnable on the conquest and shadows tracks.
   use ExUnit.Case, async: true
   alias Instance.Victory.Victory
 
@@ -228,6 +231,116 @@ defmodule Instance.Victory.VictoryTest do
     test "new/6 still works and defaults time_only to false" do
       v = Victory.new(100.0, 14, 1, [], [], 999)
       assert v.time_only == false
+    end
+  end
+
+  describe "update_tracks/1 milestone thresholds" do
+    # Build a real Victory struct via new/7, inject player/possession counts,
+    # then recompute the tracks through the public update_visibility/3 — the
+    # only update_* entry point that doesn't call into Data.Querier.
+    # faction_specs: {key, id, active_players, possessions};
+    # sector_specs: {value, owner}.
+    defp tracked(faction_specs, sector_specs, inhabitable \\ 60) do
+      factions = Enum.map(faction_specs, fn {key, id, _players, _poss} -> %{id: id, key: key} end)
+
+      sectors =
+        sector_specs
+        |> Enum.with_index()
+        |> Enum.map(fn {{value, owner}, i} -> %{id: i, name: "s#{i}", victory_points: value, owner: owner} end)
+
+      v = Victory.new(1_000.0, 14, inhabitable, sectors, factions, 999)
+
+      factions =
+        Enum.map(v.factions, fn f ->
+          {_, _, players, poss} = Enum.find(faction_specs, fn {k, _, _, _} -> k == f.key end)
+          %{f | player_count: players, possession_count: poss}
+        end)
+
+      {first_key, _, _, _} = hd(faction_specs)
+      Victory.update_visibility(%{v | factions: factions}, first_key, 0)
+    end
+
+    defp track(state, key, track_name) do
+      state.factions |> Enum.find(&(&1.key == key)) |> Map.fetch!(track_name)
+    end
+
+    test "shadows: balanced 2-faction game uses 30/60/95% of the achievable max" do
+      # Both factions 10 players; the enemy owns 40 systems -> max = 5 * 40 = 200.
+      # Faction-count factor 2 * (1/2) = 1, weighting 1.
+      state = tracked([{:ark, 1, 10, 40}, {:myrmezir, 2, 10, 40}], [{1, nil}])
+
+      assert track(state, :ark, :visibility_track).milestones == [0, 60, 120, 190]
+    end
+
+    test "shadows: outnumbering faction keeps a reachable final milestone (was > max)" do
+      # 12v8 players: weighting = sqrt(12/10) ~ 1.095. The raw final tier is
+      # 208 on a 200 max; the old `max + 3` cap pinned it at 203 — permanently
+      # unreachable. The 95% hard cap now lands it at 190.
+      state = tracked([{:ark, 1, 12, 40}, {:myrmezir, 2, 8, 40}], [{1, nil}])
+      %{milestones: milestones} = track(state, :ark, :visibility_track)
+
+      assert milestones == [0, 66, 131, 190]
+      assert Enum.at(milestones, 3) <= 5 * 40
+    end
+
+    test "shadows: 4-faction game halves the reduced coefficients via the faction-count factor" do
+      # Enemies of :ark own 14 + 13 + 13 = 40 systems -> max 200; factor 2/4 = 0.5.
+      state =
+        tracked(
+          [{:ark, 1, 5, 10}, {:myrmezir, 2, 5, 14}, {:tetrarchy, 3, 5, 13}, {:synelle, 4, 5, 13}],
+          [{1, nil}]
+        )
+
+      assert track(state, :ark, :visibility_track).milestones == [0, 30, 60, 95]
+    end
+
+    test "shadows: nothing to infiltrate leaves the final milestone unreachable, not free" do
+      state = tracked([{:ark, 1, 10, 5}, {:myrmezir, 2, 10, 0}], [{1, nil}])
+      %{milestones: milestones, index: index} = track(state, :ark, :visibility_track)
+
+      assert milestones == [0, 1, 2, 3]
+      assert index == 0
+    end
+
+    test "shadows: crossing the final milestone still pays the full 10 VP" do
+      state =
+        tracked([{:ark, 1, 10, 40}, {:myrmezir, 2, 10, 40}], [{1, nil}])
+        |> Victory.update_visibility(:ark, 190)
+
+      assert track(state, :ark, :visibility_track).index == 3
+      assert Enum.find(state.factions, &(&1.key == :ark)).victory_points == 10
+    end
+
+    test "conquest: outnumbering faction never needs 100% of sector points" do
+      # 20 sectors x 2 points = 40 total. With 12v8 weighting the raw final
+      # tier is 41.6; the old round + `total` cap turned that into "own
+      # everything" (40). Floor + 95% hard cap now lands it at 38.
+      sectors = List.duplicate({2, nil}, 20)
+      state = tracked([{:ark, 1, 12, 40}, {:myrmezir, 2, 8, 40}], sectors)
+      %{milestones: milestones} = track(state, :ark, :conquest_track)
+
+      assert Enum.at(milestones, 3) == 38
+      assert Enum.at(milestones, 3) < 40
+    end
+
+    test "conquest: final milestone rounds down" do
+      # Underdog (8v12, weighting ~0.894) on 41 total points:
+      # raw = 0.95 * 41 * 0.894 = 34.84 -> floor gives 34 where round said 35.
+      sectors = List.duplicate({1, nil}, 41)
+      state = tracked([{:ark, 1, 8, 40}, {:myrmezir, 2, 12, 40}], sectors)
+
+      assert Enum.at(track(state, :ark, :conquest_track).milestones, 3) == 34
+    end
+
+    test "conquest: 1-point maps keep the final milestone owned, not free" do
+      # The daily-challenge shape: one faction, one sector worth 1. The hard
+      # cap floors at 1, so owning the sector still maxes the track while a
+      # zero-point faction gets nothing for free.
+      state = tracked([{:ark, 1, 1, 1}], [{1, :ark}])
+      %{milestones: milestones, index: index} = track(state, :ark, :conquest_track)
+
+      assert Enum.at(milestones, 3) == 1
+      assert index == 3
     end
   end
 end


### PR DESCRIPTION
…action games

The shadows (visibility) track's final milestone was computed as round(0.98 * max * 2/factions * weighting) capped at max + 3 — a cap *above* the achievable ceiling (5 contacts x every enemy system). In a 2-faction game the faction-count factor is 1, so any faction at or above average headcount (weighting >= ~1.02) got a milestone strictly greater than max: mathematically impossible to reach. Conquest had the same shape: its final milestone collapsed to "own 100% of all sector points" for the larger faction.

Changes to update_tracks/1:

- Shadows coefficients reduced from 0.3/0.8/0.98 to 0.3/0.6/0.95, and the final tier is hard-capped at floor(0.95 * max). The index floor keeps the milestone unreachable-not-free when there is nothing to infiltrate (max = 0).
- Conquest's final tier now rounds *down* and is hard-capped at min(floor(0.95 * total), total - 1) so total conquest is never required. The cap floors at 1 so 1-point maps (the daily shape) keep the milestone owned-not-free.

Middle tiers, the population track, tier VP values (0/2/5/10), and the 14-VP win check are unchanged. Snapshot-safe: thresholds are recomputed from state on every track update, so restored instances pick up the new formula on their next tick.

Adds threshold coverage to victory_test.exs (previously only tie-break and time_only paths were tested).