### PR TITLE
perf(instance): cut large-galaxy boot 130s -> 28s and cap its CPU foo…

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,8 +50,7 @@ config :rc, RC.Accounts.AccountToken,
   validity_time: 7200,
   length: 32
 
-config :rc, RC.Accounts.Profile,
-  limit: 2
+config :rc, RC.Accounts.Profile, limit: 2
 
 config :rc, RC.Groups,
   blog_group_name: "blog-writers",
@@ -61,14 +60,11 @@ config :rc, RC.Uploader,
   valid_image_extensions: ~w(.jpg .jpeg .gif .png),
   max_image_size: 50_000_000
 
-config :rc, RC.Uploader.StandardFile,
-  path: "files/"
+config :rc, RC.Uploader.StandardFile, path: "files/"
 
-config :rc, RC.Uploader.ImageFile,
-  path: "images/"
+config :rc, RC.Uploader.ImageFile, path: "images/"
 
-config :rc, RC.Uploader.ThumbnailFile,
-  path: "thumbnails/"
+config :rc, RC.Uploader.ThumbnailFile, path: "thumbnails/"
 
 # Hammer (rate limiter). ETS backend is in-process, so limits are per-node;
 # acceptable for a small community deployment, swap for a shared backend
@@ -148,11 +144,13 @@ config :rc, RC.SystemAI,
 
 # Content-memory model for serving game data (see Data.Data). :legacy copies
 # the ~130KB content map onto each caller's heap per Querier lookup (original
-# behaviour); :shared serves it zero-copy from persistent_term. Defaults to
-# :legacy so deploying is a no-op until deliberately flipped (per-instance via
-# Data.Data.switch_memory_mode/2, globally via Data.Data.set_memory_mode/1, or
-# at boot via the RC_DATA_MEMORY_MODE env var — see config/runtime.exs).
-config :rc, :data_memory_mode, :legacy
+# behaviour); :shared serves it zero-copy from persistent_term — it is both
+# the per-agent memory fix and 50-78× faster per Querier call. :shared is the
+# default after a stable prod soak via the RC_DATA_MEMORY_MODE env override;
+# :legacy remains available per-instance via Data.Data.switch_memory_mode/2,
+# globally via Data.Data.set_memory_mode/1, or at boot via RC_DATA_MEMORY_MODE
+# — see config/runtime.exs.
+config :rc, :data_memory_mode, :shared
 
 # When true, galaxy generation draws RNG sequentially (max_concurrency: 1 in
 # Instance.Manager) so a given seed reproduces the same galaxy. Off by default
@@ -161,6 +159,14 @@ config :rc, :data_memory_mode, :legacy
 # Instance.Manager.generation_concurrency/0 and the RC_DETERMINISTIC_GENERATION
 # env var in config/runtime.exs.
 config :rc, :deterministic_generation, false
+
+# Hard cap on the parallel fan-outs of instance boot (system generation and
+# agent spawning in Instance.Manager). nil => half the online schedulers
+# (min 1), leaving headroom for live instances' tick servers while a large
+# galaxy boots — one leg of the anti-DoS work, alongside Portal.ForgeSize
+# and the account rate limits. Override at boot via RC_GALAXY_GEN_CONCURRENCY
+# (see config/runtime.exs).
+config :rc, :galaxy_gen_max_concurrency, nil
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -32,6 +32,15 @@ if System.get_env("RC_DETERMINISTIC_GENERATION") in ["1", "true"] do
   config :rc, :deterministic_generation, true
 end
 
+# Boot fan-out cap (see Instance.Manager.generation_concurrency/0). Unset =>
+# config.exs default (nil = half the online schedulers). Set to a positive
+# integer to pin how many cores a large-galaxy boot may occupy.
+case System.get_env("RC_GALAXY_GEN_CONCURRENCY") do
+  nil -> :ok
+  "" -> :ok
+  value -> config :rc, :galaxy_gen_max_concurrency, String.to_integer(value)
+end
+
 # --- Discord bot (optional) ------------------------------------------
 # Token loading supports two forms so we can keep the secret off `ps`
 # in prod while staying convenient in dev:
@@ -46,7 +55,9 @@ discord_token =
   case System.get_env("DISCORD_BOT_TOKEN_FILE") do
     path when is_binary(path) and path != "" ->
       case File.read(path) do
-        {:ok, contents} -> String.trim(contents)
+        {:ok, contents} ->
+          String.trim(contents)
+
         {:error, reason} ->
           IO.warn("DISCORD_BOT_TOKEN_FILE=#{path} unreadable (#{inspect(reason)}); bot disabled")
           nil

--- a/lib/game/instance/galaxy/galaxy.ex
+++ b/lib/game/instance/galaxy/galaxy.ex
@@ -29,20 +29,27 @@ defmodule Instance.Galaxy.Galaxy do
 
     # convert map stellar system into galaxy stellar system
     systems =
-      Enum.map(stellar_systems, fn %Instance.StellarSystem.StellarSystem{} = system ->
-        Galaxy.StellarSystem.convert(system)
+      Util.PhaseTimer.timed("galaxy_new/convert_systems", fn ->
+        Enum.map(stellar_systems, fn %Instance.StellarSystem.StellarSystem{} = system ->
+          Galaxy.StellarSystem.convert(system)
+        end)
       end)
 
     # convert map sectors into galaxy blackholes
     blackholes = Enum.map(game_data["blackholes"], fn blackhole -> Galaxy.Blackhole.new(blackhole) end)
 
     # use systems to generate connecting edges
-    edges = SpatialGraph.generate_edges(systems, blackholes)
+    edges =
+      Util.PhaseTimer.timed("galaxy_new/generate_edges", fn ->
+        SpatialGraph.generate_edges(systems, blackholes)
+      end)
 
     # convert map sectors into galaxy sectors
     sectors =
-      Enum.map(game_data["sectors"], fn sector -> Galaxy.Sector.new(sector, systems) end)
-      |> put_adjacent_sectors()
+      Util.PhaseTimer.timed("galaxy_new/sectors", fn ->
+        Enum.map(game_data["sectors"], fn sector -> Galaxy.Sector.new(sector, systems) end)
+        |> put_adjacent_sectors()
+      end)
 
     next_update = Core.DynamicValue.new(0, :misc, Core.ValuePart.new(:default, 1))
 

--- a/lib/game/instance/galaxy/spatial_graph.ex
+++ b/lib/game/instance/galaxy/spatial_graph.ex
@@ -1,6 +1,8 @@
 defmodule Instance.Galaxy.SpatialGraph do
   alias Spatial.Position
 
+  require Logger
+
   @max_dist 12
   @max_dist_squared @max_dist * @max_dist
 
@@ -17,60 +19,131 @@ defmodule Instance.Galaxy.SpatialGraph do
     systems_by_id = Enum.reduce(systems, %{}, fn sys, acc -> Map.put(acc, sys.id, sys) end)
     travel_graph = Enum.reduce(systems, travel_graph, fn system, acc -> Graph.add_vertex(acc, system.id) end)
 
+    # Spatial hash with cell size @max_dist: any two systems closer than
+    # @max_dist are in the same or adjacent cells, so the neighbor scan only
+    # examines the 3×3 neighborhood instead of all N systems. Same distance
+    # predicate and weights as the naive all-pairs scan — the edge set is
+    # identical (guarded by SpatialGraphRegressionTest) — but O(N·k) instead
+    # of O(N²): 21s → sub-second at 6.6k systems.
+    grid = build_grid(systems)
+
     travel_graph =
-      Enum.reduce(systems, travel_graph, fn system, acc ->
-        # since sqrt(x) < sqrt(y) <=> x < y we can avoid an expensive sqrt(x) in multiple loop
+      Util.PhaseTimer.timed("edges/radius_graph", fn ->
+        Enum.reduce(systems, travel_graph, fn system, acc ->
+          # since sqrt(x) < sqrt(y) <=> x < y we can avoid an expensive sqrt(x) in multiple loop
 
-        # get blackholes that could interfer with current systems edges
-        near_blackholes =
-          Enum.filter(blackholes, fn b ->
-            Position.dist_squared(b.position, system.position) < :math.pow(@max_dist + b.radius, 2)
+          # get blackholes that could interfer with current systems edges
+          near_blackholes =
+            Enum.filter(blackholes, fn b ->
+              Position.dist_squared(b.position, system.position) < :math.pow(@max_dist + b.radius, 2)
+            end)
+
+          # Sort candidates back into `systems` order (their original index)
+          # so edges are added in exactly the order the all-pairs scan used —
+          # keeps the output list byte-identical, not just set-identical.
+          neighbors =
+            grid
+            |> grid_candidates(system)
+            |> Enum.filter(fn {_idx, s} -> dist_squared(system, s) < @max_dist_squared and s.id != system.id end)
+            |> Enum.sort_by(fn {idx, _s} -> idx end)
+            |> Enum.map(fn {_idx, s} -> s end)
+            |> Enum.filter(fn s -> not edge_traverse_a_blackhole?(s, system, near_blackholes) end)
+
+          Enum.reduce(neighbors, acc, fn n, acc2 ->
+            Graph.add_edge(acc2, system.id, n.id, weight: distance(system, n))
           end)
-
-        neighbors =
-          systems
-          |> Enum.filter(fn s -> dist_squared(system, s) < @max_dist_squared and s.id != system.id end)
-          |> Enum.filter(fn s -> not edge_traverse_a_blackhole?(s, system, near_blackholes) end)
-
-        Enum.reduce(neighbors, acc, fn n, acc2 ->
-          Graph.add_edge(acc2, system.id, n.id, weight: distance(system, n))
         end)
       end)
 
-    travel_graph = assemble_graph_components(travel_graph, systems, systems_by_id, blackholes)
+    travel_graph =
+      Util.PhaseTimer.timed("edges/assemble_components", fn ->
+        assemble_graph_components(travel_graph, systems, systems_by_id, blackholes)
+      end)
 
-    Graph.edges(travel_graph)
-    |> Enum.map(fn edge ->
-      %{
-        s1: systems_by_id[edge.v1],
-        s2: systems_by_id[edge.v2],
-        weight: edge.weight
-      }
+    Util.PhaseTimer.timed("edges/dump_edge_list", fn ->
+      Graph.edges(travel_graph)
+      |> Enum.map(fn edge ->
+        %{
+          s1: systems_by_id[edge.v1],
+          s2: systems_by_id[edge.v2],
+          weight: edge.weight
+        }
+      end)
     end)
   end
 
+  defp build_grid(systems) do
+    systems
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {system, idx}, acc ->
+      Map.update(acc, cell_of(system.position), [{idx, system}], fn entries -> [{idx, system} | entries] end)
+    end)
+  end
+
+  defp cell_of(%{x: x, y: y}) do
+    {floor(x / @max_dist), floor(y / @max_dist)}
+  end
+
+  defp grid_candidates(grid, system) do
+    {cx, cy} = cell_of(system.position)
+
+    for dx <- -1..1,
+        dy <- -1..1,
+        entry <- Map.get(grid, {cx + dx, cy + dy}, []),
+        do: entry
+  end
+
+  # Joins disconnected components of the radius graph by repeatedly adding,
+  # for each component, the shortest non-blackhole-crossing edge to a system
+  # outside it, until one component remains.
+  #
+  # Deliberately the same algorithm as the original (same couples, same sort,
+  # same blackhole fallback — output is byte-identical); the wins are pure
+  # mechanics: Graph.components is computed once per pass instead of twice,
+  # and component membership is a MapSet instead of an `Enum.member?` walk of
+  # a list — that list walk inside a min_by over all systems was ~80% of a
+  # 6.6k-system boot's edge cost (72s for a 2-component galaxy; now <1s).
   defp assemble_graph_components(graph, systems, systems_by_id, blackholes) do
-    if length(Graph.components(graph)) == 1 do
+    components = Graph.components(graph)
+    component_count = length(components)
+    Logger.warning("[boot-timing] edges/components_remaining: #{component_count}")
+
+    if component_count == 1 do
       graph
     else
       graph =
-        Enum.reduce(Graph.components(graph), graph, fn component, acc1 ->
+        Enum.reduce(components, graph, fn component, acc1 ->
+          component_set = MapSet.new(component)
+
+          # Chunked fan-out: one task per member would copy the closure
+          # (all systems + the component MapSet, ~2MB at 6.6k systems) into
+          # every spawned process — ~13GB of term-copying for a big
+          # component. Chunks keep the copies to one per task while
+          # preserving member order (chunks are ordered, results are
+          # flattened in order), so the output stays byte-identical.
           nearest_couples =
-            Task.async_stream(component, fn system_id ->
-              system = systems_by_id[system_id]
+            component
+            |> Enum.chunk_every(500)
+            |> Task.async_stream(
+              fn chunk ->
+                Enum.map(chunk, fn system_id ->
+                  system = systems_by_id[system_id]
 
-              nearest_neighbor =
-                Enum.min_by(systems, fn s ->
-                  if s.id == system.id or Enum.member?(component, s.id),
-                    do: :infinity,
-                    else: distance(system, s)
+                  nearest_neighbor =
+                    Enum.min_by(systems, fn s ->
+                      if s.id == system.id or MapSet.member?(component_set, s.id),
+                        do: :infinity,
+                        else: distance(system, s)
+                    end)
+
+                  distance = distance(system, nearest_neighbor)
+
+                  {system, nearest_neighbor, distance}
                 end)
-
-              distance = distance(system, nearest_neighbor)
-
-              {system, nearest_neighbor, distance}
-            end)
-            |> Stream.map(fn {:ok, result} -> result end)
+              end,
+              timeout: :infinity
+            )
+            |> Stream.flat_map(fn {:ok, results} -> results end)
             |> Enum.to_list()
 
           nearest_couples_sorted = Enum.sort(nearest_couples, fn {_, _, d1}, {_, _, d2} -> d1 <= d2 end)

--- a/lib/game/instance/manager.ex
+++ b/lib/game/instance/manager.ex
@@ -306,7 +306,20 @@ defmodule Instance.Manager do
 
   ## Private API - implementations
 
+  # The Manager runs the single-threaded boot phases (edge graph, sector
+  # assembly) in its own process, so it joins the fan-out workers at :low
+  # priority for the duration of the boot — see boot_task_priority/0.
   defp init_from_model(supervisor_pid, instance, tutorial_id, progress_channel \\ nil) do
+    previous_priority = Process.flag(:priority, :low)
+
+    try do
+      do_init_from_model(supervisor_pid, instance, tutorial_id, progress_channel)
+    after
+      Process.flag(:priority, previous_priority)
+    end
+  end
+
+  defp do_init_from_model(supervisor_pid, instance, tutorial_id, progress_channel) do
     instance_id = instance.id
     game_data = instance.game_data
     user_broadcast(progress_channel, :step_4, instance_id)
@@ -383,24 +396,28 @@ defmodule Instance.Manager do
     neutral_overrides = compute_neutral_overrides(game_data)
 
     systems =
-      Stream.flat_map(game_data["sectors"], fn sector ->
-        sector["systems"]
-        |> Stream.with_index()
-        |> Stream.map(fn {system, idx} ->
-          opts = Map.get(neutral_overrides, {sector["key"], system["key"]}, [])
-          {idx, system, sector["key"], instance_id, opts}
+      Util.PhaseTimer.timed("stellar_systems_generation", fn ->
+        Stream.flat_map(game_data["sectors"], fn sector ->
+          sector["systems"]
+          |> Stream.with_index()
+          |> Stream.map(fn {system, idx} ->
+            opts = Map.get(neutral_overrides, {sector["key"], system["key"]}, [])
+            {idx, system, sector["key"], instance_id, opts}
+          end)
+          |> Enum.to_list()
         end)
+        |> Task.async_stream(
+          fn {_idx, system, sector_key, instance_id, opts} ->
+            boot_task_priority()
+            Instance.StellarSystem.StellarSystem.new(system, sector_key, instance_id, opts)
+          end,
+          max_concurrency: generation_concurrency(),
+          ordered: true,
+          timeout: :infinity
+        )
+        |> Stream.map(fn {:ok, result} -> result end)
         |> Enum.to_list()
       end)
-      |> Task.async_stream(
-        fn {_idx, system, sector_key, instance_id, opts} ->
-          Instance.StellarSystem.StellarSystem.new(system, sector_key, instance_id, opts)
-        end,
-        max_concurrency: generation_concurrency(),
-        ordered: true
-      )
-      |> Stream.map(fn {:ok, result} -> result end)
-      |> Enum.to_list()
 
     # count inhabitable systems
     inhabitable_systems =
@@ -440,7 +457,11 @@ defmodule Instance.Manager do
     user_broadcast(progress_channel, :step_7, instance_id)
 
     # Spawn galaxy manager
-    data = Instance.Galaxy.Galaxy.new(game_data, players, systems, tutorial_id)
+    data =
+      Util.PhaseTimer.timed("galaxy_new_total", fn ->
+        Instance.Galaxy.Galaxy.new(game_data, players, systems, tutorial_id)
+      end)
+
     channel = "instance:global:#{instance_id}"
     state = Core.GenState.new(:galaxy, instance_id, :master, data, channel)
     sectors = data.sectors
@@ -495,23 +516,32 @@ defmodule Instance.Manager do
     # Spawn stellar system
     user_broadcast(progress_channel, :step_10, instance_id)
 
-    systems
-    |> Task.async_stream(fn system ->
-      state = Core.GenState.new(:stellar_system, instance_id, system.id, system, nil)
-      DynamicSupervisor.start_child(supervisor_pid, {Instance.StellarSystem.Agent, state: state})
+    Util.PhaseTimer.timed("spawn_system_agents", fn ->
+      systems
+      |> Task.async_stream(
+        fn system ->
+          boot_task_priority()
+          state = Core.GenState.new(:stellar_system, instance_id, system.id, system, nil)
+          DynamicSupervisor.start_child(supervisor_pid, {Instance.StellarSystem.Agent, state: state})
+        end,
+        max_concurrency: generation_concurrency(),
+        timeout: :infinity
+      )
+      |> Stream.run()
     end)
-    |> Stream.run()
 
     # RELATION STEP
     user_broadcast(progress_channel, :step_11, instance_id)
 
-    players
-    |> Enum.each(fn player ->
-      # affect player to faction
-      Game.call(instance_id, :faction, player.faction_id, {:add_player, player})
+    Util.PhaseTimer.timed("player_claims", fn ->
+      players
+      |> Enum.each(fn player ->
+        # affect player to faction
+        Game.call(instance_id, :faction, player.faction_id, {:add_player, player})
 
-      # affect player to stellar system
-      Game.call(instance_id, :player, player.id, :claim_initial_system)
+        # affect player to stellar system
+        Game.call(instance_id, :player, player.id, :claim_initial_system)
+      end)
     end)
 
     user_broadcast(progress_channel, :step_12, instance_id)
@@ -521,19 +551,39 @@ defmodule Instance.Manager do
 
   # System generation draws from the single shared seeded :rand agent
   # (positions, body rolls, neutral-status rolls, names via Data.Picker).
-  # By default it runs concurrently (max_concurrency = schedulers, which is
-  # async_stream's own default — so this is behaviourally unchanged), but the
-  # concurrent draw ORDER makes the generated galaxy non-deterministic across
-  # runs even on a fixed seed. When `:rc, :deterministic_generation` is true we
-  # force max_concurrency: 1 so draws happen in a fixed order and a given seed
-  # reproduces the same galaxy — required for baseline-vs-modified differential
-  # testing (and for snapshot/replay reproducibility). Off by default; flip via
-  # config or the RC_DETERMINISTIC_GENERATION env var (see config/runtime.exs).
+  # The concurrent draw ORDER makes the generated galaxy non-deterministic
+  # across runs even on a fixed seed, so when `:rc, :deterministic_generation`
+  # is true we force max_concurrency: 1 — draws happen in a fixed order and a
+  # given seed reproduces the same galaxy (baseline-vs-modified differential
+  # testing, snapshot/replay reproducibility). Flip via config or the
+  # RC_DETERMINISTIC_GENERATION env var (see config/runtime.exs).
+  #
+  # Otherwise the fan-out is capped at half the online schedulers (min 1,
+  # override via :galaxy_gen_max_concurrency / RC_GALAXY_GEN_CONCURRENCY): a
+  # large-galaxy boot is minutes of CPU-bound work, and an uncapped fan-out
+  # pegs every core and starves live instances' tick servers — this cap plus
+  # the :low task priority (see boot_task_priority/0) is the availability leg
+  # of the anti-DoS work, alongside Portal.ForgeSize and the account rate
+  # limits.
   defp generation_concurrency do
-    if Application.get_env(:rc, :deterministic_generation, false),
-      do: 1,
-      else: System.schedulers_online()
+    cond do
+      Application.get_env(:rc, :deterministic_generation, false) ->
+        1
+
+      cap = Application.get_env(:rc, :galaxy_gen_max_concurrency) ->
+        max(cap, 1)
+
+      true ->
+        max(div(System.schedulers_online(), 2), 1)
+    end
   end
+
+  # Boot fan-out workers run at :low scheduler priority: under CPU contention
+  # the BEAM serves :normal-priority processes (live game ticks, channels)
+  # first, so a booting galaxy degrades its own latency instead of the
+  # server's. No inversion risk — these workers only *call into* :normal
+  # agents (rand, Data registry), never the reverse.
+  defp boot_task_priority, do: Process.flag(:priority, :low)
 
   # Stage 6 #1.5 — turn `game_data["neutralDistribution"]` (scenario-wide
   # default) and `game_data["sectors"][i]["neutral"]` (per-sector override)

--- a/lib/game/util/phase_timer.ex
+++ b/lib/game/util/phase_timer.ex
@@ -1,0 +1,24 @@
+defmodule Util.PhaseTimer do
+  @moduledoc """
+  Wall-clock phase timing for coarse-grained boot instrumentation.
+
+  Instance creation for a large galaxy is a multi-second, CPU-heavy
+  pipeline (system generation → edge graph → agent spawns); these logs
+  attribute that cost per phase so a slow boot in dev or prod is
+  diagnosable from the log stream alone.
+  """
+
+  require Logger
+
+  @doc """
+  Runs `fun`, logs `[boot-timing] <label>: <ms>` at info level, and
+  returns `fun`'s result.
+  """
+  def timed(label, fun) do
+    {us, result} = :timer.tc(fun)
+    # :warning so the line clears dev's console level (:warning) — these fire
+    # a handful of times per instance boot, so there's no log-volume concern.
+    Logger.warning("[boot-timing] #{label}: #{Float.round(us / 1000, 1)} ms")
+    result
+  end
+end

--- a/profile_edges.exs
+++ b/profile_edges.exs
@@ -1,0 +1,73 @@
+# Standalone scaling sweep of Instance.Galaxy.SpatialGraph.generate_edges/2.
+#
+#   docker compose exec rc mix run profile_edges.exs
+#
+# Feeds the real Big One system positions (grid + the same ±0.5 jitter the
+# instance pipeline applies) at increasing prefixes, so local density matches
+# the real galaxy at every N. Sectors are contiguous in the JSON, so a prefix
+# is a spatially-contiguous region, not a sparse subsample.
+
+raw = Jason.decode!(File.read!(System.get_env("SCENARIO_JSON", "/data/bigone.json")))
+gd = raw["game_data"]
+
+:rand.seed(:exsss, {1, 2, 3})
+
+systems =
+  gd["sectors"]
+  |> Enum.flat_map(fn sec -> sec["systems"] end)
+  |> Enum.with_index(1)
+  |> Enum.map(fn {s, i} ->
+    %{
+      id: i,
+      position: %Spatial.Position{
+        x: s["position"]["x"] + :rand.uniform() - 0.5,
+        y: s["position"]["y"] + :rand.uniform() - 0.5
+      }
+    }
+  end)
+
+blackholes = Enum.map(gd["blackholes"], fn b -> Instance.Galaxy.Blackhole.new(b) end)
+
+IO.puts("total systems: #{length(systems)}, blackholes: #{length(blackholes)}")
+
+for frac <- [0.125, 0.25, 0.5, 1.0] do
+  n = round(length(systems) * frac)
+  subset = Enum.take(systems, n)
+
+  {us, edges} = :timer.tc(fn -> Instance.Galaxy.SpatialGraph.generate_edges(subset, blackholes) end)
+  IO.puts("N=#{n}: #{Float.round(us / 1_000_000, 2)} s, edges=#{length(edges)}")
+end
+
+# --- name-picker cost split: file re-read vs reservoir-sampling walk ---------
+
+path = Path.join([:code.priv_dir(:rc), "data/name/", "place.txt"])
+
+{us, names} =
+  :timer.tc(fn ->
+    Enum.reduce(1..200, nil, fn _, _ -> path |> File.stream!() |> Enum.to_list() end)
+  end)
+
+IO.puts("place.txt File.stream!|>to_list: #{Float.round(us / 1000 / 200, 3)} ms/call (#{length(names)} lines)")
+
+rstate = :rand.seed_s(:exsss, {7, 7, 7})
+
+{us, _} =
+  :timer.tc(fn ->
+    Enum.reduce(1..200, rstate, fn _, rs ->
+      {rs2, _picked} = REnum.take_random(rs, names, 1)
+      rs2
+    end)
+  end)
+
+IO.puts("REnum.take_random(names, 1) walk: #{Float.round(us / 1000 / 200, 3)} ms/call")
+
+{us, _} =
+  :timer.tc(fn ->
+    Enum.reduce(1..10_000, rstate, fn _, rs ->
+      {idx, rs2} = :rand.uniform_s(length(names), rs)
+      _ = Enum.at(names, idx - 1)
+      rs2
+    end)
+  end)
+
+IO.puts("uniform-index pick (cached list): #{Float.round(us / 1000 / 10_000, 4)} ms/call")

--- a/profile_galaxy_boot.exs
+++ b/profile_galaxy_boot.exs
@@ -1,0 +1,114 @@
+# Profiles a full instance boot of a large scenario (default: /data/bigone.json).
+#
+# Run inside the rc container while the stack is up:
+#   docker compose exec rc mix run profile_galaxy_boot.exs
+#
+# Mirrors Daily.Boot.boot_persisted/2's create path: scenario row → instance →
+# publish → one registration (admin@abc's profile) → Instance.Manager.
+# create_from_model, which is where all the CPU goes and where the
+# [boot-timing] phase logs come from. Destroys the supervision tree afterward
+# so repeat runs don't accumulate 6.6k-process instances.
+
+require Logger
+
+path = System.get_env("SCENARIO_JSON", "/data/bigone.json")
+raw = Jason.decode!(File.read!(path))
+game_data = raw["game_data"]
+
+n_systems = game_data["sectors"] |> Enum.map(&length(&1["systems"])) |> Enum.sum()
+IO.puts("=== boot profile: #{length(game_data["sectors"])} sectors / #{n_systems} systems ===")
+
+account = RC.Repo.get_by!(RC.Accounts.Account, email: "admin@abc")
+profile = RC.Repo.get_by!(RC.Accounts.Profile, account_id: account.id)
+
+{:ok, scenario} =
+  %RC.Scenarios.Scenario{}
+  |> RC.Scenarios.Scenario.changeset(%{
+    game_data: game_data,
+    game_metadata: raw["game_metadata"],
+    is_map: false
+  })
+  |> RC.Repo.insert()
+
+faction_attrs =
+  Enum.map(game_data["factions"], fn f -> %{"key" => f["key"], "capacity" => 221} end)
+
+instance_attrs = %{
+  "name" => "boot-profile #{System.os_time(:second)}",
+  "description" => "galaxy-generation CPU profiling",
+  "opening_date" => DateTime.to_iso8601(DateTime.utc_now()),
+  "registration_type" => "pre_registration",
+  "game_type" => "private",
+  "public" => false,
+  "start_setting" => "auto",
+  "factions" => faction_attrs
+}
+
+{:ok, %{instance: instance}} = RC.Instances.create_instance(instance_attrs, scenario, account.id)
+{:ok, _} = RC.Instances.publish_instance(instance, account.id)
+
+[faction | _] = instance.factions
+{:ok, _} = RC.Registrations.register_profile(faction, profile)
+
+loaded = RC.Instances.get_instance_with_registration(instance.id)
+
+{us, result} = :timer.tc(fn -> Instance.Manager.create_from_model(loaded, nil) end)
+IO.puts("=== TOTAL create_from_model: #{Float.round(us / 1_000_000, 2)} s → #{inspect(result)} ===")
+
+# --- micro-benches against the live instance's agents/caches -----------------
+
+iid = instance.id
+
+bench = fn label, n, fun ->
+  {us, _} = :timer.tc(fn -> Enum.each(1..n, fn _ -> fun.() end) end)
+  IO.puts("#{label}: #{Float.round(us / 1000 / n, 3)} ms/call (n=#{n})")
+end
+
+sample_system = hd(hd(game_data["sectors"])["systems"])
+sample_type = String.to_existing_atom(sample_system["type"])
+
+bench.("rand round-trip (Game.call {:uniform, 50})", 500, fn ->
+  Game.call(iid, :rand, :master, {:uniform, 50})
+end)
+
+bench.("Data.Picker.random \"place\"", 200, fn ->
+  Data.Picker.random("place", iid)
+end)
+
+bench.("Data.Querier.one Constant", 500, fn ->
+  Data.Querier.one(Data.Game.Constant, iid, :main)
+end)
+
+bench.("Data.Querier.one StellarSystem #{sample_type}", 500, fn ->
+  Data.Querier.one(Data.Game.StellarSystem, iid, sample_type)
+end)
+
+bench.("StellarSystem.new serial", 100, fn ->
+  Instance.StellarSystem.StellarSystem.new(sample_system, 1, iid)
+end)
+
+# Same benches with the instance flipped to the :shared (persistent_term,
+# zero-copy) content cache — isolates the :legacy registry-copy tax.
+try do
+  IO.puts("--- switching instance to :shared data_memory_mode ---")
+  Data.Data.switch_memory_mode(iid, :shared)
+
+  bench.("Data.Querier.one Constant [shared]", 500, fn ->
+    Data.Querier.one(Data.Game.Constant, iid, :main)
+  end)
+
+  bench.("Data.Querier.one StellarSystem #{sample_type} [shared]", 500, fn ->
+    Data.Querier.one(Data.Game.StellarSystem, iid, sample_type)
+  end)
+
+  bench.("StellarSystem.new serial [shared]", 100, fn ->
+    Instance.StellarSystem.StellarSystem.new(sample_system, 1, iid)
+  end)
+rescue
+  e -> IO.puts("[shared-mode bench failed: #{Exception.message(e)}]")
+end
+
+# --- teardown ----------------------------------------------------------------
+
+Instance.Manager.destroy(iid)
+IO.puts("destroyed instance #{iid}")

--- a/test/data/data_persistent_term_test.exs
+++ b/test/data/data_persistent_term_test.exs
@@ -68,19 +68,19 @@ defmodule Data.DataPersistentTermTest do
     end
   end
 
-  test "global default mode is honoured by insert/2 and is :legacy unless flipped" do
-    assert Data.Data.memory_mode() == :legacy
+  test "global default mode is honoured by insert/2 and is :shared unless flipped" do
+    assert Data.Data.memory_mode() == :shared
 
     iid = System.unique_integer([:positive])
-    Data.Data.set_memory_mode(:shared)
+    Data.Data.set_memory_mode(:legacy)
 
     try do
-      assert Data.Data.memory_mode() == :shared
+      assert Data.Data.memory_mode() == :legacy
       Data.Data.insert(iid, speed: :fast, mode: :prod)
-      # :shared meta omits the :data copy; get(:data) still returns content.
+      # :legacy meta carries its own :data copy; get(:data) serves it.
       assert Data.Data.get(iid, :data) == Data.Querier.fetch_all(speed: :fast, mode: :prod)
     after
-      Data.Data.set_memory_mode(:legacy)
+      Data.Data.set_memory_mode(:shared)
       Data.Data.clear(iid)
     end
   end

--- a/test/game/instance/galaxy/spatial_graph_regression_test.exs
+++ b/test/game/instance/galaxy/spatial_graph_regression_test.exs
@@ -1,0 +1,241 @@
+defmodule Game.Instance.Galaxy.SpatialGraphRegressionTest do
+  @moduledoc """
+  Proves the optimized `Instance.Galaxy.SpatialGraph.generate_edges/2`
+  (spatial-grid neighbor scan + MapSet component assembly) produces output
+  **byte-identical** to the original all-pairs implementation, which is
+  embedded below as the reference. Layouts are seeded and cover the paths
+  that differ mechanically between the two implementations:
+
+    * connected radius graph (assemble is a no-op)
+    * fragmented graph (multi-pass component assembly)
+    * blackhole inside the cloud (radius-phase edge filtering)
+    * blackhole between clusters (assemble couple filtering + fallback)
+
+  Pure-function test — no DB, no instance tree.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :capture_log
+
+  alias Instance.Galaxy.SpatialGraph
+  alias Spatial.Position
+
+  # The pre-optimization implementation, verbatim (minus timing wraps).
+  # If `SpatialGraph` is ever intentionally changed to produce different
+  # edges, this reference must be updated in the same commit — the point of
+  # this module is to catch *unintentional* divergence from refactors.
+  defmodule Reference do
+    alias Spatial.Position
+
+    @max_dist 12
+    @max_dist_squared @max_dist * @max_dist
+
+    defp distance(system_1, system_2), do: Position.distance(system_1.position, system_2.position)
+    defp dist_squared(system_1, system_2), do: Position.dist_squared(system_1.position, system_2.position)
+
+    def generate_edges(systems, blackholes) do
+      travel_graph = Graph.new(type: :undirected)
+      systems_by_id = Enum.reduce(systems, %{}, fn sys, acc -> Map.put(acc, sys.id, sys) end)
+      travel_graph = Enum.reduce(systems, travel_graph, fn system, acc -> Graph.add_vertex(acc, system.id) end)
+
+      travel_graph =
+        Enum.reduce(systems, travel_graph, fn system, acc ->
+          near_blackholes =
+            Enum.filter(blackholes, fn b ->
+              Position.dist_squared(b.position, system.position) < :math.pow(@max_dist + b.radius, 2)
+            end)
+
+          neighbors =
+            systems
+            |> Enum.filter(fn s -> dist_squared(system, s) < @max_dist_squared and s.id != system.id end)
+            |> Enum.filter(fn s -> not edge_traverse_a_blackhole?(s, system, near_blackholes) end)
+
+          Enum.reduce(neighbors, acc, fn n, acc2 ->
+            Graph.add_edge(acc2, system.id, n.id, weight: distance(system, n))
+          end)
+        end)
+
+      travel_graph = assemble_graph_components(travel_graph, systems, systems_by_id, blackholes)
+
+      Graph.edges(travel_graph)
+      |> Enum.map(fn edge ->
+        %{
+          s1: systems_by_id[edge.v1],
+          s2: systems_by_id[edge.v2],
+          weight: edge.weight
+        }
+      end)
+    end
+
+    defp assemble_graph_components(graph, systems, systems_by_id, blackholes) do
+      if length(Graph.components(graph)) == 1 do
+        graph
+      else
+        graph =
+          Enum.reduce(Graph.components(graph), graph, fn component, acc1 ->
+            nearest_couples =
+              Task.async_stream(component, fn system_id ->
+                system = systems_by_id[system_id]
+
+                nearest_neighbor =
+                  Enum.min_by(systems, fn s ->
+                    if s.id == system.id or Enum.member?(component, s.id),
+                      do: :infinity,
+                      else: distance(system, s)
+                  end)
+
+                distance = distance(system, nearest_neighbor)
+
+                {system, nearest_neighbor, distance}
+              end)
+              |> Stream.map(fn {:ok, result} -> result end)
+              |> Enum.to_list()
+
+            nearest_couples_sorted = Enum.sort(nearest_couples, fn {_, _, d1}, {_, _, d2} -> d1 <= d2 end)
+
+            nearest_couple =
+              Enum.reduce(nearest_couples_sorted, nil, fn {origin, target, distance}, acc ->
+                if is_nil(acc) and not edge_traverse_a_blackhole?(origin, target, blackholes) do
+                  {origin, target, distance}
+                else
+                  acc
+                end
+              end)
+
+            {origin, target, distance} =
+              case nearest_couple do
+                nil -> hd(nearest_couples_sorted)
+                nearest_couple -> nearest_couple
+              end
+
+            Graph.add_edge(acc1, origin.id, target.id, weight: distance)
+          end)
+
+        assemble_graph_components(graph, systems, systems_by_id, blackholes)
+      end
+    end
+
+    defp edge_traverse_a_blackhole?(sys1, sys2, blackholes) do
+      p1 = sys1.position
+      p2 = sys2.position
+      p1p2 = Position.substr(p2, p1)
+      norm = Position.dot(p1p2, p1p2)
+
+      Enum.any?(blackholes, fn b ->
+        p3 = b.position
+        p1p3 = Position.substr(p1, p3)
+        d1 = 2 * Position.dot(p1p3, p1p2)
+        d2 = Position.dot(p1p3, p1p3) - b.radius * b.radius
+        discriminant = d1 * d1 - 4 * norm * d2
+
+        if discriminant < 0 do
+          false
+        else
+          discriminant = :math.sqrt(discriminant)
+          t1 = (-d1 - discriminant) / (2 * norm)
+          t2 = (-d1 + discriminant) / (2 * norm)
+
+          cond do
+            t1 >= 0 && t1 <= 1 -> true
+            t2 >= 0 && t2 <= 1 -> true
+            true -> false
+          end
+        end
+      end)
+    end
+  end
+
+  # ---- layout builders (seeded, deterministic) -------------------------------
+
+  defp cloud(seed, n, {x0, y0}, {w, h}, id_start) do
+    :rand.seed(:exsss, seed)
+
+    Enum.map(0..(n - 1), fn i ->
+      %{
+        id: id_start + i,
+        position: %Position{x: x0 + :rand.uniform() * w, y: y0 + :rand.uniform() * h}
+      }
+    end)
+  end
+
+  defp blackhole(x, y, radius) do
+    %{position: %Position{x: x, y: y}, radius: radius}
+  end
+
+  defp assert_identical(systems, blackholes) do
+    new_edges = SpatialGraph.generate_edges(systems, blackholes)
+    old_edges = Reference.generate_edges(systems, blackholes)
+
+    assert new_edges == old_edges
+    new_edges
+  end
+
+  defp connected?(systems, edges) do
+    graph =
+      Enum.reduce(systems, Graph.new(type: :undirected), fn s, g -> Graph.add_vertex(g, s.id) end)
+
+    graph = Enum.reduce(edges, graph, fn e, g -> Graph.add_edge(g, e.s1.id, e.s2.id) end)
+    length(Graph.components(graph)) == 1
+  end
+
+  # ---- cases -----------------------------------------------------------------
+
+  test "dense connected cloud — radius phase only" do
+    systems = cloud({1, 2, 3}, 250, {0, 0}, {60, 60}, 1)
+
+    edges = assert_identical(systems, [])
+    assert edges != []
+    assert connected?(systems, edges)
+  end
+
+  test "fragmented clusters and singletons — multi-pass component assembly" do
+    systems =
+      cloud({4, 5, 6}, 80, {0, 0}, {30, 30}, 1) ++
+        cloud({7, 8, 9}, 80, {60, 0}, {30, 30}, 1_000) ++
+        cloud({10, 11, 12}, 80, {0, 60}, {30, 30}, 2_000) ++
+        [%{id: 9_001, position: %Position{x: 120.0, y: 120.0}}] ++
+        [%{id: 9_002, position: %Position{x: -40.0, y: -40.0}}]
+
+    edges = assert_identical(systems, [])
+    assert connected?(systems, edges)
+  end
+
+  test "blackhole inside a cloud — radius-phase edge filtering" do
+    systems = cloud({13, 14, 15}, 200, {0, 0}, {50, 50}, 1)
+    blackholes = [blackhole(25.0, 25.0, 8)]
+
+    edges = assert_identical(systems, blackholes)
+    assert edges != []
+  end
+
+  test "blackhole between clusters — assemble couple filtering and fallback" do
+    # Two clusters separated by more than @max_dist with a blackhole sitting
+    # on the corridor between them, so the nearest joining couples cross it
+    # and the assemble pass has to walk down its sorted list (or fall back).
+    systems =
+      cloud({16, 17, 18}, 60, {0, 0}, {25, 25}, 1) ++
+        cloud({19, 20, 21}, 60, {45, 0}, {25, 25}, 500)
+
+    blackholes = [blackhole(35.0, 12.5, 6)]
+
+    edges = assert_identical(systems, blackholes)
+    assert connected?(systems, edges)
+  end
+
+  test "grid cells behave at negative coordinates and cell boundaries" do
+    # Positions straddling 0 and exact multiples of the 12-unit cell size —
+    # catches off-by-one cell assignment (floor vs div) on the grid path.
+    systems = [
+      %{id: 1, position: %Position{x: -0.5, y: -0.5}},
+      %{id: 2, position: %Position{x: 0.5, y: 0.5}},
+      %{id: 3, position: %Position{x: 12.0, y: 0.0}},
+      %{id: 4, position: %Position{x: 23.9, y: 0.1}},
+      %{id: 5, position: %Position{x: 24.1, y: -0.1}},
+      %{id: 6, position: %Position{x: 36.5, y: 0.0}},
+      %{id: 7, position: %Position{x: -12.1, y: -11.9}}
+    ]
+
+    edges = assert_identical(systems, [])
+    assert connected?(systems, edges)
+  end
+end


### PR DESCRIPTION
…tprint

Booting the 6,643-system Big One scenario burned 130.5s of CPU in create_from_model — a self-DoS vector when large galaxies are created rapidly. Phase instrumentation (new Util.PhaseTimer, [boot-timing] logs) attributed it: edge-graph assembly 72.7s, the O(N^2) radius scan 21.1s, system generation 29.0s.

SpatialGraph, output byte-identical (regression-tested):
- radius scan: spatial hash with @max_dist cells + 3x3 neighborhood instead of all-pairs; candidates re-sorted to original order (21.1s -> 1.5s)
- assemble_graph_components: same algorithm, but MapSet membership instead of an O(K) list walk inside the min_by, Graph.components computed once per pass, and the per-member fan-out chunked — one task per member copied the ~2MB closure into 6,640 processes, ~13GB of term-copying (72.7s -> 1.0s)
- test embeds the old implementation verbatim as a reference and asserts exact equality across five seeded layouts (fragmented components, blackhole corridor, cell boundaries); the :gen_determinism end-to-end suite also passes unchanged

Data memory mode now defaults to :shared (50-78x faster per Querier lookup, zero-copy persistent_term; prod has been soaking it via RC_DATA_MEMORY_MODE). RC_DATA_MEMORY_MODE still overrides.

Boot CPU throttling (availability leg of the anti-DoS work): generation and agent-spawn fan-outs cap at half the online schedulers (override: :galaxy_gen_max_concurrency / RC_GALAXY_GEN_CONCURRENCY), and boot work runs at :low scheduler priority — the Manager during init plus every fan-out worker — so live instances win the scheduler under contention. Boot streams get timeout: :infinity because a deliberately-starved worker must not trip async_stream's 5s kill; the inner Game.calls keep their own 5s timeouts for real wedges.

Result on the same Big One boot: 27.9s total (gen 20.2s, edges 2.9s), ~2 cores at low priority instead of a saturated box. Remaining time is dominated by Data.Picker re-reading place.txt per name draw, which the in-flight name-generation rework replaces. profile_galaxy_boot.exs / profile_edges.exs are the repeatable measurement harnesses.