### PR TITLE
feat(discord): diplo channels, start-time modal, victory posts, daily…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,12 +129,18 @@ S3_STORAGE_DIR=/storage
 #     channel where Game.News bulletins for discord_ready games are
 #     relayed (public tier only). Prod: 1526229102783107173. Unset =
 #     no relay.
+#   DISCORD_DIPLO_CATEGORY_ID — category id in the game server under
+#     which /promote creates pairwise inter-faction diplomacy channels
+#     for matches with more than two factions. Prod: the diplo-ground
+#     category, 1525856603385892925. Unset = the bot creates its own
+#     per-match category instead.
 # DISCORD_BOT_TOKEN=
 # DISCORD_BOT_TOKEN_FILE=
 # DISCORD_COMMUNITY_GUILD_ID=
 # DISCORD_GAME_GUILD_ID=
 # DISCORD_COMMUNITY_ANNOUNCE_CHANNEL_ID=
 # DISCORD_NEWS_CHANNEL_ID=1526229102783107173
+# DISCORD_DIPLO_CATEGORY_ID=1525856603385892925
 
 # AppSignal observability. Set ACTIVE=true and provide PUSH_API_KEY to enable.
 APPSIGNAL_ACTIVE=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,34 +3,28 @@
 ## Branching & releases
 
 `master` is the **production trunk** — it's what `./deploy/release.sh <ref>`
-deploys. It advances **only** two ways: a **hotfix** to the live version, or a
-**promotion** of a finished version branch. **Feature work never lands on
-`master` directly** — the next version is integrated on a long-lived
-`release/X.Y` branch (e.g. `release/1.1`), and feature branches branch off it
-and PR back into it.
+deploys. Since v1.1 shipped (release/1.1 merged, July 2026), development
+happens **directly on master**: feature branches commit/merge straight to
+`master` as rolling "hotfixes" to the live version. There is currently no
+active `release/*` branch.
+
+A long-lived `release/X.Y` branch (next: `release/1.2`) is only cut when
+production needs to freeze again — at that point master-vs-release rules
+apply: hotfixes to the live version go to `master` and get forward-ported
+into the release branch (`git merge origin/master`, keeping the branch's
+higher version on conflict); the release branch promotes by merging into
+`master`, tagging `vX.Y.0`, and deploying.
 
 Versioning is semver with version-file bumps:
 
 - App version lives in `mix.exs` (`version:`) and `front/package.json`
-  (`"version"`) — bump both on the release branch. `assets/package.json` is a
-  legacy pipeline (optional). `priv/VERSION` is auto-stamped by the deploy —
+  (`"version"`) — bump both together. `assets/package.json` is a legacy
+  pipeline (optional). `priv/VERSION` is auto-stamped by the deploy —
   **never edit it**.
-- Tags are `vMAJOR.MINOR.PATCH`. `v1.0.0` = the frozen baseline (current
-  production); `release/1.1` ships as `v1.1.0`.
-
-**Hotfix:** branch off `master` → merge to `master` → bump patch + tag
-`v1.0.x` → `./deploy/release.sh v1.0.x` → **forward-port** into every active
-`release/*` branch (`git switch release/1.1 && git merge origin/master`,
-keeping the branch's higher version on conflict). Forward-porting is what keeps
-hotfixes from being lost when a release branch is later promoted.
-
-**Promotion:** sync the release branch (`git merge origin/master`), confirm
-version files, merge `release/X.Y` → `master`, tag `vX.Y.0`, deploy.
+- Tags are `vMAJOR.MINOR.PATCH`; production currently runs the v1.1 line.
 
 The deploy script is ref-agnostic (any branch/tag/commit); CI
-(`.github/workflows/elixir.yml`) runs on all branches but **never deploys**. If
-`master` is branch-protected (PR-required), the "merge to `master`" steps above
-happen via a PR into `master` on GitHub instead of a local merge + push.
+(`.github/workflows/elixir.yml`) runs on all branches but **never deploys**.
 
 ## Dev port assignment (worktree-aware Docker)
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -77,7 +77,8 @@ if discord_token do
     community_guild_id: System.get_env("DISCORD_COMMUNITY_GUILD_ID"),
     game_guild_id: System.get_env("DISCORD_GAME_GUILD_ID"),
     community_announce_channel_id: System.get_env("DISCORD_COMMUNITY_ANNOUNCE_CHANNEL_ID"),
-    news_channel_id: System.get_env("DISCORD_NEWS_CHANNEL_ID")
+    news_channel_id: System.get_env("DISCORD_NEWS_CHANNEL_ID"),
+    diplo_category_id: System.get_env("DISCORD_DIPLO_CATEGORY_ID")
 end
 
 # Opt-in debug instrumentation. Each flag defaults to false; set the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       DISCORD_COMMUNITY_GUILD_ID: "${DISCORD_COMMUNITY_GUILD_ID:-}"
       DISCORD_GAME_GUILD_ID: "${DISCORD_GAME_GUILD_ID:-}"
       DISCORD_COMMUNITY_ANNOUNCE_CHANNEL_ID: "${DISCORD_COMMUNITY_ANNOUNCE_CHANNEL_ID:-}"
+      DISCORD_NEWS_CHANNEL_ID: "${DISCORD_NEWS_CHANNEL_ID:-}"
+      DISCORD_DIPLO_CATEGORY_ID: "${DISCORD_DIPLO_CATEGORY_ID:-}"
     # Host ports are parametrized so parallel worktrees can run side-by-side.
     # Run `bin/rc-worktree-setup` (or .ps1) once in each worktree to allocate
     # a unique slot — it writes RC_HTTP_PORT / RC_FRONT_PORT into .env, which

--- a/docs/discord-bot.md
+++ b/docs/discord-bot.md
@@ -15,7 +15,14 @@ discussion in the project history.
 | ---- | ------- |
 | `lib/rc/discord.ex` | Supervisor + on/off entry point + guild-id helpers |
 | `lib/rc/discord/consumer.ex` | Nostrum event handler (`:READY`, `:INTERACTION_CREATE`) |
-| `lib/rc/discord/commands.ex` | Slash command registry + dispatch |
+| `lib/rc/discord/commands.ex` | Slash command registry + dispatch (incl. the /promote start-time modal) |
+| `lib/rc/discord/legacy_match.ex` | Promotion: faction categories, pairwise diplomacy channels, announcements, teardown |
+| `lib/rc/discord/news.ex` | Immediate-feed renderers + victory embeds (pure) |
+| `lib/rc/discord/news_relay.ex` | Posts the immediate feed + victory announcements |
+| `lib/rc/discord/bulletin.ex` | Daily-summary slot math + rendering (pure) |
+| `lib/rc/discord/daily_bulletin.ex` | Daily-summary scheduler (posts once a day per match) |
+| `lib/rc/discord/gov_relay.ex` | Faction-government election news + leadership role sync |
+| `lib/rc/discord/role_sync.ex` | Faction role assignment during a match's active window |
 | `config/runtime.exs` | Reads env vars, configures `:nostrum` and `:rc, RC.Discord` |
 | `.env.example` | Documents the env-var contract |
 
@@ -28,10 +35,58 @@ discussion in the project history.
 | `DISCORD_COMMUNITY_GUILD_ID` | optional* | Server ID of the public community guild |
 | `DISCORD_GAME_GUILD_ID` | optional* | Server ID of the Legacy-games guild |
 | `DISCORD_NEWS_CHANNEL_ID` | optional | Channel id of the all-factions `#news` channel (prod: `1526229102783107173`). `RC.Discord.News` relays Game.News bulletins for `discord_ready` games there, public tier only. Unset = no relay |
+| `DISCORD_DIPLO_CATEGORY_ID` | optional | Category id in the game guild under which `/promote` creates pairwise inter-faction diplomacy channels for matches with more than two factions (prod: the diplo-ground category, `1525856603385892925`). Unset = the bot creates its own per-match category |
 
 \* At least one guild ID must be set, or the bot logs a warning and stays
 dormant — there's nothing for it to do without somewhere to register
 commands.
+
+## What posts where (feature map)
+
+All game-event posting is gated on the instance being `discord_ready`.
+Times below are US Eastern wall time (`America/New_York`, so EST/EDT is
+automatic).
+
+**Promotion (`/promote legacy`).** After picking the instance, a modal
+asks for the real start time (`YYYY-MM-DD HH:MM` Eastern, or a unix
+timestamp). That time is what the registration announcement renders —
+`opening_date` is only a fallback — and it also drives the role-sync
+activation window (start − 6h). For matches with **more than two
+factions**, promotion additionally creates one private text channel per
+faction pair (`#ark-card`, `#card-myr`, …), visible to both factions'
+roles, under `DISCORD_DIPLO_CATEGORY_ID` (or a bot-made category).
+`/teardown` removes exactly the channels the bot created.
+
+**Immediate feed (Legacy `#news`).** Only events every player can
+already see on the galaxy map post instantly: sector control changes,
+every colonization, every dominion flip (incl. liberations and
+abandonments), and victory-point movement. Battles, bombardments,
+pillages, conquests, covert ops, and galaxy firsts do NOT post live.
+
+**Daily summary bulletin (Legacy `#news`).** Once a day per running
+match, in a random 30-minute slot between 12:00 and 14:00 Eastern, the
+bot posts a digest: battle counts with per-faction win/loss records
+and ratios, conquest/bombard/pillage tallies, and the window's galaxy
+firsts (named). The data cutoff is a *hidden* random 30-minute slot
+between 07:00 and 11:00 Eastern — both slots derive deterministically
+from (date, stored per-match random secret), so they reshuffle daily
+and can't be predicted or reconstructed by players. Two-faction
+matches get full detail (player records, system names); matches with
+more factions get faction-level tallies only. A missed or paused day
+folds into the next bulletin; nothing is dropped.
+
+**Victory.** When a `discord_ready` match concludes, the bot posts
+"Congrats to [faction]!" embeds to the community announce channel
+(community-guild emoji) and the Legacy `#news` channel (game-guild
+emoji).
+
+**Faction government (Legacy `#news`).** Election lifecycle news only:
+elections opening, seats filled (with the player's Discord display
+name appended when linked — never an @-mention), failed elections,
+depositions, dissolutions, ARK challenges. Patents, lexes, taxes, and
+policy changes never broadcast. Seat holders also get/lose the
+leadership roles on the game guild (faction-leader, econ, military —
+role ids hardcoded in `RC.Discord.GovRelay`).
 
 ## Local dev setup
 

--- a/lib/game/instance/character/actions/loot.ex
+++ b/lib/game/instance/character/actions/loot.ex
@@ -139,6 +139,19 @@ defmodule Instance.Character.Actions.Loot do
       )
     end
 
+    # News-ticker hook: successful pillages feed the Discord daily
+    # summary bulletin (News.Server records them; there is still no
+    # in-game pillage bulletin). Fire-and-forget.
+    if result in [:normal_success, :critical_success] do
+      Game.News.emit(character.instance_id, "loot.hit", %{
+        faction: Atom.to_string(character.owner.faction),
+        victim_faction: if(defender, do: Atom.to_string(defender.faction)),
+        system_name: system.name,
+        system_id: system.id,
+        sector_id: system.sector_id
+      })
+    end
+
     # finish action
     character = Character.finish_action(character)
 

--- a/lib/game/instance/faction/agent.ex
+++ b/lib/game/instance/faction/agent.ex
@@ -802,10 +802,16 @@ defmodule Instance.Faction.Agent do
   # Government events, from ticks (drained) and from direct ops:
   # `:refund` settles escrow; lifecycle milestones go to the faction
   # audit log and (Legacy pace only, same guard as :add_player) the
-  # player-event card feed.
+  # player-event card feed. Leadership ceremony events additionally
+  # relay to Discord (best-effort cast; no-op without the bot).
   defp settle_government_events(state, events) do
     Enum.reduce(events, state, fn event, state ->
       settle_government_event(state, event)
+      # Discord relay decides which events broadcast (leadership
+      # ceremony only — patents/lexes/taxes/policy churn stay off the
+      # wire by design, user decision 2026-07-18). Non-ceremony events
+      # are dropped inside post_async before any cast happens.
+      RC.Discord.GovRelay.post_async(state.instance_id, state.data.key, event)
       state
     end)
   end

--- a/lib/game/instance/faction/government.ex
+++ b/lib/game/instance/faction/government.ex
@@ -850,23 +850,35 @@ defmodule Instance.Faction.Government do
   Seat a player. A player never holds two seats — except under the
   small-faction relaxation (`opts[:keep_other_seats]`), where one member
   may chair the whole government.
+
+  Every `:seat_changed` event carries `:previous` (the displaced
+  holder, or nil) so downstream consumers (the Discord leadership-role
+  sync in particular) can retract state granted to the old holder.
+  Seats implicitly cleared because the winner vacated their old chair
+  emit their own `:seat_changed` too — without it those seats would
+  change hands invisibly.
   """
   def fill_seat(%Government{} = government, seat, %{player_id: player_id, name: name}, opts \\ []) do
     holder = %{player_id: player_id, name: name}
+    previous = Map.get(government.seats, seat)
 
-    seats =
+    {seats, cleared_events} =
       if Keyword.get(opts, :keep_other_seats, false) do
-        government.seats
+        {government.seats, []}
       else
-        Map.new(government.seats, fn {key, current} ->
-          if current != nil and current.player_id == player_id,
-            do: {key, nil},
-            else: {key, current}
+        Enum.reduce(government.seats, {government.seats, []}, fn {key, current}, {seats, events} ->
+          if key != seat and current != nil and current.player_id == player_id do
+            {Map.put(seats, key, nil),
+             [%{type: :seat_changed, seat: key, player_id: nil, name: nil, previous: current} | events]}
+          else
+            {seats, events}
+          end
         end)
       end
 
     {%{government | seats: Map.put(seats, seat, holder)},
-     [%{type: :seat_changed, seat: seat, player_id: player_id, name: name}]}
+     cleared_events ++
+       [%{type: :seat_changed, seat: seat, player_id: player_id, name: name, previous: previous}]}
   end
 
   def vacate_seat(%Government{} = government, seat) do
@@ -874,9 +886,9 @@ defmodule Instance.Faction.Government do
       nil ->
         {government, []}
 
-      _holder ->
+      holder ->
         {%{government | seats: Map.put(government.seats, seat, nil)},
-         [%{type: :seat_changed, seat: seat, player_id: nil, name: nil}]}
+         [%{type: :seat_changed, seat: seat, player_id: nil, name: nil, previous: holder}]}
     end
   end
 

--- a/lib/game/instance/victory/agent.ex
+++ b/lib/game/instance/victory/agent.ex
@@ -11,7 +11,9 @@ defmodule Instance.Victory.Agent do
 
   @decorate tick()
   def on_cast({:add_player, faction_id}, state) do
-    {:noreply, %{state | data: Victory.add_player(state.data, faction_id)}}
+    data = Victory.add_player(state.data, faction_id)
+    relay_vp_changes(state.data, data, state.instance_id)
+    {:noreply, %{state | data: data}}
   end
 
   @decorate tick()
@@ -21,6 +23,7 @@ defmodule Instance.Victory.Agent do
       |> Victory.reset_player_count(players)
       |> Victory.update_systems(systems)
 
+    relay_vp_changes(state.data, data, state.instance_id)
     {:noreply, %{state | data: data}}
   end
 
@@ -31,6 +34,7 @@ defmodule Instance.Victory.Agent do
       |> Victory.reset_player_count(players)
       |> Victory.update_visibility(faction_key, visibility_count)
 
+    relay_vp_changes(state.data, data, state.instance_id)
     {:noreply, %{state | data: data}}
   end
 
@@ -41,6 +45,7 @@ defmodule Instance.Victory.Agent do
       |> Victory.reset_player_count(players)
       |> Victory.update_sector(sector)
 
+    relay_vp_changes(state.data, data, state.instance_id)
     {:noreply, %{state | data: data}}
   end
 
@@ -81,6 +86,28 @@ defmodule Instance.Victory.Agent do
     {:noreply, state}
   end
 
+  # News hook: victory-star movement is public in-game (every player
+  # sees the victory panel), so a faction's victory_points changing
+  # may be announced the moment it happens. Emitted on the news wire —
+  # News.Server owns eligibility (speed/tutorial) and routes it to
+  # Discord only; NewsRelay additionally gates on discord_ready and
+  # rolls bursts up, so sim/daily/unpromoted instances never post.
+  defp relay_vp_changes(old_data, new_data, instance_id) do
+    old_vp = Map.new(old_data.factions, fn f -> {f.key, f.victory_points} end)
+
+    Enum.each(new_data.factions, fn f ->
+      prev = Map.get(old_vp, f.key)
+
+      if prev != nil and prev != f.victory_points do
+        Game.News.emit(instance_id, "vp.changed", %{
+          faction: Atom.to_string(f.key),
+          vp: f.victory_points,
+          prev_vp: prev
+        })
+      end
+    end)
+  end
+
   defp do_next_tick(state, next_tick) do
     {change, data, export} = Victory.next_tick(state.data, next_tick)
 
@@ -111,6 +138,15 @@ defmodule Instance.Victory.Agent do
 
           RC.Instances.record_victory(export.ranking, export.victory_type)
           RC.Rankings.update_rankings(export.ranking)
+
+          # Discord: announce the victor on the community server and in
+          # the Legacy #news channel. Best-effort cast; the relay gates
+          # on discord_ready so unpromoted games never post.
+          RC.Discord.News.post_victory_async(state.instance_id, %{
+            winner: data.winner,
+            victory_points: List.first(export.ranking).victory_points,
+            victory_type: export.victory_type
+          })
       end
     end
 

--- a/lib/game/news/server.ex
+++ b/lib/game/news/server.ex
@@ -56,6 +56,12 @@ defmodule Game.News.Server do
   defstruct [
     :instance_id,
     eligibility: :unknown,
+    # Lazily resolved "is this a promoted discord_ready match?" —
+    # gates the DB-backed daily-bulletin accumulator
+    # (RC.Discord.BulletinEvent). Promotion happens before a game can
+    # start, so the answer is stable for the life of a running
+    # instance; a failed lookup stays :unknown and retries.
+    bulletin_eligible: :unknown,
     # first_keys whose claim has been settled (won or lost) this
     # server lifetime — repeat probes short-circuit here.
     claimed: MapSet.new(),
@@ -111,25 +117,54 @@ defmodule Game.News.Server do
 
   ## Routing — one clause per raw event kind.
 
-  defp route(state, "colonize.first", payload),
-    do: first(state, "colonize.first", "news.colonize.first", payload)
+  # Colonizations are public map knowledge, so Discord announces every
+  # one immediately (the render layer owns the wording); the in-game
+  # ticker still only bulletins the galaxy first.
+  defp route(state, "colonize.first", payload) do
+    RC.Discord.News.post_async(state.instance_id, "discord.colonized", payload)
+    first(state, "colonize.first", "news.colonize.first", payload)
+  end
 
-  defp route(state, "dominion.taken", payload),
-    do: first(state, "dominion.first", "news.dominion.first", payload)
+  # Dominion flips likewise: every one posts to Discord instantly,
+  # in-game keeps the galaxy-first bulletin.
+  defp route(state, "dominion.taken", payload) do
+    RC.Discord.News.post_async(state.instance_id, "discord.dominion", payload)
+    first(state, "dominion.first", "news.dominion.first", payload)
+  end
 
-  defp route(state, "conquest.taken", payload),
-    do: publish(state, "news.conquest", payload)
+  # Conquests stay instant in-game but are withheld from Discord's
+  # instant feed — they land in the daily summary bulletin.
+  defp route(state, "conquest.taken", payload) do
+    state = record_for_bulletin(state, "conquest", payload)
+    publish(state, "news.conquest", payload)
+  end
 
-  defp route(state, "raid.hit", payload),
-    do: dedup(state, {:raid, payload[:faction], payload[:system_id]}, "news.raid", payload)
+  defp route(state, "raid.hit", payload) do
+    state = record_for_bulletin(state, "raid", payload)
+    dedup(state, {:raid, payload[:faction], payload[:system_id]}, "news.raid", payload)
+  end
 
-  # Battles: dedup policy is per-publisher. The web surfaces keep the
-  # suppress-and-summarize window (below); Discord gets EVERY battle
-  # and rolls them up itself by editing its previous message — so the
-  # relay is fed here, pre-dedup, and publish/3 skips battle keys.
+  # Successful pillages: no in-game bulletin (unchanged), but they
+  # count toward the Discord daily summary.
+  defp route(state, "loot.hit", payload),
+    do: record_for_bulletin(state, "loot", payload)
+
+  # Victory-point movement: Discord-only (the in-game victory panel
+  # already live-updates for everyone, so no ticker bulletin). Routing
+  # through here rather than straight from Victory.Agent keeps the
+  # speed/tutorial eligibility gate on it.
+  defp route(state, "vp.changed", payload) do
+    RC.Discord.News.post_async(state.instance_id, "discord.vp_changed", payload)
+    state
+  end
+
+  # Battles: the web surfaces keep the suppress-and-summarize window
+  # (below); Discord no longer sees battles live at all — each one is
+  # accumulated for the daily summary bulletin (player decision
+  # 2026-07: instant battle intel gave too much away).
   defp route(state, "battle.fought", payload) do
     payload = enrich_sector_name(payload, state.instance_id)
-    RC.Discord.News.post_async(state.instance_id, "news.battle", payload)
+    state = record_for_bulletin(state, "battle", payload)
     dedup(state, {:battle, payload[:sector_id]}, "news.battle", payload)
   end
 
@@ -283,9 +318,64 @@ defmodule Game.News.Server do
     "news.agent.converted" => [:attacker_faction]
   }
 
-  # Battle bulletins reach Discord pre-dedup via route/3 (the relay
-  # rolls them up itself); publishing them again here would double-post.
-  @discord_skip_keys ["news.battle", "news.battle.summary"]
+  # DB-backed accumulator for the Discord daily summary bulletin.
+  # Only PROMOTED discord_ready matches write rows (checked once,
+  # cached) — a discord_ready flag alone, without a discord_matches
+  # row, has no bulletin consumer and would accumulate unbounded.
+  # Everything else — sims, dailies, unpromoted games — skips at zero
+  # DB cost. Insert failures log and never disturb the news pipeline.
+  defp record_for_bulletin(state, kind, payload) do
+    state = resolve_bulletin_eligible(state)
+
+    if state.bulletin_eligible == true do
+      %RC.Discord.BulletinEvent{}
+      |> RC.Discord.BulletinEvent.changeset(%{
+        instance_id: state.instance_id,
+        kind: kind,
+        payload: payload
+      })
+      |> RC.Repo.insert()
+      |> case do
+        {:ok, _row} ->
+          :ok
+
+        {:error, changeset} ->
+          Logger.warning("Game.News.Server bulletin-event insert failed",
+            instance_id: state.instance_id,
+            kind: kind,
+            reason: inspect(changeset.errors)
+          )
+      end
+    end
+
+    state
+  rescue
+    e ->
+      Logger.warning("Game.News.Server record_for_bulletin crashed: #{inspect(e)}")
+      state
+  end
+
+  defp resolve_bulletin_eligible(%{bulletin_eligible: :unknown, instance_id: iid} = state) do
+    import Ecto.Query, only: [from: 2]
+
+    eligible =
+      RC.Repo.exists?(
+        from(m in RC.Discord.Match,
+          join: i in assoc(m, :instance),
+          where: m.instance_id == ^iid,
+          where: i.discord_ready == true
+        )
+      )
+
+    %{state | bulletin_eligible: eligible}
+  rescue
+    # Transient DB failure: stay :unknown so the next event retries —
+    # caching false here would silently disable the bulletin for the
+    # rest of this weeks-long instance's server lifetime.
+    _ -> state
+  end
+
+  defp resolve_bulletin_eligible(state), do: state
 
   defp publish(state, bulletin_key, payload) do
     payload =
@@ -312,11 +402,10 @@ defmodule Game.News.Server do
           }
         })
 
-        # Discord relay for discord_ready games (async, best-effort;
-        # posts only the public tier — #news is an all-factions channel).
-        unless bulletin_key in @discord_skip_keys do
-          RC.Discord.News.post_async(state.instance_id, bulletin_key, payload)
-        end
+        # Discord relay for discord_ready games (async, best-effort).
+        # RC.Discord.News.render/2 owns which bulletin kinds actually
+        # post immediately — everything else is a silent no-op there.
+        RC.Discord.News.post_async(state.instance_id, bulletin_key, payload)
 
       {:error, reason} ->
         Logger.warning("Game.News.Server publish failed",

--- a/lib/rc/discord.ex
+++ b/lib/rc/discord.ex
@@ -69,10 +69,14 @@ defmodule RC.Discord do
           # the gateway consumer; its own try/rescue keeps Discord
           # failures from cascading.
           RC.Discord.RoleSync,
-          # Game.News → #news channel relay. Owns Discord's dedup
-          # policy (battle roll-up by message edit). Casts to it from
-          # a botless node are silent no-ops.
-          RC.Discord.NewsRelay
+          # Game.News → #news channel immediate relay + victory
+          # announcements. Casts to it from a botless node are silent
+          # no-ops.
+          RC.Discord.NewsRelay,
+          # Once-a-day summary bulletin (seeded post/cutoff slots).
+          RC.Discord.DailyBulletin,
+          # Faction-government election news + leadership role sync.
+          RC.Discord.GovRelay
         ]
 
         Supervisor.init(children, strategy: :one_for_one)
@@ -108,6 +112,14 @@ defmodule RC.Discord do
   """
   def news_channel_id,
     do: get_snowflake(:news_channel_id)
+
+  @doc """
+  Category ID in the game guild under which `/promote` places pairwise
+  inter-faction diplomacy channels (prod: the diplo-ground category).
+  nil = the bot creates its own per-match category instead.
+  """
+  def diplo_category_id,
+    do: get_snowflake(:diplo_category_id)
 
   @doc """
   Whether the bot supervisor is actually running (token + guild

--- a/lib/rc/discord/bulletin.ex
+++ b/lib/rc/discord/bulletin.ex
@@ -1,0 +1,317 @@
+defmodule RC.Discord.Bulletin do
+  @moduledoc """
+  Pure logic for the daily summary bulletin: seeded slot selection and
+  message rendering. `RC.Discord.DailyBulletin` owns scheduling, DB
+  reads, and posting; everything here is side-effect free and
+  unit-tested without the bot.
+
+  ## Seeded slots
+
+  Two windows, both US-Eastern wall time in 30-minute increments
+  (inclusive endpoints):
+
+    * **post slot** — when today's bulletin goes out: 12:00 to 14:00
+    * **cutoff slot** — the hidden data cutoff: 07:00 to 11:00
+
+  Both are pure functions of `(date, salt)` where the salt is the
+  match's stored random secret (`discord_matches.bulletin_salt`) —
+  never derived from observable data, so even watching weeks of
+  public post times can't narrow down the hidden cutoff. Each day's
+  window is `(yesterday's cutoff, today's cutoff]`, tracked by a
+  stored high-water mark so a missed posting day folds into the next
+  bulletin instead of losing events.
+
+  ## Detail tiers
+
+  With more than two factions the bulletin stays deliberately vague:
+  per-faction tallies only, no player names, no systems, no times.
+  With exactly two factions the enemy already knows what happened to
+  them, so player records and system names are included. Firsts name
+  the player in both tiers (player decision 2026-07).
+  """
+
+  alias RC.Discord.EasternTime
+  alias RC.Discord.News
+
+  # Post window 12:00-14:00 ET, cutoff window 07:00-11:00 ET.
+  @slot_minutes 30
+  @post_base_minutes 12 * 60
+  @post_slot_count 5
+  @cutoff_base_minutes 7 * 60
+  @cutoff_slot_count 9
+
+  # Display caps so a busy day can't blow Discord's 2000-char limit.
+  @max_list_names 8
+  @max_record_players 12
+
+  @building_names %{
+    "high_factory_dome" => "Metamaterials Factory",
+    "monument_dome" => "Monolith"
+  }
+
+  # --- Seeded slots ----------------------------------------------------
+
+  @doc "Today's bulletin post time (ET) for the given date + salt."
+  def post_time(%Date{} = date, salt),
+    do: slot_datetime(date, salt, :post, @post_base_minutes, @post_slot_count)
+
+  @doc "Today's hidden data cutoff (ET) for the given date + salt."
+  def cutoff_time(%Date{} = date, salt),
+    do: slot_datetime(date, salt, :cutoff, @cutoff_base_minutes, @cutoff_slot_count)
+
+  defp slot_datetime(date, salt, kind, base_minutes, slot_count) do
+    slot = :erlang.phash2({to_string(salt), Date.to_iso8601(date), kind}, slot_count)
+    minutes = base_minutes + slot * @slot_minutes
+
+    date
+    |> NaiveDateTime.new!(Time.new!(div(minutes, 60), rem(minutes, 60), 0))
+    |> EasternTime.from_naive!()
+  end
+
+  # --- Rendering -------------------------------------------------------
+
+  @doc """
+  Render the bulletin message. `events` are `RC.Discord.BulletinEvent`
+  structs (string-keyed payloads, as read back from JSONB);
+  `firsts_lines` are pre-rendered sentences from `first_line/3`.
+  """
+  def render(instance_name, faction_count, events, firsts_lines) do
+    detailed? = faction_count <= 2
+    by_kind = Enum.group_by(events, & &1.kind)
+
+    sections =
+      [
+        battles_section(Map.get(by_kind, "battle", []), detailed?),
+        strikes_section("Conquests", Map.get(by_kind, "conquest", []), detailed?, "took"),
+        strikes_section("Bombards", Map.get(by_kind, "raid", []), detailed?, "bombarded"),
+        strikes_section("Pillages", Map.get(by_kind, "loot", []), detailed?, "pillaged"),
+        firsts_section(firsts_lines)
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    truncate_at_line("📰 **#{instance_name}** daily bulletin\n" <> Enum.join(sections, "\n"))
+  end
+
+  # Discord caps messages at 2000 chars. The per-section caps make
+  # overflow unlikely, but if it happens, cut at a line boundary — a
+  # raw character slice can bisect a custom-emoji token or a markdown
+  # pair and post visible garbage.
+  @max_message_chars 1900
+
+  defp truncate_at_line(content) when byte_size(content) <= @max_message_chars, do: content
+
+  defp truncate_at_line(content) do
+    kept =
+      content
+      |> String.split("\n")
+      |> Enum.reduce_while([], fn line, acc ->
+        candidate = Enum.reverse([line | acc]) |> Enum.join("\n")
+
+        if String.length(candidate) > @max_message_chars,
+          do: {:halt, acc},
+          else: {:cont, [line | acc]}
+      end)
+      |> Enum.reverse()
+      |> Enum.join("\n")
+
+    kept <> "\n(truncated)"
+  end
+
+  # --- Battles ---------------------------------------------------------
+
+  defp battles_section([], _detailed?), do: "**Battles**: none reported."
+
+  defp battles_section(battles, detailed?) do
+    total = length(battles)
+    draws = Enum.count(battles, fn e -> payload(e)["winner"] == "draw" end)
+
+    faction_records =
+      Enum.reduce(battles, %{}, fn event, acc ->
+        p = payload(event)
+
+        case winner_loser_factions(p) do
+          {nil, nil} -> acc
+          {winner, loser} -> acc |> bump(winner, :wins) |> bump(loser, :losses)
+        end
+      end)
+
+    tally =
+      faction_records
+      |> Enum.sort_by(fn {_f, %{wins: w, losses: l}} -> {-w, l} end)
+      |> Enum.map_join(", ", fn {faction, %{wins: w, losses: l}} ->
+        "#{News.faction_emoji(faction)}#{News.faction_name(faction)} #{record_label(w, l)}#{ratio_label(w, l)}"
+      end)
+
+    draw_note = if draws > 0, do: " (#{draws} inconclusive)", else: ""
+    line = "**Battles**: #{total} engagement#{plural(total)}#{draw_note}. #{tally}"
+    line = String.trim_trailing(line)
+
+    if detailed? do
+      case player_records(battles) do
+        "" -> line
+        records -> line <> "\nRecords: #{records}."
+      end
+    else
+      line
+    end
+  end
+
+  defp winner_loser_factions(p) do
+    attacker = p["attacker_faction"]
+    defender = p["defender_faction"]
+
+    case p["winner"] do
+      "attackers" -> {attacker, defender}
+      "defenders" -> {defender, attacker}
+      _ -> {nil, nil}
+    end
+  end
+
+  defp bump(acc, nil, _key), do: acc
+
+  defp bump(acc, faction, key) do
+    acc
+    |> Map.put_new(faction, %{wins: 0, losses: 0})
+    |> update_in([faction, key], &(&1 + 1))
+  end
+
+  # Two-faction tier only: aggregate each named player's window record
+  # from the battle payloads' winners/losers lists.
+  defp player_records(battles) do
+    battles
+    |> Enum.reduce(%{}, fn event, acc ->
+      p = payload(event)
+
+      acc
+      |> fold_players(p["winners"] || [], fn {w, l} -> {w + 1, l} end)
+      |> fold_players(p["losers"] || [], fn {w, l} -> {w, l + 1} end)
+    end)
+    |> Enum.sort_by(fn {{name, _f}, {w, l}} -> {-w, l, name} end)
+    |> Enum.take(@max_record_players)
+    |> Enum.map_join(", ", fn {{name, faction}, {w, l}} ->
+      "#{News.player_display(name, faction)} #{record_label(w, l)}"
+    end)
+  end
+
+  defp fold_players(records, players, bump_fun) do
+    Enum.reduce(players, records, fn player, acc ->
+      key = {player["name"], player["faction"]}
+      Map.update(acc, key, bump_fun.({0, 0}), bump_fun)
+    end)
+  end
+
+  defp record_label(w, 0), do: "#{w}W"
+  defp record_label(0, l), do: "#{l}L"
+  defp record_label(w, l), do: "#{w}W #{l}L"
+
+  defp ratio_label(w, l) when w + l > 0, do: " (#{round(100 * w / (w + l))}%)"
+  defp ratio_label(_w, _l), do: ""
+
+  # --- Conquests / bombards / pillages ---------------------------------
+
+  defp strikes_section(label, [], _detailed?, _verb), do: "**#{label}**: none."
+
+  defp strikes_section(label, events, detailed?, verb) do
+    by_faction =
+      events
+      |> Enum.group_by(fn e -> payload(e)["faction"] end)
+      |> Enum.sort_by(fn {_f, list} -> -length(list) end)
+
+    body =
+      if detailed? do
+        Enum.map_join(by_faction, " ", fn {faction, list} ->
+          "#{News.faction_emoji(faction)}#{News.faction_name(faction)} #{verb} #{system_list(list)}."
+        end)
+      else
+        Enum.map_join(by_faction, ", ", fn {faction, list} ->
+          "#{News.faction_emoji(faction)}#{News.faction_name(faction)} #{length(list)}"
+        end)
+      end
+
+    "**#{label}**: #{body}"
+  end
+
+  # Named-systems list for the two-faction tier, deduplicated with
+  # repeat-strike counts (bombing the same system thrice reads "Vega
+  # x3", not three entries).
+  defp system_list(events) do
+    {names, dropped} =
+      events
+      |> Enum.map(fn e -> payload(e)["system_name"] || "an uncharted system" end)
+      |> Enum.reduce(%{}, fn name, acc -> Map.update(acc, name, 1, &(&1 + 1)) end)
+      |> Enum.sort_by(fn {name, n} -> {-n, name} end)
+      |> Enum.map(fn
+        {name, 1} -> name
+        {name, n} -> "#{name} x#{n}"
+      end)
+      |> Enum.split(@max_list_names)
+
+    case dropped do
+      [] -> Enum.join(names, ", ")
+      more -> Enum.join(names, ", ") <> " and #{length(more)} more"
+    end
+  end
+
+  # --- Firsts ----------------------------------------------------------
+
+  defp firsts_section([]), do: nil
+  defp firsts_section(lines), do: "**Firsts**: " <> Enum.join(lines, " ")
+
+  @doc """
+  One sentence for an `instance_firsts` claim inside the window.
+  `who` is the winning profile's name (nil falls back to the faction
+  display name, then to "Someone").
+  """
+  def first_line(first_key, who, faction_ref) do
+    subject =
+      cond do
+        who not in [nil, ""] and faction_ref not in [nil, ""] ->
+          "#{who} (#{News.faction_name(faction_ref)})"
+
+        who not in [nil, ""] ->
+          to_string(who)
+
+        faction_ref not in [nil, ""] ->
+          News.faction_name(faction_ref)
+
+        true ->
+          "Someone"
+      end
+
+    "#{subject} was first to #{first_deed(first_key)}."
+  end
+
+  defp first_deed("colonize.first"), do: "found a colony"
+  defp first_deed("dominion.first"), do: "take a dominion"
+  defp first_deed("ship.capital.first"), do: "field a capital ship"
+  defp first_deed("credit.10m.first"), do: "bank ten million credits"
+  defp first_deed("doctrine.15.first"), do: "bring fifteen lexes into law"
+  defp first_deed("faction.erased_25.first"), do: "field 25 Erased"
+  defp first_deed("faction.navarchs_25.first"), do: "field 25 Navarchs"
+  defp first_deed("faction.siderians_25.first"), do: "field 25 Siderians"
+
+  defp first_deed("building." <> rest) do
+    building = String.replace_suffix(rest, ".first", "")
+    "complete a #{Map.get(@building_names, building, humanize(building))}"
+  end
+
+  defp first_deed("income." <> rest) do
+    resource = rest |> String.replace_suffix("_100.first", "")
+    "raise #{resource} output above 100"
+  end
+
+  defp first_deed(other), do: humanize(String.replace_suffix(other, ".first", ""))
+
+  defp humanize(key), do: key |> String.replace(["_", "."], " ")
+
+  defp plural(1), do: ""
+  defp plural(_), do: "s"
+
+  # BulletinEvent payloads come back from JSONB string-keyed; tests may
+  # hand-build structs with atom keys. Normalize.
+  defp payload(%{payload: p}) when is_map(p) do
+    Map.new(p, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  defp payload(_), do: %{}
+end

--- a/lib/rc/discord/bulletin_event.ex
+++ b/lib/rc/discord/bulletin_event.ex
@@ -1,0 +1,41 @@
+defmodule RC.Discord.BulletinEvent do
+  @moduledoc """
+  One accumulated game event bound for a match's daily summary
+  bulletin (`RC.Discord.DailyBulletin`).
+
+  Written by `Game.News.Server` for `discord_ready` instances only —
+  the raw wire events that players agreed should reach Discord as a
+  once-a-day digest instead of an instant post:
+
+    * `"battle"`   — a fleet engagement (payload carries factions,
+      winners/losers, system/sector for the 2-faction detail level)
+    * `"raid"`     — a successful orbital bombardment
+    * `"loot"`     — a successful pillage
+    * `"conquest"` — a system taken by siege
+
+  Rows are consumed (deleted) by the bulletin post that summarizes
+  them, so the table holds at most ~one day of events per live match.
+  Payloads are stored verbatim; the bulletin renderer decides how much
+  detail each faction-count tier reveals.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "discord_bulletin_events" do
+    field(:kind, :string)
+    field(:payload, :map, default: %{})
+
+    belongs_to(:instance, RC.Instances.Instance)
+
+    timestamps(updated_at: false, type: :utc_datetime_usec)
+  end
+
+  @doc false
+  def changeset(event, attrs) do
+    event
+    |> cast(attrs, [:instance_id, :kind, :payload])
+    |> validate_required([:instance_id, :kind])
+    |> foreign_key_constraint(:instance_id)
+  end
+end

--- a/lib/rc/discord/commands.ex
+++ b/lib/rc/discord/commands.ex
@@ -52,14 +52,18 @@ defmodule RC.Discord.Commands do
   # Interaction types — dispatched on in `dispatch/1`.
   @itx_type_app_command 2
   @itx_type_message_component 3
+  @itx_type_modal_submit 5
 
   # Interaction response types.
   # 4 = CHANNEL_MESSAGE_WITH_SOURCE  (new visible reply)
   # 6 = DEFERRED_UPDATE_MESSAGE      (component ack — edit later)
   # 7 = UPDATE_MESSAGE               (replace component's source message)
+  # 9 = MODAL                        (pop a form; only valid as the FIRST
+  #                                   response to a command/component)
   @response_channel_message 4
   @response_deferred_update 6
   @response_update_message 7
+  @response_modal 9
 
   # Message flags. 64 = EPHEMERAL — visible only to the invoker.
   @ephemeral_flag 64
@@ -68,6 +72,10 @@ defmodule RC.Discord.Commands do
   @component_action_row 1
   @component_button 2
   @component_string_select 3
+  @component_text_input 4
+
+  # Text input styles — 1 = SHORT (single line).
+  @text_input_style_short 1
 
   # Button styles — 4 = DANGER (red), 2 = SECONDARY (gray).
   @button_style_secondary 2
@@ -229,6 +237,10 @@ defmodule RC.Discord.Commands do
 
   def dispatch(%{type: @itx_type_message_component, data: %{custom_id: custom_id}} = interaction) do
     handle_component(custom_id, interaction)
+  end
+
+  def dispatch(%{type: @itx_type_modal_submit, data: %{custom_id: custom_id}} = interaction) do
+    handle_modal(custom_id, interaction)
   end
 
   def dispatch(other) do
@@ -919,7 +931,7 @@ defmodule RC.Discord.Commands do
         case interaction.data.values do
           [<<"instance:", id_str::binary>>] ->
             case Integer.parse(id_str) do
-              {instance_id, ""} -> do_promote_legacy(interaction, instance_id, actual_id)
+              {instance_id, ""} -> prompt_promote_start_modal(interaction, instance_id, actual_id)
               _ -> update_message_ephemeral(interaction, "❌ Bad selection payload.")
             end
 
@@ -974,29 +986,137 @@ defmodule RC.Discord.Commands do
     end
   end
 
-  # --- /promote legacy: actually create the channels -----------------
+  # --- /promote legacy: start-time modal, then create the channels ----
+
+  # Between picking the instance and creating channels we pop a modal
+  # asking for the real start time. opening_date has never reliably
+  # matched actual start times, so the operator types the truth and the
+  # registration announcement renders that instead.
+  defp prompt_promote_start_modal(interaction, instance_id, user_id) do
+    send_response(interaction, %{
+      type: @response_modal,
+      data: %{
+        custom_id: "promote_start:#{instance_id}:#{user_id}",
+        title: "Legacy start time",
+        components: [
+          %{
+            type: @component_action_row,
+            components: [
+              %{
+                type: @component_text_input,
+                custom_id: "start_time",
+                style: @text_input_style_short,
+                label: "Start time (US Eastern) or unix seconds",
+                placeholder: "2026-07-20 18:00",
+                required: true,
+                min_length: 4,
+                max_length: 32
+              }
+            ]
+          }
+        ]
+      }
+    })
+  end
+
+  defp handle_modal("promote_start:" <> rest, interaction) do
+    actual_id = interaction_user_id(interaction)
+
+    with [instance_id_str, expected_user_id_str] <- String.split(rest, ":"),
+         {instance_id, ""} <- Integer.parse(instance_id_str) do
+      cond do
+        is_nil(actual_id) ->
+          update_message_ephemeral(interaction, "❌ Couldn't identify your Discord account.")
+
+        to_string(actual_id) != expected_user_id_str ->
+          update_message_ephemeral(interaction, "❌ This form isn't for you.")
+
+        true ->
+          raw = modal_input_value(interaction, "start_time") || ""
+
+          case RC.Discord.LegacyMatch.parse_start_time(raw) do
+            {:ok, start_at} ->
+              do_promote_legacy(interaction, instance_id, actual_id, start_at)
+
+            {:error, :out_of_range} ->
+              update_message_ephemeral(
+                interaction,
+                "❌ `#{raw}` parses to a time outside the sane window (past day to +60 days). " <>
+                  "Re-run `/promote legacy` and check the year."
+              )
+
+            {:error, :bad_format} ->
+              update_message_ephemeral(
+                interaction,
+                "❌ Couldn't parse `#{raw}`. Use `YYYY-MM-DD HH:MM` in US Eastern time " <>
+                  "(24h clock), or a unix timestamp in seconds. Re-run `/promote legacy`."
+              )
+          end
+      end
+    else
+      _ ->
+        update_message_ephemeral(interaction, "❌ Malformed form token.")
+    end
+  end
+
+  defp handle_modal(custom_id, interaction) do
+    Logger.warning("[RC.Discord.Commands] unknown modal custom_id: #{inspect(custom_id)}")
+    update_message_ephemeral(interaction, "❌ Unrecognized form. Try the command again.")
+  end
+
+  # Modal submits deliver values nested one action row deep:
+  # data.components -> [%{components: [%{custom_id, value}]}].
+  defp modal_input_value(interaction, input_id) do
+    rows =
+      case interaction do
+        %{data: %{components: rows}} when is_list(rows) -> rows
+        _ -> []
+      end
+
+    Enum.find_value(rows, fn row ->
+      row
+      |> Map.get(:components, [])
+      |> Enum.find_value(fn input ->
+        if to_string(Map.get(input, :custom_id)) == input_id, do: Map.get(input, :value)
+      end)
+    end)
+  end
 
   # Channel creation can take 5–10s (5 categories × 7 channels worst
   # case, each its own Discord API round-trip with rate-limit
   # waits). The 3s initial-response window forces us to defer first
   # and edit the original message with the result.
-  defp do_promote_legacy(interaction, instance_id, promoter_discord_id) do
+  defp do_promote_legacy(interaction, instance_id, promoter_discord_id, start_at) do
     case defer_update(interaction) do
       :ok -> :ok
       _ -> Logger.error("[RC.Discord.Commands] defer_update failed before promote")
     end
 
-    result = RC.Discord.LegacyMatch.promote(instance_id, promoter_discord_id)
+    result =
+      RC.Discord.LegacyMatch.promote(instance_id, promoter_discord_id, announced_start_at: start_at)
+
     edit_promote_result(interaction, instance_id, result)
   end
 
   defp edit_promote_result(interaction, instance_id, {:ok, match}) do
     n = map_size(match.faction_categories)
+    diplo_count = map_size(match.diplo_channels || %{})
+    start_unix = match.announced_start_at && DateTime.to_unix(match.announced_start_at)
+
+    diplo_line =
+      if diplo_count > 0,
+        do: " Created **#{diplo_count}** pairwise diplomacy channels.",
+        else: ""
+
+    start_line =
+      if start_unix,
+        do: " Announced start: <t:#{start_unix}:F>.",
+        else: ""
 
     edit_original(
       interaction,
-      "✅ Promoted instance ##{instance_id}. Created **#{n}** faction categories with channels. " <>
-        "Players will get role assignments at game start - 6h (Phase 2)."
+      "✅ Promoted instance ##{instance_id}. Created **#{n}** faction categories with channels." <>
+        diplo_line <> start_line <> " Players will get role assignments at game start - 6h."
     )
   end
 

--- a/lib/rc/discord/daily_bulletin.ex
+++ b/lib/rc/discord/daily_bulletin.ex
@@ -1,0 +1,261 @@
+defmodule RC.Discord.DailyBulletin do
+  @moduledoc """
+  Scheduler for the once-a-day summary bulletin (`RC.Discord.Bulletin`
+  holds the pure slot/rendering logic).
+
+  Every minute, for each promoted live match (`discord_matches` row +
+  instance `discord_ready` + state running):
+
+    1. Compute today's seeded post slot (12:00-14:00 ET). Before it:
+       do nothing. After it, if today's bulletin hasn't posted yet:
+    2. Compute today's seeded cutoff slot (07:00-11:00 ET). Collect
+       every accumulated `discord_bulletin_events` row up to the
+       cutoff, plus `instance_firsts` claimed inside the window
+       `(last summarized cutoff, today's cutoff]`.
+    3. Post the bulletin to #news, then in ONE transaction delete the
+       consumed rows and stamp `bulletin_last_posted_on` /
+       `bulletin_cutoff_at`. A failed post leaves everything unstamped
+       so the next tick retries; a failed transaction logs loudly (at
+       worst one duplicate bulletin once the DB recovers — never a
+       once-a-minute flood).
+
+  The slot seed is `bulletin_salt`, a random per-match secret
+  generated lazily on first sweep — stored, never derived, so weeks of
+  observed post times can't be used to predict the hidden cutoff.
+
+  Paused matches are skipped (no empty digests during an off-season
+  pause); their events fold into the first bulletin after unpause via
+  the cutoff high-water mark. Ended matches get their leftover
+  accumulator rows pruned.
+
+  Runs only under `RC.Discord`'s supervisor (bot configured), and even
+  then ignores itself in :test.
+  """
+
+  use GenServer
+
+  require Logger
+  import Ecto.Query
+
+  alias Nostrum.Api.Message
+  alias RC.Discord.Bulletin
+  alias RC.Discord.BulletinEvent
+  alias RC.Discord.EasternTime
+  alias RC.Discord.Match
+  alias RC.Instances.Instance
+  alias RC.Instances.InstanceFirst
+  alias RC.Repo
+
+  @tick_ms 60_000
+  # Wait before the first tick so we don't compete with boot-time work.
+  @initial_delay_ms 45_000
+
+  def start_link(opts \\ []),
+    do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(_opts) do
+    if Application.get_env(:rc, :environment) == :test do
+      :ignore
+    else
+      schedule(@initial_delay_ms)
+      {:ok, %{}}
+    end
+  end
+
+  @doc "Force a sweep now (operator debugging from iex)."
+  def run_now, do: GenServer.cast(__MODULE__, :run_now)
+
+  @impl true
+  def handle_info(:tick, state) do
+    sweep()
+    schedule(@tick_ms)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast(:run_now, state) do
+    sweep()
+    {:noreply, state}
+  end
+
+  defp schedule(ms), do: Process.send_after(self(), :tick, ms)
+
+  defp sweep do
+    now = DateTime.utc_now()
+
+    # Lean per-minute query: no preloads — the check needs only the
+    # match row and the instance's state; the heavier render data
+    # loads inside post_bulletin for the (rare) due match.
+    from(m in Match,
+      join: i in assoc(m, :instance),
+      where: i.discord_ready == true,
+      where: i.state == "running",
+      preload: [instance: i]
+    )
+    |> Repo.all()
+    |> Enum.each(&maybe_post(&1, now))
+
+    prune_ended_matches()
+  rescue
+    e ->
+      Logger.warning("[RC.Discord.DailyBulletin] sweep failed: #{Exception.message(e)}")
+  end
+
+  # A finished match never posts again, so its unconsumed accumulator
+  # rows would otherwise linger forever. Prune them here (normally a
+  # zero-row no-op).
+  defp prune_ended_matches do
+    from(e in BulletinEvent,
+      join: i in Instance,
+      on: i.id == e.instance_id,
+      where: i.state == "ended"
+    )
+    |> Repo.delete_all()
+  end
+
+  defp maybe_post(%Match{} = match, now_utc) do
+    match = ensure_salt(match)
+    today = EasternTime.today()
+
+    posted_today? =
+      match.bulletin_last_posted_on != nil and
+        Date.compare(match.bulletin_last_posted_on, today) != :lt
+
+    due? = DateTime.compare(now_utc, Bulletin.post_time(today, match.bulletin_salt)) != :lt
+
+    with false <- posted_today?,
+         true <- due?,
+         channel_id when not is_nil(channel_id) <- RC.Discord.news_channel_id() do
+      cutoff_utc =
+        today
+        |> Bulletin.cutoff_time(match.bulletin_salt)
+        |> EasternTime.to_utc()
+
+      post_bulletin(match, channel_id, today, cutoff_utc)
+    else
+      _ -> :ok
+    end
+  rescue
+    e ->
+      Logger.warning(
+        "[RC.Discord.DailyBulletin] bulletin for instance ##{match.instance_id} failed: " <>
+          Exception.message(e)
+      )
+  end
+
+  # The slot seed must be a stored random secret. Deriving it from
+  # anything observable (timestamps) would let players reconstruct it
+  # from weeks of public post times and predict the hidden cutoff.
+  defp ensure_salt(%Match{bulletin_salt: salt} = match) when is_binary(salt), do: match
+
+  defp ensure_salt(%Match{} = match) do
+    salt = Base.encode16(:crypto.strong_rand_bytes(16), case: :lower)
+
+    {1, _} =
+      Repo.update_all(from(m in Match, where: m.id == ^match.id, where: is_nil(m.bulletin_salt)),
+        set: [bulletin_salt: salt]
+      )
+
+    %{match | bulletin_salt: salt}
+  rescue
+    # Lost a race with a concurrent sweep (can't happen — single
+    # process — but cheap to be exact): re-read the winning salt.
+    _ -> Repo.get!(Match, match.id)
+  end
+
+  defp post_bulletin(%Match{} = match, channel_id, today, cutoff_utc) do
+    events =
+      from(e in BulletinEvent,
+        where: e.instance_id == ^match.instance_id,
+        where: e.inserted_at <= ^cutoff_utc,
+        order_by: e.inserted_at
+      )
+      |> Repo.all()
+
+    window_start = match.bulletin_cutoff_at || match.inserted_at
+    firsts = load_first_lines(match.instance_id, window_start, cutoff_utc)
+
+    instance = Repo.preload(match.instance, [:factions])
+    faction_count = length(instance.factions || [])
+    instance_name = instance.name || "Game ##{match.instance_id}"
+
+    content = Bulletin.render(instance_name, faction_count, events, firsts)
+
+    case Message.create(channel_id, %{content: content}) do
+      {:ok, _msg} ->
+        consume_and_stamp(match, events, today, cutoff_utc)
+
+      {:error, reason} ->
+        # No stamp, no delete — the next tick retries with the same
+        # window.
+        Logger.warning(
+          "[RC.Discord.DailyBulletin] post failed for instance ##{match.instance_id}: " <>
+            inspect(reason)
+        )
+    end
+  end
+
+  # Delete exactly the rows that were rendered and stamp the latch in
+  # one transaction. If this fails (DB blip right after a successful
+  # post), the worst case is ONE duplicate bulletin when the DB
+  # recovers — the alternative (ignoring the stamp result) re-posts
+  # every minute for the rest of the day.
+  defp consume_and_stamp(%Match{} = match, events, today, cutoff_utc) do
+    ids = Enum.map(events, & &1.id)
+
+    result =
+      Repo.transaction(fn ->
+        Repo.delete_all(from(e in BulletinEvent, where: e.id in ^ids))
+
+        Repo.update_all(from(m in Match, where: m.id == ^match.id),
+          set: [bulletin_last_posted_on: today, bulletin_cutoff_at: cutoff_utc]
+        )
+      end)
+
+    case result do
+      {:ok, _} ->
+        Logger.warning(
+          "[RC.Discord.DailyBulletin] posted bulletin for instance ##{match.instance_id} " <>
+            "(#{length(ids)} events, cutoff #{cutoff_utc})"
+        )
+
+      {:error, reason} ->
+        Logger.error(
+          "[RC.Discord.DailyBulletin] posted for instance ##{match.instance_id} but could not " <>
+            "stamp/consume (#{inspect(reason)}); a duplicate bulletin may follow when the DB recovers"
+        )
+    end
+  end
+
+  defp load_first_lines(instance_id, from_dt, to_dt) do
+    # instance_firsts stamps at second precision; truncate the usec
+    # bounds so Ecto can cast the params.
+    from_dt = DateTime.truncate(from_dt, :second)
+    to_dt = DateTime.truncate(to_dt, :second)
+
+    from(f in InstanceFirst,
+      where: f.instance_id == ^instance_id,
+      where: f.inserted_at > ^from_dt,
+      where: f.inserted_at <= ^to_dt,
+      order_by: f.inserted_at,
+      preload: [:winning_faction, winning_registration: :profile]
+    )
+    |> Repo.all()
+    |> Enum.map(fn first ->
+      who =
+        case first.winning_registration do
+          %{profile: %{name: name}} when is_binary(name) -> name
+          _ -> nil
+        end
+
+      faction_ref =
+        case first.winning_faction do
+          %{faction_ref: ref} -> ref
+          _ -> nil
+        end
+
+      Bulletin.first_line(first.first_key, who, faction_ref)
+    end)
+  end
+end

--- a/lib/rc/discord/eastern_time.ex
+++ b/lib/rc/discord/eastern_time.ex
@@ -1,0 +1,46 @@
+defmodule RC.Discord.EasternTime do
+  @moduledoc """
+  Shared US-Eastern wall-clock plumbing for the Discord features (the
+  /promote start-time modal, the daily-bulletin slots). One home for
+  the timezone name, the tz database, and the DST disambiguation
+  policy so every Discord surface agrees on what "12:00 Eastern"
+  means.
+  """
+
+  @timezone "America/New_York"
+  @tz_db Tzdata.TimeZoneDatabase
+
+  @doc "The IANA timezone all Discord scheduling uses."
+  def timezone, do: @timezone
+
+  @doc """
+  Resolve a naive Eastern wall time to a `DateTime`. DST policy:
+  the fall-back repeated hour takes its FIRST occurrence; the
+  spring-forward gap lands just after it.
+  """
+  @spec from_naive(NaiveDateTime.t()) :: {:ok, DateTime.t()} | {:error, term()}
+  def from_naive(%NaiveDateTime{} = naive) do
+    case DateTime.from_naive(naive, @timezone, @tz_db) do
+      {:ok, dt} -> {:ok, dt}
+      {:ambiguous, first, _second} -> {:ok, first}
+      {:gap, _before, after_dt} -> {:ok, after_dt}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc "Same as `from_naive/1` but raises on error."
+  def from_naive!(%NaiveDateTime{} = naive) do
+    {:ok, dt} = from_naive(naive)
+    dt
+  end
+
+  @doc "Shift any DateTime to UTC."
+  def to_utc(%DateTime{} = dt), do: DateTime.shift_zone!(dt, "Etc/UTC", @tz_db)
+
+  @doc "The current civil date in US Eastern."
+  def today do
+    DateTime.utc_now()
+    |> DateTime.shift_zone!(@timezone, @tz_db)
+    |> DateTime.to_date()
+  end
+end

--- a/lib/rc/discord/gov_relay.ex
+++ b/lib/rc/discord/gov_relay.ex
@@ -1,0 +1,336 @@
+defmodule RC.Discord.GovRelay do
+  @moduledoc """
+  Faction-government news for Discord: election lifecycle blasts in
+  the Legacy #news channel, plus leadership role assignment.
+
+  `Instance.Faction.Agent` forwards a curated set of government events
+  here (see `@ceremony_events` — leadership positions and the
+  ceremony/processes around them only; patents, lexes, taxes, policy
+  churn are deliberately NOT broadcast). Casting to the unregistered
+  name (bot off, :test) is a silent no-op.
+
+  ## Seat holders and roles
+
+  When a leadership seat changes hands the relay reconciles the
+  matching Discord role (`@seat_roles`) on the game guild: the
+  displaced holder loses it, the new holder gains it — both only when
+  the player has linked their Discord account. Seat announcements for
+  linked players append their Discord display name in plain text
+  (never an @-mention).
+  """
+
+  use GenServer
+
+  require Logger
+  import Ecto.Query, only: [from: 2]
+
+  alias Nostrum.Api.Guild, as: NostrumGuild
+  alias Nostrum.Api.Message
+  alias RC.Accounts.Account
+  alias RC.Accounts.Profile
+  alias RC.Discord.News
+  alias RC.Repo
+
+  # Government seats that carry a Discord role + announcements.
+  @leadership_seats [:leader, :economy, :military]
+
+  # Role ids on the Legacy game guild (uploaded by the operator).
+  @seat_roles %{
+    leader: 1_528_027_563_862_266_007,
+    economy: 1_528_028_142_734_803_034,
+    military: 1_528_028_233_789_083_760
+  }
+
+  # Event types the faction agent forwards. Everything else in the
+  # government engine stays off Discord.
+  @ceremony_events [
+    :elections_opened,
+    :seat_changed,
+    :election_failed,
+    :revote_opened,
+    :seat_incapacitated,
+    :deposition_started,
+    :deposed,
+    :government_dissolved,
+    :cabinet_dissolved,
+    :crisis_vote_started,
+    :challenge_started,
+    :challenge_defended,
+    :government_overthrown
+  ]
+
+  # --- Public API ------------------------------------------------------
+
+  @doc "Event types worth forwarding from the faction agent."
+  def ceremony_events, do: @ceremony_events
+
+  @doc """
+  Fire-and-forget relay from the faction agent. The agent forwards
+  EVERY settled government event; the ceremony filter lives here (one
+  source of truth next to `render/2`) and non-ceremony events return
+  without casting. A cast to the unregistered name (bot disabled,
+  :test) is a silent no-op.
+  """
+  def post_async(instance_id, faction_key, event) do
+    if is_map(event) and Map.get(event, :type) in @ceremony_events do
+      GenServer.cast(__MODULE__, {:gov_event, instance_id, faction_key, event})
+    end
+
+    :ok
+  end
+
+  def start_link(opts \\ []),
+    do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(_opts), do: {:ok, %{}}
+
+  @impl true
+  def handle_cast({:gov_event, instance_id, faction_key, event}, state) do
+    case RC.Instances.get_instance(instance_id) do
+      %{discord_ready: true, name: instance_name} ->
+        # Resolve the seated/displaced players' Discord identities once
+        # per event — role sync and the announcement decoration share it.
+        identities = seat_identities(event)
+        sync_roles(event, identities)
+
+        event = decorate_seated(event, identities)
+
+        case render(faction_key, event) do
+          nil -> :ok
+          message -> post("🗳️ **#{instance_name}**: #{message}", instance_id)
+        end
+
+      _ ->
+        :ok
+    end
+
+    {:noreply, state}
+  rescue
+    e ->
+      Logger.warning("[RC.Discord.GovRelay] gov event handling crashed: #{inspect(e)}")
+      {:noreply, state}
+  end
+
+  # --- Rendering (pure; unit-tested without the bot) -------------------
+
+  @doc """
+  One short sentence for a government event, or nil for events that
+  don't broadcast (non-leadership seats, plain vacancies). Keep these
+  short and sweet, and free of em-dashes (user rule).
+  """
+  def render(faction_key, event)
+
+  def render(faction_key, %{type: :elections_opened} = event) do
+    seats =
+      (event[:seats] || [])
+      |> Enum.filter(&(&1 in @leadership_seats))
+
+    case seats do
+      [] ->
+        nil
+
+      seats ->
+        "Elections have opened for #{faction(faction_key)}: #{Enum.map_join(seats, ", ", &seat_name/1)}."
+    end
+  end
+
+  def render(faction_key, %{type: :seat_changed, seat: seat, player_id: player_id} = event)
+      when seat in @leadership_seats and not is_nil(player_id) do
+    who = event[:who_display] || event[:name] || "A new holder"
+    "#{who} is now the #{seat_name(seat)} of #{faction(faction_key)}."
+  end
+
+  def render(faction_key, %{type: :election_failed, seat: seat})
+      when seat in @leadership_seats do
+    "The #{seat_name(seat)} election for #{faction(faction_key)} has failed. The seat stays open."
+  end
+
+  def render(faction_key, %{type: :revote_opened, seat: seat} = event)
+      when seat in @leadership_seats do
+    round_note = if event[:round], do: " (round #{event[:round]})", else: ""
+    "A new vote for the #{seat_name(seat)} of #{faction(faction_key)} has opened#{round_note}."
+  end
+
+  def render(faction_key, %{type: :seat_incapacitated, seat: seat} = event)
+      when seat in @leadership_seats do
+    who = event[:name] || "The holder"
+    "#{who} no longer holds the #{seat_name(seat)} seat of #{faction(faction_key)}."
+  end
+
+  def render(faction_key, %{type: :deposition_started, seat: seat})
+      when seat in @leadership_seats do
+    "A vote to depose the #{seat_name(seat)} of #{faction(faction_key)} has begun."
+  end
+
+  def render(faction_key, %{type: :deposed, seat: seat} = event)
+      when seat in @leadership_seats do
+    who = event[:name] || "The holder"
+    "#{who} has been deposed as the #{seat_name(seat)} of #{faction(faction_key)}."
+  end
+
+  def render(faction_key, %{type: :government_dissolved}),
+    do: "The government of #{faction(faction_key)} has been dissolved."
+
+  def render(faction_key, %{type: :cabinet_dissolved}),
+    do: "The cabinet of #{faction(faction_key)} has been dissolved."
+
+  def render(faction_key, %{type: :crisis_vote_started}),
+    do: "A crisis vote against the leadership of #{faction(faction_key)} has begun."
+
+  def render(faction_key, %{type: :challenge_started} = event) do
+    who = event[:name] || "A challenger"
+    "#{who} has launched a challenge for the leadership of #{faction(faction_key)}."
+  end
+
+  def render(faction_key, %{type: :challenge_defended}) do
+    "The leadership of #{faction(faction_key)} has defended its position. The challenge failed."
+  end
+
+  def render(faction_key, %{type: :government_overthrown} = event) do
+    who = event[:name] || "A challenger"
+    "#{who} has overthrown the government of #{faction(faction_key)}."
+  end
+
+  def render(_faction_key, _event), do: nil
+
+  defp faction(key), do: News.faction_display(to_string(key))
+
+  defp seat_name(:leader), do: "Leader"
+  defp seat_name(:economy), do: "Head of Economy"
+  defp seat_name(:military), do: "Head of Military"
+  defp seat_name(other), do: other |> to_string() |> String.capitalize()
+
+  # --- Seat identity resolution ----------------------------------------
+
+  # One DB lookup per involved player per event: %{new: discord_id |
+  # nil, prev: discord_id | nil}. Only seat_changed events on
+  # leadership seats involve identities.
+  defp seat_identities(%{type: :seat_changed, seat: seat} = event)
+       when seat in @leadership_seats do
+    %{
+      new: event |> Map.get(:player_id) |> discord_id_for_profile(),
+      prev: event |> Map.get(:previous) |> holder_id() |> discord_id_for_profile()
+    }
+  end
+
+  defp seat_identities(_event), do: %{new: nil, prev: nil}
+
+  # For a freshly seated player with a linked Discord account, append
+  # their Discord display name in plain text ("Nova (Discord: kurtz)").
+  # Never an @-mention (user rule).
+  defp decorate_seated(%{type: :seat_changed, seat: seat, player_id: player_id, name: name} = event, %{
+         new: discord_id
+       })
+       when seat in @leadership_seats and not is_nil(player_id) and not is_nil(discord_id) do
+    who =
+      case member_display_name(discord_id) do
+        nil -> name
+        display -> "#{name} (Discord: #{display})"
+      end
+
+    Map.put(event, :who_display, who)
+  end
+
+  defp decorate_seated(event, _identities), do: event
+
+  # --- Leadership role sync --------------------------------------------
+
+  defp sync_roles(%{type: :seat_changed, seat: seat} = event, identities)
+       when seat in @leadership_seats do
+    role_id = Map.fetch!(@seat_roles, seat)
+
+    case RC.Discord.game_guild_id() do
+      nil ->
+        :ok
+
+      guild_id ->
+        same_player? =
+          Map.get(event, :player_id) != nil and
+            Map.get(event, :player_id) == event |> Map.get(:previous) |> holder_id()
+
+        if identities.prev != nil and not same_player? do
+          change_role(:remove, guild_id, identities.prev, role_id, seat)
+        end
+
+        if identities.new != nil do
+          change_role(:add, guild_id, identities.new, role_id, seat)
+        end
+
+        :ok
+    end
+  end
+
+  defp sync_roles(_event, _identities), do: :ok
+
+  defp holder_id(%{player_id: id}), do: id
+  defp holder_id(_), do: nil
+
+  defp change_role(op, guild_id, discord_id, role_id, seat) do
+    user_id = String.to_integer(to_string(discord_id))
+
+    result =
+      case op do
+        :add -> NostrumGuild.add_member_role(guild_id, user_id, role_id)
+        :remove -> NostrumGuild.remove_member_role(guild_id, user_id, role_id)
+      end
+
+    case result do
+      {:ok} ->
+        Logger.info("[RC.Discord.GovRelay] #{op} #{seat} role for #{discord_id}")
+
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "[RC.Discord.GovRelay] #{op} #{seat} role failed for #{discord_id}: #{inspect(reason)}"
+        )
+    end
+  end
+
+  # --- Identity plumbing -----------------------------------------------
+
+  # Government player_ids are profile ids; a profile hangs off an
+  # account, which may carry a Discord link. Single joined query.
+  defp discord_id_for_profile(nil), do: nil
+
+  defp discord_id_for_profile(profile_id) do
+    from(p in Profile,
+      join: a in Account,
+      on: a.id == p.account_id,
+      where: p.id == ^profile_id,
+      select: a.discord_id
+    )
+    |> Repo.one()
+  end
+
+  defp member_display_name(discord_id) do
+    with guild_id when not is_nil(guild_id) <- RC.Discord.game_guild_id(),
+         {:ok, member} <- NostrumGuild.member(guild_id, String.to_integer(to_string(discord_id))) do
+      user = Map.get(member, :user) || %{}
+
+      Map.get(member, :nick) || Map.get(user, :global_name) || Map.get(user, :username)
+    else
+      _ -> nil
+    end
+  end
+
+  defp post(content, instance_id) do
+    case RC.Discord.news_channel_id() do
+      nil ->
+        :ok
+
+      channel_id ->
+        case Message.create(channel_id, %{content: content}) do
+          {:ok, _msg} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning(
+              "[RC.Discord.GovRelay] post failed (instance ##{instance_id}): #{inspect(reason)}"
+            )
+        end
+    end
+  end
+end

--- a/lib/rc/discord/legacy_match.ex
+++ b/lib/rc/discord/legacy_match.ex
@@ -63,6 +63,18 @@ defmodule RC.Discord.LegacyMatch do
     "ask-anything"
   ]
 
+  # Short faction tags used to name pairwise diplomacy channels
+  # (#ark-card, #card-myr, …) — mirrors the hand-made channels from
+  # the first 3-faction Legacy match. Sorted alphabetically inside a
+  # pair so the same two factions always produce the same name.
+  @faction_abbrevs %{
+    "ark" => "ark",
+    "cardan" => "card",
+    "myrmezir" => "myr",
+    "synelle" => "syn",
+    "tetrarchy" => "tet"
+  }
+
   # Game faction key → list of substring patterns to match against
   # Discord role names. Match is case-insensitive; a role is accepted
   # if its name contains EVERY pattern in the list. So `tetrarchy` +
@@ -138,12 +150,75 @@ defmodule RC.Discord.LegacyMatch do
   # Discord caps select menus at 25 options.
   @select_menu_cap 25
 
+  # Sanity window for the entered start time: -1 day .. +60 days.
+  # Catches typo years without restricting real scheduling freedom.
+  @start_time_past_slack_s 86_400
+  @start_time_future_cap_s 60 * 86_400
+
   # --- Public API ------------------------------------------------------
 
   @doc """
   Returns the faction-key → role-pattern-list map.
   """
   def faction_role_patterns, do: @faction_role_patterns
+
+  @doc """
+  Parse the operator-entered start time from the /promote modal.
+
+  Accepts either:
+
+    * `"YYYY-MM-DD HH:MM"` (24h) — wall-clock US Eastern time
+      (America/New_York, so EST/EDT is handled), or
+    * a bare unix timestamp in seconds.
+
+  Returns `{:ok, %DateTime{}}` in UTC, or `{:error, :bad_format}` /
+  `{:error, :out_of_range}`. The range check (-1 day .. +60 days from
+  `now`) guards against typo years producing absurd announcements.
+  """
+  @spec parse_start_time(String.t(), DateTime.t()) ::
+          {:ok, DateTime.t()} | {:error, :bad_format | :out_of_range}
+  def parse_start_time(input, now \\ DateTime.utc_now()) when is_binary(input) do
+    input = String.trim(input)
+
+    parsed =
+      cond do
+        Regex.match?(~r/^\d{9,11}$/, input) ->
+          DateTime.from_unix(String.to_integer(input))
+
+        true ->
+          parse_eastern_wall_time(input)
+      end
+
+    case parsed do
+      {:ok, dt} ->
+        diff = DateTime.diff(dt, now)
+
+        if diff < -@start_time_past_slack_s or diff > @start_time_future_cap_s,
+          do: {:error, :out_of_range},
+          else: {:ok, RC.Discord.EasternTime.to_utc(dt)}
+
+      {:error, _} ->
+        {:error, :bad_format}
+    end
+  end
+
+  defp parse_eastern_wall_time(input) do
+    with [_, y, mo, d, h, mi] <-
+           Regex.run(~r/^(\d{4})-(\d{1,2})-(\d{1,2})[ T](\d{1,2}):(\d{2})$/, input),
+         {:ok, naive} <-
+           NaiveDateTime.new(
+             String.to_integer(y),
+             String.to_integer(mo),
+             String.to_integer(d),
+             String.to_integer(h),
+             String.to_integer(mi),
+             0
+           ) do
+      RC.Discord.EasternTime.from_naive(naive)
+    else
+      _ -> {:error, :bad_format}
+    end
+  end
 
   @doc """
   Given a faction_ref string and a map of `%{role_name => role_id}`
@@ -283,9 +358,9 @@ defmodule RC.Discord.LegacyMatch do
   cross-channel transaction. Phase 3 will provide a teardown command;
   for Phase 1, the operator can manually delete stuck channels.
   """
-  @spec promote(integer(), String.t() | integer()) ::
+  @spec promote(integer(), String.t() | integer(), keyword()) ::
           {:ok, Match.t()} | {:error, term()}
-  def promote(instance_id, promoter_discord_id) when is_integer(instance_id) do
+  def promote(instance_id, promoter_discord_id, opts \\ []) when is_integer(instance_id) do
     with {:ok, instance} <- load_eligible_instance(instance_id),
          {:ok, guild_id} <- fetch_game_guild_id(),
          {:ok, bot_user_id} <- fetch_bot_user_id(),
@@ -297,11 +372,22 @@ defmodule RC.Discord.LegacyMatch do
              instance,
              roles_by_name
            ),
+         # Best-effort by design: once faction categories exist, the
+         # promotion MUST reach insert_match so the Match row records
+         # them — aborting here would orphan channels no /teardown can
+         # find, and a retried /promote would duplicate everything.
+         # Partial diplo results are recorded; the count in the
+         # operator's reply is the tell that something failed.
+         diplo = create_diplomacy_channels_best_effort(guild_id, bot_user_id, instance, roles_by_name),
          {:ok, match} <-
-           insert_match(instance.id, faction_categories, to_string(promoter_discord_id)) do
+           insert_match(instance.id, faction_categories, to_string(promoter_discord_id),
+             diplo: diplo,
+             announced_start_at: Keyword.get(opts, :announced_start_at)
+           ) do
       Logger.info(
         "[RC.Discord.LegacyMatch] promoted instance ##{instance.id} (#{instance.name}) " <>
-          "with #{map_size(faction_categories)} faction categories"
+          "with #{map_size(faction_categories)} faction categories and " <>
+          "#{map_size(diplo.channels)} diplomacy channels"
       )
 
       # Community announcement is NOT posted here — it fires on
@@ -429,6 +515,112 @@ defmodule RC.Discord.LegacyMatch do
     end)
   end
 
+  # --- Pairwise diplomacy channels (matches with > 2 factions) --------
+  #
+  # In a 2-faction match the enemy is the only other faction, so a
+  # shared channel adds nothing. With 3+ factions each PAIR gets a
+  # private text channel (#ark-card, #ark-myr, #card-myr, …) where the
+  # two factions can talk without the rest of the galaxy listening in.
+  #
+  # Placement: under the operator's standing diplomacy category when
+  # `DISCORD_DIPLO_CATEGORY_ID` is configured (prod: the diplo-ground
+  # category), else under a bot-created per-match category. The Match
+  # row tracks channel ids individually so teardown removes exactly
+  # what the bot created and never touches operator-made channels.
+  #
+  # BEST-EFFORT: failures log and skip, they never abort the
+  # promotion — by this point the faction categories already exist on
+  # the guild, and aborting before insert_match would orphan them
+  # (no Match row = no /teardown, and a retried /promote duplicates
+  # everything). Whatever was created is returned and recorded.
+  defp create_diplomacy_channels_best_effort(guild_id, bot_user_id, instance, roles_by_name) do
+    refs = instance.factions |> Enum.map(& &1.faction_ref) |> Enum.sort()
+
+    if length(refs) <= 2 do
+      %{category_id: nil, channels: %{}}
+    else
+      case resolve_diplo_category(guild_id, bot_user_id, instance) do
+        {:ok, category_id, created?} ->
+          channels = create_diplo_pair_channels(guild_id, bot_user_id, category_id, refs, roles_by_name)
+
+          %{
+            category_id: if(created?, do: to_string(category_id)),
+            channels: channels
+          }
+
+        {:error, reason} ->
+          Logger.warning(
+            "[RC.Discord.LegacyMatch] diplomacy category creation failed for " <>
+              "instance ##{instance.id}: #{inspect(reason)} — promoting without diplomacy channels"
+          )
+
+          %{category_id: nil, channels: %{}}
+      end
+    end
+  end
+
+  defp resolve_diplo_category(guild_id, bot_user_id, instance) do
+    case RC.Discord.diplo_category_id() do
+      nil ->
+        overwrites = build_overwrites(guild_id, bot_user_id, nil)
+
+        case Channel.create(guild_id,
+               name: "DIPLOMACY - LEGACY: #{instance.name || "##{instance.id}"}",
+               type: @channel_type_category,
+               permission_overwrites: overwrites
+             ) do
+          {:ok, %{id: category_id}} -> {:ok, category_id, true}
+          {:error, reason} -> {:error, reason}
+        end
+
+      category_id ->
+        {:ok, category_id, false}
+    end
+  end
+
+  defp create_diplo_pair_channels(guild_id, bot_user_id, category_id, refs, roles_by_name) do
+    pairs = for a <- refs, b <- refs, a < b, do: {a, b}
+
+    Enum.reduce(pairs, %{}, fn {a, b}, acc ->
+      name = "#{diplo_abbrev(a)}-#{diplo_abbrev(b)}"
+
+      # A pair channel carries its own full overwrite set (explicit
+      # overwrites replace category inheritance): @everyone denied,
+      # bot allowed, both factions' roles allowed.
+      role_overwrites =
+        [a, b]
+        |> Enum.map(&resolve_faction_role(&1, roles_by_name))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.map(fn role_id ->
+          %{id: role_id, type: @overwrite_type_role, allow: @faction_role_allow, deny: 0}
+        end)
+
+      overwrites = build_overwrites(guild_id, bot_user_id, nil) ++ role_overwrites
+
+      case Channel.create(guild_id,
+             name: name,
+             type: @channel_type_text,
+             parent_id: category_id,
+             permission_overwrites: overwrites
+           ) do
+        {:ok, %{id: channel_id}} ->
+          Map.put(acc, name, to_string(channel_id))
+
+        {:error, reason} ->
+          # Skip and continue — a partial pair set beats an aborted
+          # promotion. The success reply's channel count is the alarm.
+          Logger.warning(
+            "[RC.Discord.LegacyMatch] diplomacy channel ##{name} failed: #{inspect(reason)}"
+          )
+
+          acc
+      end
+    end)
+  end
+
+  defp diplo_abbrev(faction_ref),
+    do: Map.get(@faction_abbrevs, faction_ref, String.slice(faction_ref, 0, 4))
+
   # Always includes:
   #   - @everyone (= guild_id role) denied VIEW_CHANNEL
   #   - bot user explicitly allowed View + Manage + Send + Embed,
@@ -511,9 +703,25 @@ defmodule RC.Discord.LegacyMatch do
   # categories, deletes children then categories. Returns a count.
   # Errors during deletion are accumulated but the loop continues —
   # partial deletion is better than abandoned channels.
-  defp delete_match_channels(guild_id, %Match{faction_categories: faction_categories}) do
+  #
+  # Diplomacy cleanup: a bot-created diplomacy category joins the
+  # target set (its pair channels are its children). When the pair
+  # channels live under an operator-owned category instead, only the
+  # individually tracked channel ids are deleted — never the category
+  # or any operator-made sibling.
+  defp delete_match_channels(guild_id, %Match{faction_categories: faction_categories} = match) do
     target_category_ids =
       faction_categories
+      |> Map.values()
+      |> Kernel.++(List.wrap(Map.get(match, :diplomacy_category_id)))
+      |> Enum.map(&parse_snowflake/1)
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    tracked_channel_ids =
+      match
+      |> Map.get(:diplo_channels)
+      |> Kernel.||(%{})
       |> Map.values()
       |> Enum.map(&parse_snowflake/1)
       |> Enum.reject(&is_nil/1)
@@ -524,7 +732,10 @@ defmodule RC.Discord.LegacyMatch do
         children =
           Enum.filter(channels, fn ch ->
             parent_id = Map.get(ch, :parent_id) || Map.get(ch, "parent_id")
-            parent_id != nil and MapSet.member?(target_category_ids, parent_id)
+            channel_id = Map.get(ch, :id) || Map.get(ch, "id")
+
+            (parent_id != nil and MapSet.member?(target_category_ids, parent_id)) or
+              (channel_id != nil and MapSet.member?(tracked_channel_ids, channel_id))
           end)
 
         {channels_deleted, channel_errors} = delete_each(children)
@@ -630,7 +841,7 @@ defmodule RC.Discord.LegacyMatch do
         :no_channel
 
       channel_id ->
-        embed = build_announcement_embed(kind, match.instance)
+        embed = build_announcement_embed(kind, match)
 
         case Message.create(channel_id, %{embeds: [embed]}) do
           {:ok, _msg} ->
@@ -666,25 +877,31 @@ defmodule RC.Discord.LegacyMatch do
     end
   end
 
-  defp build_announcement_embed(:registration, instance) do
-    opening_unix = DateTime.to_unix(instance.opening_date)
+  defp build_announcement_embed(:registration, match) do
+    instance = match.instance
+
+    # The operator-entered start time from the /promote modal is the
+    # authoritative one; opening_date is the site-side plan and has
+    # historically not matched real start times.
+    start_at = Map.get(match, :announced_start_at) || instance.opening_date
+    start_unix = DateTime.to_unix(start_at)
 
     base_embed(instance,
       title: "📜 Registration open: #{instance.name || "##{instance.id}"}",
       description:
         "A new community-wide Legacy game is open for registration. " <>
-          "The game will begin in 24hrs.",
+          "The game begins <t:#{start_unix}:R>.",
       extra_fields: [
         %{
-          name: "Opens",
-          value: "<t:#{opening_unix}:F> (<t:#{opening_unix}:R>)",
+          name: "Game starts",
+          value: "<t:#{start_unix}:F> (<t:#{start_unix}:R>)",
           inline: false
         }
       ]
     )
   end
 
-  defp build_announcement_embed(:live, instance) do
+  defp build_announcement_embed(:live, %{instance: instance}) do
     base_embed(instance,
       title: "🚀 Game is live: #{instance.name || "##{instance.id}"}",
       description:
@@ -723,12 +940,17 @@ defmodule RC.Discord.LegacyMatch do
 
   # --- Bookkeeping ----------------------------------------------------
 
-  defp insert_match(instance_id, faction_categories, promoter_discord_id) do
+  defp insert_match(instance_id, faction_categories, promoter_discord_id, opts) do
+    diplo = Keyword.get(opts, :diplo, %{category_id: nil, channels: %{}})
+
     %Match{}
     |> Match.changeset(%{
       instance_id: instance_id,
       faction_categories: faction_categories,
-      promoted_by_discord_id: promoter_discord_id
+      promoted_by_discord_id: promoter_discord_id,
+      diplomacy_category_id: diplo.category_id,
+      diplo_channels: diplo.channels,
+      announced_start_at: Keyword.get(opts, :announced_start_at)
     })
     |> Repo.insert()
     |> case do

--- a/lib/rc/discord/match.ex
+++ b/lib/rc/discord/match.ex
@@ -34,6 +34,24 @@ defmodule RC.Discord.Match do
     # post went out at that time.
     field(:announced_registration_at, :utc_datetime_usec)
     field(:announced_live_at, :utc_datetime_usec)
+    # Operator-entered start time from the /promote modal. The
+    # registration announcement renders this (opening_date has never
+    # reliably matched real start times).
+    field(:announced_start_at, :utc_datetime_usec)
+    # Pairwise inter-faction diplomacy channels (matches with > 2
+    # factions). `diplo_channels` maps channel name → snowflake string;
+    # `diplomacy_category_id` is set only when the bot created its own
+    # category (nil = channels live under an operator-owned category),
+    # so teardown deletes exactly what the bot created.
+    field(:diplomacy_category_id, :string)
+    field(:diplo_channels, :map, default: %{})
+    # Daily-summary bulletin bookkeeping: the once-a-day posted latch,
+    # the cutoff high-water mark of events already summarized, and the
+    # random per-match secret seeding the daily slots (stored — never
+    # derivable from anything players can observe).
+    field(:bulletin_last_posted_on, :date)
+    field(:bulletin_cutoff_at, :utc_datetime_usec)
+    field(:bulletin_salt, :string)
 
     belongs_to(:instance, RC.Instances.Instance)
 
@@ -49,7 +67,13 @@ defmodule RC.Discord.Match do
       :promoted_by_discord_id,
       :role_assignment_active,
       :announced_registration_at,
-      :announced_live_at
+      :announced_live_at,
+      :announced_start_at,
+      :diplomacy_category_id,
+      :diplo_channels,
+      :bulletin_last_posted_on,
+      :bulletin_cutoff_at,
+      :bulletin_salt
     ])
     |> validate_required([:instance_id, :faction_categories, :promoted_by_discord_id])
     |> unique_constraint(:instance_id)

--- a/lib/rc/discord/news.ex
+++ b/lib/rc/discord/news.ex
@@ -9,25 +9,41 @@ defmodule RC.Discord.News do
   ## Broadcast semantics
 
   \\#news is a **general-broadcast** channel — every player from every
-  faction can read it. Messages therefore render ONLY the public tier
-  of each story, mirroring the `news.*.public` templates in
-  `front/src/locales/en/portal.json` (keep the two in sync when
-  wording changes). The payloads arriving here are already stripped by
+  faction can read it. The immediate feed is deliberately narrow
+  (player decision 2026-07): only events every player can already see
+  on the galaxy map — sector control changes, colonizations, dominion
+  flips, and victory-point movements — post the moment they happen.
+  Battles, raids, pillages, conquests, and galaxy firsts are withheld
+  and land in the once-a-day summary (`RC.Discord.DailyBulletin`).
+
+  The payloads arriving here are already stripped by
   `Game.News.Server.publish/3` (no attacker faction on covert ops, no
   winner bookkeeping), so even a template bug can't leak more than the
   public payload contains.
 
   Faction names render with their custom guild emoji appended, e.g.
-  `Tetrarchy <:tetrarchy:1521144218742034463>`.
+  `Tetrarchy <:tetrarchy:1521144218742034463>`. The community server
+  and the Legacy game server are separate Discords with separate
+  emoji uploads, hence two maps.
   """
 
-  # Custom emoji in the community guild, one per playable faction.
+  # Custom emoji in the Legacy game guild, one per playable faction.
   @faction_emoji %{
     "ark" => "<:ark:1521144064374739145>",
     "cardan" => "<:cardan:1521144119605329961>",
     "myrmezir" => "<:myrmezir:1521144307728519208>",
     "synelle" => "<:synelle:1521144259015868577>",
     "tetrarchy" => "<:tetrarchy:1521144218742034463>"
+  }
+
+  # Custom emoji in the community guild (separate Discord, separate
+  # uploads — used for the victory announcement there).
+  @community_faction_emoji %{
+    "ark" => "<:ark:1528019447812456519>",
+    "cardan" => "<:cardan:1528019517744091136>",
+    "myrmezir" => "<:myrmezir:1528019561117516013>",
+    "synelle" => "<:synelle:1528019609725435934>",
+    "tetrarchy" => "<:tetrarchy:1528019668617658458>"
   }
 
   # Display names live in the frontend locale files; the backend Data
@@ -40,22 +56,11 @@ defmodule RC.Discord.News do
     "tetrarchy" => "Tetrarchy"
   }
 
-  @building_names %{
-    "high_factory_dome" => "Metamaterials Factory",
-    "monument_dome" => "Monolith"
-  }
-
-  @ship_names %{
-    "capital_1" => "Destroyer",
-    "capital_2" => "Cruiser",
-    "capital_3" => "Coordinator"
-  }
-
   @doc """
   Fire-and-forget relay. Casts to `RC.Discord.NewsRelay`, which owns
-  Discord's dedup policy (battle roll-up by message edit) and the
-  actual API calls. Casting to the unregistered name (bot disabled,
-  :test) is a silent no-op — GenServer.cast never fails.
+  the gating (channel configured + `discord_ready`) and the actual API
+  calls. Casting to the unregistered name (bot disabled, :test) is a
+  silent no-op — GenServer.cast never fails.
   """
   def post_async(instance_id, bulletin_key, payload) do
     GenServer.cast(RC.Discord.NewsRelay, {:bulletin, instance_id, bulletin_key, payload})
@@ -63,70 +68,42 @@ defmodule RC.Discord.News do
   end
 
   @doc """
-  Aggregated battle line for the roll-up message.
-
-  `counts` maps sector name → engagement count; `records` maps
-  `{player_name, faction_key}` → `{wins, losses}` accumulated inside
-  the current roll-up window (never all-time).
-
-  A lone battle reads as a story naming victor and vanquished; from
-  the second battle on, the line becomes a per-sector tally plus each
-  involved player's window record.
+  Fire-and-forget victory announcement. `info` carries `:winner`
+  (faction key atom or string), `:victory_points`, `:victory_type`.
+  The relay posts to BOTH the community announce channel (community
+  emoji) and the Legacy #news channel (game-guild emoji).
   """
-  def battle_rollup(counts, records \\ %{})
-
-  def battle_rollup(counts, records) when map_size(counts) == 1 do
-    case {Map.to_list(counts), split_single_battle(records)} do
-      {[{sector, 1}], {[_ | _] = winners, [_ | _] = losers}} ->
-        "A skirmish took place in sector #{sector} — " <>
-          "#{player_list(winners)} defeated #{player_list(losers)}."
-
-      {[{sector, 1}], _} ->
-        "A small skirmish took place in sector #{sector}."
-
-      {[{sector, n}], _} ->
-        "Fleet engagements reported in sector #{sector} ×#{n}#{records_suffix(records)}"
-    end
+  def post_victory_async(instance_id, info) do
+    GenServer.cast(RC.Discord.NewsRelay, {:victory, instance_id, info})
+    :ok
   end
 
-  def battle_rollup(counts, records) do
-    tally =
-      counts
-      |> Enum.sort_by(fn {sector, n} -> {-n, sector} end)
-      |> Enum.map_join(", ", fn {sector, n} -> "sector #{sector} ×#{n}" end)
+  @doc """
+  Victory announcement embed. `guild` picks the emoji upload set:
+  `:community` or `:game` (separate Discords, separate emoji ids).
 
-    "Fleet engagements reported: #{tally}#{records_suffix(records)}"
+  Wording per user spec 2026-07-18 — title "Congrats to [FACTION]!",
+  body "[Scenario] has concluded in a victory with [VP] VP in favor
+  of [emoji][faction]." No other emoji.
+  """
+  def victory_embed(scenario_name, faction_key, victory_points, guild)
+      when guild in [:community, :game] do
+    key = to_string(faction_key)
+    name = Map.get(@faction_names, key, key)
+    emoji_map = if guild == :community, do: @community_faction_emoji, else: @faction_emoji
+    emoji = Map.get(emoji_map, key, "")
+
+    %{
+      title: "Congrats to #{name}!",
+      description:
+        "#{scenario_name} has concluded in a victory with #{victory_points} VP " <>
+          "in favor of #{emoji}#{name}.",
+      color: 0x57F287,
+      footer: %{text: "Marat · Friend of the People"}
+    }
   end
 
-  # A single battle's records split cleanly into pure winners (1-0)
-  # and pure losers (0-1). Anything else (draw, missing data) falls
-  # back to the anonymous line.
-  defp split_single_battle(records) do
-    {Enum.filter(records, fn {_, {w, l}} -> w > 0 and l == 0 end) |> Enum.map(&elem(&1, 0)),
-     Enum.filter(records, fn {_, {w, l}} -> l > 0 and w == 0 end) |> Enum.map(&elem(&1, 0))}
-  end
-
-  defp player_list(players),
-    do: Enum.map_join(players, ", ", fn {name, faction} -> player_display(name, faction) end)
-
-  defp records_suffix(records) when map_size(records) == 0, do: "."
-
-  defp records_suffix(records) do
-    line =
-      records
-      |> Enum.sort_by(fn {{name, _f}, {w, l}} -> {-w, l, name} end)
-      |> Enum.map_join(" · ", fn {{name, faction}, {w, l}} ->
-        "#{player_display(name, faction)} #{record_label(w, l)}"
-      end)
-
-    " — #{line}."
-  end
-
-  defp record_label(w, 0), do: "#{w}W"
-  defp record_label(0, l), do: "#{l}L"
-  defp record_label(w, l), do: "#{w}W #{l}L"
-
-  @doc "Player name with their faction's guild emoji appended."
+  @doc "Player name with their faction's game-guild emoji appended."
   def player_display(name, faction_key) do
     case Map.get(@faction_emoji, faction_key) do
       nil -> to_string(name)
@@ -134,29 +111,50 @@ defmodule RC.Discord.News do
     end
   end
 
-  @doc """
-  Render the public-tier headline for a bulletin, or nil for kinds
-  that don't post to Discord. Pure — unit-tested without the bot.
+  # Roll-up lines: when one faction colonizes / flips several systems
+  # in quick succession, the relay EDITS its previous message into one
+  # aggregated line instead of posting again (anti-flood — same policy
+  # the old battle roll-up enforced).
 
-  Wording mirrors the `news.*.public` templates in
-  front/src/locales/en/portal.json.
+  @rollup_max_names 8
+
+  @doc "Aggregated colonization line for a roll-up window."
+  def colonized_rollup(faction_key, system_names) do
+    "#{faction_display(faction_key)} has colonized #{length(system_names)} systems: #{name_list(system_names)}."
+  end
+
+  @doc "Aggregated dominion line for a roll-up window."
+  def dominion_rollup(faction_key, system_names) do
+    "#{faction_display(faction_key)} has taken #{length(system_names)} dominions: #{name_list(system_names)}."
+  end
+
+  defp name_list(names) do
+    {shown, dropped} = Enum.split(Enum.uniq(names), @rollup_max_names)
+
+    case dropped do
+      [] -> Enum.join(shown, ", ")
+      more -> Enum.join(shown, ", ") <> " and #{length(more)} more"
+    end
+  end
+
+  @doc """
+  Render the immediate-feed headline for a bulletin, or nil for kinds
+  that don't post to Discord instantly. Pure — unit-tested without
+  the bot.
+
+  Only publicly-visible-on-the-map events render here (sector control,
+  colonization, dominion flips, victory points). Battles, raids,
+  pillages, conquests, covert ops, and galaxy firsts return nil — they
+  are withheld from the instant feed and surface in the daily summary
+  bulletin instead (player decision 2026-07).
   """
   def render(bulletin_key, payload)
-
-  def render("news.colonize.first", p),
-    do: "#{faction(p)} has founded the galaxy's first new colony, on #{system(p)}."
-
-  def render("news.dominion.first", p),
-    do: "#{faction(p)} has taken the galaxy's first dominion. #{system(p)} now answers to foreign rule."
 
   def render("news.dominion.liberated", p),
     do: "#{system(p)} has been freely liberated from #{faction(p)} control."
 
   def render("news.system.abandoned", p),
     do: "#{faction(p)} has abandoned #{system(p)}."
-
-  def render("news.conquest", p),
-    do: "A system in sector #{sector(p)} has fallen to #{faction(p)} after a siege."
 
   def render("news.sector.flipped", p),
     do: "#{faction(p)} has taken control of sector #{sector(p)} from #{faction_display(p[:prev_faction])}."
@@ -167,61 +165,34 @@ defmodule RC.Discord.News do
   def render("news.sector.lost", p),
     do: "#{faction_display(p[:prev_faction])} has lost control of sector #{sector(p)}."
 
-  def render("news.raid", p),
-    do: "An orbital bombardment has been reported in sector #{sector(p)}."
+  # Every colonization, not just the galaxy first — settled ownership
+  # is public map knowledge in-game, so Discord may name it too.
+  def render("discord.colonized", p),
+    do: "#{faction(p)} has colonized #{system(p)}."
 
-  def render("news.raid.summary", p),
-    do: "Bombardments continue in sector #{sector(p)}. At least #{p[:count]} more strikes have been reported."
-
-  def render("news.battle", p),
-    do: "A small skirmish took place in sector #{sector(p)}."
-
-  def render("news.battle.summary", p),
-    do: "Fighting continues in sector #{sector(p)}. At least #{p[:count]} more engagements have been reported."
-
-  def render("news.agent.assassinated", p) do
-    "Governor #{p[:target_name]}, one of the most distinguished administrators in the galaxy, " <>
-      "has been assassinated. There are no suspects."
+  def render("discord.dominion", p) do
+    case p[:prev_faction] do
+      nil -> "#{faction(p)} has taken #{system(p)} as a dominion."
+      prev -> "#{faction(p)} has taken the dominion of #{system(p)} from #{faction_display(prev)}."
+    end
   end
 
-  def render("news.agent.converted", p) do
-    "Governor #{p[:target_name]}, long admired throughout the galaxy, has renounced their post. " <>
-      "No explanation has been given."
+  # Victory-track movement — the in-game victory panel shows this to
+  # everyone, so the bot may announce it the moment a star changes.
+  def render("discord.vp_changed", p) do
+    verb = if (p[:vp] || 0) >= (p[:prev_vp] || 0), do: "risen", else: "fallen"
+    "#{faction(p)} has #{verb} to #{p[:vp]} victory points."
   end
 
-  def render("news.faction.erased", p),
-    do: "#{faction(p)} has trained a formidable shadow organization to safeguard their systems from spies."
-
-  def render("news.faction.navarchs", p),
-    do: "#{faction(p)} has assembled a formidable corps of Navarchs to command its fleets across the galaxy."
-
-  def render("news.faction.siderians", p),
-    do: "#{faction(p)} has cultivated a formidable circle of Siderians to sway hearts and minds across the galaxy."
-
-  def render("news.building.first", p),
-    do: "#{faction(p)} has completed the galaxy's first #{building(p)}, on #{system(p)}."
-
-  def render("news.ship.capital", p),
-    do: "#{faction(p)} employs the #{ship(p)} to mark a new age of ship warfare."
-
-  def render("news.income.first", p),
-    do: "#{faction(p)} is the first to raise its #{p[:resource]} output above 100."
-
-  def render("news.credit.first", p),
-    do: "The treasury of #{faction(p)} is the first to exceed ten million credits."
-
-  def render("news.doctrine.first", p),
-    do: "#{faction(p)} is the first to bring fifteen lexes into law."
-
-  # Unknown bulletin kinds stay off Discord — a generic "something
-  # happened" line is noise in a chat channel (unlike the in-game
-  # ticker, where the fallback keeps layout stable).
+  # Everything else stays off the instant feed: battles, raids,
+  # pillages, conquests, and firsts belong to the daily bulletin;
+  # covert-ops stories stay in-game only.
   def render(_key, _payload), do: nil
 
   ## Param helpers — nil-tolerant so a malformed payload degrades the
   ## sentence, never crashes the relay.
 
-  @doc "Faction display name with its guild emoji appended."
+  @doc "Faction display name with its game-guild emoji appended."
   def faction_display(key) when is_binary(key) do
     name = Map.get(@faction_names, key, key)
 
@@ -233,9 +204,15 @@ defmodule RC.Discord.News do
 
   def faction_display(_), do: "An unknown power"
 
+  @doc "Bare display name (no emoji) for a faction key."
+  def faction_name(key) when is_binary(key), do: Map.get(@faction_names, key, key)
+  def faction_name(key), do: faction_name(to_string(key))
+
+  @doc "Game-guild emoji string for a faction key, or empty string."
+  def faction_emoji(key) when is_binary(key), do: Map.get(@faction_emoji, key, "")
+  def faction_emoji(key), do: faction_emoji(to_string(key))
+
   defp faction(p), do: faction_display(p[:faction])
   defp system(p), do: p[:system_name] || "an uncharted system"
   defp sector(p), do: p[:sector_name] || "an uncharted region"
-  defp building(p), do: Map.get(@building_names, p[:building], p[:building])
-  defp ship(p), do: Map.get(@ship_names, p[:ship], p[:ship])
 end

--- a/lib/rc/discord/news_relay.ex
+++ b/lib/rc/discord/news_relay.ex
@@ -1,27 +1,32 @@
 defmodule RC.Discord.NewsRelay do
   @moduledoc """
-  GenServer that owns all posting of Game.News bulletins to the #news
-  channel — and with it, Discord's OWN dedup policy.
+  GenServer that owns all immediate posting of Game.News bulletins to
+  the #news channel, plus the end-of-game victory announcement.
 
-  ## Publisher-owned dedup
+  ## Immediate feed
 
-  Game.News.Server no longer decides flood behavior for Discord. Every
-  battle event reaches this relay individually; the web surfaces keep
-  their suppress-and-summarize window inside News.Server. Here:
+  `RC.Discord.News.render/2` decides which bulletin kinds post — the
+  instant feed is limited to publicly-visible map events (sector
+  control, colonizations, dominion flips, victory-point movement).
+  The render check is pure and runs FIRST, so withheld kinds cost
+  nothing; the `discord_ready` + name lookup is cached per instance
+  for the relay's lifetime.
 
-    * **Battles roll up by editing.** The first battle posts a normal
-      line. Any further battle arriving less than 5 minutes after this
-      relay's last battle post/update EDITS that message into an
-      aggregated per-sector tally ("Fleet engagements reported:
-      sector Nubrae ×3, …") instead of posting again. The window is
-      rolling — sustained fighting keeps updating one message, which
-      is exactly the anti-flood behavior a chat channel wants.
-    * **Everything else posts one message per bulletin** (bulletins
-      are already rare: firsts, conquests, sector flips…).
+  ## Roll-up (anti-flood)
 
-  Battles are the only rolled-up kind for now: fleets can't convoy
-  yet, so engagements arrive in quick succession. The pattern
-  generalizes if other kinds ever need per-publisher dedup.
+  Colonizations, dominion flips, and VP movements can arrive in
+  bursts (a game-start settling rush, a sector tug-of-war). Per
+  (instance, kind, faction), a follower arriving within 5 minutes of
+  the previous post EDITS that message — colonize/dominion lines
+  aggregate into a systems list, VP lines update in place to the
+  newest value. Sector-control events post one message each (rare and
+  momentous).
+
+  ## Victory announcements
+
+  `{:victory, instance_id, info}` posts an embed to both the
+  community announce channel (community-guild emoji) and the Legacy
+  #news channel (game-guild emoji). Best-effort.
 
   ## Lifecycle
 
@@ -29,7 +34,7 @@ defmodule RC.Discord.NewsRelay do
   configured and connected. `RC.Discord.News.post_async/3` casts here;
   a cast to the unregistered name (bot off, :test) is a silent no-op
   by GenServer semantics. Roll-up state is in-memory only — a restart
-  simply starts a fresh message, never loses news.
+  simply starts fresh messages, never loses news.
   """
 
   use GenServer
@@ -39,12 +44,16 @@ defmodule RC.Discord.NewsRelay do
   alias Nostrum.Api.Message
   alias RC.Discord.News
 
-  # Rolling window: a battle arriving within this of the last battle
-  # post/update edits that message instead of posting a new one.
+  # A follower arriving within this of the last post/edit for the same
+  # (instance, kind, faction) edits that message instead of posting.
   @rollup_window_ms 5 * 60 * 1000
-  # A message absorbs at most this many battles; the next battle
-  # starts a fresh message (and a fresh window/tally).
-  @max_battles_per_message 5
+  # A message absorbs at most this many events; the next one starts a
+  # fresh message (and a fresh window).
+  @max_events_per_message 20
+
+  # Bulletin kinds that roll up. Everything else that renders posts
+  # one message per event.
+  @rollup_keys ["discord.colonized", "discord.dominion", "discord.vp_changed"]
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -52,18 +61,24 @@ defmodule RC.Discord.NewsRelay do
 
   @impl true
   def init(_opts) do
-    # %{instance_id => %{msg_id, channel_id, counts: %{sector => n}, last_at}}
-    {:ok, %{battles: %{}}}
+    # instances: %{instance_id => {discord_ready, name} | :missing}
+    # windows:   %{{instance_id, key, faction} => %{msg_id, channel_id,
+    #              payloads, count, last_at}}
+    {:ok, %{instances: %{}, windows: %{}}}
   end
 
   @impl true
   def handle_cast({:bulletin, instance_id, bulletin_key, payload}, state) do
     state =
-      with channel_id when not is_nil(channel_id) <- RC.Discord.news_channel_id(),
-           %{discord_ready: true, name: instance_name} <- RC.Instances.get_instance(instance_id) do
-        dispatch(state, instance_id, channel_id, instance_name, bulletin_key, payload)
+      with headline when not is_nil(headline) <- News.render(bulletin_key, payload),
+           channel_id when not is_nil(channel_id) <- RC.Discord.news_channel_id(),
+           {state, {true, instance_name}} <- instance_info(state, instance_id) do
+        dispatch(state, instance_id, channel_id, instance_name, bulletin_key, payload, headline)
       else
-        # Channel unset or instance missing / not discord_ready.
+        # Withheld kind, channel unset, or instance missing / not
+        # discord_ready. instance_info threads state through even on
+        # the negative path.
+        {state, _not_ready} -> state
         _ -> state
       end
 
@@ -74,82 +89,154 @@ defmodule RC.Discord.NewsRelay do
       {:noreply, state}
   end
 
-  ## Battle roll-up
+  @impl true
+  def handle_cast({:victory, instance_id, info}, state) do
+    case RC.Instances.get_instance(instance_id) do
+      %{discord_ready: true} = instance ->
+        post_victory(instance, info)
 
-  defp dispatch(state, instance_id, channel_id, instance_name, "news.battle", payload) do
-    sector = payload[:sector_name] || "an uncharted region"
+      _ ->
+        :ok
+    end
+
+    {:noreply, state}
+  rescue
+    e ->
+      Logger.warning("[RC.Discord.NewsRelay] victory handling crashed: #{inspect(e)}")
+      {:noreply, state}
+  end
+
+  # discord_ready never flips once a game is live (promotion happens
+  # pre-start), and instance names don't change mid-match — cache both
+  # for the relay's lifetime instead of re-querying per event.
+  defp instance_info(state, instance_id) do
+    case Map.get(state.instances, instance_id) do
+      nil ->
+        info =
+          case RC.Instances.get_instance(instance_id) do
+            %{discord_ready: ready, name: name} -> {ready, name}
+            _ -> :missing
+          end
+
+        state = put_in(state.instances[instance_id], info)
+        {state, if(info == :missing, do: false, else: info)}
+
+      :missing ->
+        {state, false}
+
+      {ready, name} ->
+        {state, {ready, name}}
+    end
+  end
+
+  ## Immediate posting, with roll-up for burst-prone kinds.
+
+  defp dispatch(state, instance_id, channel_id, instance_name, key, payload, _headline)
+       when key in @rollup_keys do
+    window_key = {instance_id, key, payload[:faction]}
     now = System.monotonic_time(:millisecond)
-    window = state.battles[instance_id]
+    window = state.windows[window_key]
 
     if window != nil and now - window.last_at < @rollup_window_ms and
-         window.battles < @max_battles_per_message do
-      counts = Map.update(window.counts, sector, 1, &(&1 + 1))
-      records = merge_records(window.records, payload)
-      content = "📰 **#{instance_name}** — #{News.battle_rollup(counts, records)}"
+         window.count < @max_events_per_message do
+      payloads = window.payloads ++ [payload]
+      content = "📰 **#{instance_name}**: #{rollup_content(key, payload[:faction], payloads)}"
 
       case Message.edit(window.channel_id, window.msg_id, %{content: content}) do
         {:ok, _} ->
-          window = %{window | counts: counts, records: records, battles: window.battles + 1, last_at: now}
-          put_in(state.battles[instance_id], window)
+          window = %{window | payloads: payloads, count: window.count + 1, last_at: now}
+          put_in(state.windows[window_key], window)
 
         {:error, reason} ->
           # Message likely deleted by a moderator — fall back to a
-          # fresh post carrying the full tally so nothing is lost.
-          Logger.warning("[RC.Discord.NewsRelay] battle roll-up edit failed: #{inspect(reason)}")
-          post_battle(state, instance_id, channel_id, instance_name, counts, records, window.battles + 1, now)
+          # fresh post carrying the aggregate so nothing is lost.
+          Logger.warning("[RC.Discord.NewsRelay] roll-up edit failed: #{inspect(reason)}")
+
+          start_window(state, window_key, channel_id, instance_id, instance_name, key, payloads, now)
       end
     else
-      post_battle(state, instance_id, channel_id, instance_name, %{sector => 1}, merge_records(%{}, payload), 1, now)
+      start_window(state, window_key, channel_id, instance_id, instance_name, key, [payload], now)
     end
   end
 
-  ## Everything else: one message per bulletin.
-
-  defp dispatch(state, instance_id, channel_id, instance_name, bulletin_key, payload) do
-    case News.render(bulletin_key, payload) do
-      nil ->
-        state
-
-      headline ->
-        create("📰 **#{instance_name}** — #{headline}", channel_id, instance_id)
-        state
-    end
+  defp dispatch(state, instance_id, channel_id, instance_name, _key, _payload, headline) do
+    create("📰 **#{instance_name}**: #{headline}", channel_id, instance_id)
+    state
   end
 
-  defp post_battle(state, instance_id, channel_id, instance_name, counts, records, battles, now) do
-    content = "📰 **#{instance_name}** — #{News.battle_rollup(counts, records)}"
+  defp start_window(state, window_key, channel_id, instance_id, instance_name, key, payloads, now) do
+    {_iid, _key, faction} = window_key
+    content = "📰 **#{instance_name}**: #{rollup_content(key, faction, payloads)}"
 
     case create(content, channel_id, instance_id) do
       {:ok, msg} ->
         window = %{
           msg_id: msg.id,
           channel_id: channel_id,
-          counts: counts,
-          records: records,
-          battles: battles,
+          payloads: payloads,
+          count: length(payloads),
           last_at: now
         }
 
-        put_in(state.battles[instance_id], window)
+        put_in(state.windows[window_key], window)
 
       _ ->
-        # Post failed — drop the window so the next battle retries fresh.
-        %{state | battles: Map.delete(state.battles, instance_id)}
+        # Post failed — drop the window so the next event retries fresh.
+        %{state | windows: Map.delete(state.windows, window_key)}
     end
   end
 
-  # Fold one battle's winners/losers into the window's per-player
-  # {wins, losses} records. Keys are {name, faction_key}.
-  defp merge_records(records, payload) do
-    records
-    |> fold_players(payload[:winners] || [], fn {w, l} -> {w + 1, l} end)
-    |> fold_players(payload[:losers] || [], fn {w, l} -> {w, l + 1} end)
-  end
+  # A single event renders its normal line; from the second on, the
+  # message becomes an aggregate (colonize/dominion) or the newest
+  # value (VP).
+  defp rollup_content(key, faction, payloads)
 
-  defp fold_players(records, players, bump) do
-    Enum.reduce(players, records, fn player, acc ->
-      key = {player[:name], player[:faction]}
-      Map.update(acc, key, bump.({0, 0}), bump)
+  defp rollup_content(key, _faction, [payload]), do: News.render(key, payload)
+
+  defp rollup_content("discord.colonized", faction, payloads),
+    do: News.colonized_rollup(faction, Enum.map(payloads, &(&1[:system_name] || "an uncharted system")))
+
+  defp rollup_content("discord.dominion", faction, payloads),
+    do: News.dominion_rollup(faction, Enum.map(payloads, &(&1[:system_name] || "an uncharted system")))
+
+  defp rollup_content("discord.vp_changed", _faction, payloads),
+    do: News.render("discord.vp_changed", List.last(payloads))
+
+  ## Victory
+
+  defp post_victory(instance, info) do
+    instance = RC.Repo.preload(instance, [:scenario])
+
+    scenario_name =
+      case instance.scenario do
+        %{game_metadata: metadata} -> get_in(metadata || %{}, ["name"])
+        _ -> nil
+      end
+
+    scenario_name = scenario_name || instance.name || "A Legacy match"
+
+    destinations = [
+      {RC.Discord.community_announce_channel_id(), :community, "community announce"},
+      {RC.Discord.news_channel_id(), :game, "news"}
+    ]
+
+    Enum.each(destinations, fn
+      {nil, _guild, label} ->
+        Logger.info("[RC.Discord.NewsRelay] no #{label} channel; skipping victory post")
+
+      {channel_id, guild, _label} ->
+        embed = News.victory_embed(scenario_name, info[:winner], info[:victory_points], guild)
+
+        case Message.create(channel_id, %{embeds: [embed]}) do
+          {:ok, _msg} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning(
+              "[RC.Discord.NewsRelay] victory post failed (channel #{channel_id}, " <>
+                "instance ##{instance.id}): #{inspect(reason)}"
+            )
+        end
     end)
   end
 

--- a/lib/rc/discord/role_sync.ex
+++ b/lib/rc/discord/role_sync.ex
@@ -222,9 +222,10 @@ defmodule RC.Discord.RoleSync do
     end
   end
 
-  # Find matches whose instance's opening_date is within 6 hours from
-  # now (or past) AND aren't yet active AND aren't ended. Activate +
-  # bulk sync each one.
+  # Find matches whose start time is within 6 hours from now (or past)
+  # AND aren't yet active AND aren't ended. Activate + bulk sync each
+  # one. The operator-entered announced_start_at (from the /promote
+  # modal) is authoritative when present; opening_date is the fallback.
   defp activate_due_matches do
     threshold = DateTime.add(DateTime.utc_now(), @lead_seconds, :second)
 
@@ -232,7 +233,7 @@ defmodule RC.Discord.RoleSync do
       from(m in Match,
         join: i in assoc(m, :instance),
         where: m.role_assignment_active == false,
-        where: i.opening_date <= ^threshold,
+        where: coalesce(m.announced_start_at, i.opening_date) <= ^threshold,
         where: i.state != "ended",
         preload: [instance: [:factions]]
       )

--- a/priv/repo/migrations/20260718000001_add_discord_bulletin_and_match_extensions.exs
+++ b/priv/repo/migrations/20260718000001_add_discord_bulletin_and_match_extensions.exs
@@ -1,0 +1,50 @@
+defmodule RC.Repo.Migrations.AddDiscordBulletinAndMatchExtensions do
+  use Ecto.Migration
+
+  # Discord bot feature batch (2026-07-18):
+  #
+  #   * `discord_matches.announced_start_at` — operator-entered start time
+  #     collected by the /promote modal. The registration announcement
+  #     renders this instead of instances.opening_date (which historically
+  #     hasn't matched real start times).
+  #   * `discord_matches.diplomacy_category_id` + `diplo_channels` — the
+  #     pairwise inter-faction diplomacy channels created for matches with
+  #     more than two factions. category id is nil when the channels were
+  #     placed under a pre-existing (operator-owned) category; channel ids
+  #     are tracked individually so teardown can delete exactly what the
+  #     bot created.
+  #   * `discord_matches.bulletin_last_posted_on` / `bulletin_cutoff_at` —
+  #     daily-summary bookkeeping. The posted-on date is the once-a-day
+  #     latch; the cutoff is the high-water mark of game events already
+  #     summarized (a missed day folds into the next bulletin instead of
+  #     losing its window).
+  #   * `discord_matches.bulletin_salt` — random per-match secret seeding
+  #     the daily post/cutoff slots. A stored secret (not a derivable
+  #     timestamp) so observing weeks of public post times can never
+  #     narrow down the hidden cutoff slot. Generated lazily on first
+  #     bulletin sweep.
+  #   * `discord_bulletin_events` — battle/raid/loot/conquest accumulator
+  #     rows written by Game.News.Server for discord_ready instances.
+  #     Consumed (deleted) by each daily bulletin post, so the table stays
+  #     one-window small per live match.
+  def change do
+    alter table(:discord_matches) do
+      add(:announced_start_at, :utc_datetime_usec)
+      add(:diplomacy_category_id, :string)
+      add(:diplo_channels, :map, null: false, default: %{})
+      add(:bulletin_last_posted_on, :date)
+      add(:bulletin_cutoff_at, :utc_datetime_usec)
+      add(:bulletin_salt, :string)
+    end
+
+    create table(:discord_bulletin_events) do
+      add(:instance_id, references(:instances, on_delete: :delete_all), null: false)
+      add(:kind, :string, null: false)
+      add(:payload, :map, null: false, default: %{})
+
+      timestamps(updated_at: false, type: :utc_datetime_usec)
+    end
+
+    create(index(:discord_bulletin_events, [:instance_id, :inserted_at]))
+  end
+end

--- a/test/game/instance/faction/government_test.exs
+++ b/test/game/instance/faction/government_test.exs
@@ -567,6 +567,41 @@ defmodule Instance.Faction.GovernmentTest do
 
       assert {:error, :already_seated} = Government.appoint(government, 1, :economy, 1, ctx)
     end
+
+    # :previous on :seat_changed is what lets the Discord leadership-
+    # role sync retract the old holder's role — these pin the contract.
+    test "seat_changed events carry the displaced holder" do
+      {government, _events, ctx} = founded(:tetrarchy, players(4))
+      {government, _} = close_open_ballots(government, ctx)
+
+      {government, [event]} =
+        Government.fill_seat(government, :leader, %{player_id: 1, name: "Player 1"})
+
+      assert %{type: :seat_changed, seat: :leader, player_id: 1, previous: nil} = event
+
+      {government, [event]} =
+        Government.fill_seat(government, :leader, %{player_id: 2, name: "Player 2"})
+
+      assert %{previous: %{player_id: 1, name: "Player 1"}} = event
+
+      {_government, [event]} = Government.vacate_seat(government, :leader)
+      assert %{type: :seat_changed, player_id: nil, previous: %{player_id: 2}} = event
+    end
+
+    test "moving to a new seat emits a seat_changed for the implicitly cleared one" do
+      {government, _events, ctx} = founded(:tetrarchy, players(4))
+      {government, _} = close_open_ballots(government, ctx)
+
+      {government, _} = Government.fill_seat(government, :economy, %{player_id: 3, name: "Player 3"})
+
+      {_government, events} =
+        Government.fill_seat(government, :leader, %{player_id: 3, name: "Player 3"})
+
+      assert [
+               %{type: :seat_changed, seat: :economy, player_id: nil, previous: %{player_id: 3}},
+               %{type: :seat_changed, seat: :leader, player_id: 3, previous: nil}
+             ] = events
+    end
   end
 
   describe "empty faction (zero registered members)" do

--- a/test/rc/discord/bulletin_test.exs
+++ b/test/rc/discord/bulletin_test.exs
@@ -1,0 +1,213 @@
+defmodule RC.Discord.BulletinTest do
+  @moduledoc """
+  Pure tests for the daily-summary bulletin: seeded slot selection
+  (deterministic, in-window, salt-sensitive) and the two rendering
+  tiers (vague for >2 factions, detailed for 2).
+  """
+
+  use ExUnit.Case, async: true
+
+  alias RC.Discord.Bulletin
+
+  @salt "2026-07-01 12:34:56.789012Z"
+
+  defp event(kind, payload), do: %RC.Discord.BulletinEvent{kind: kind, payload: payload}
+
+  defp battle(attacker, defender, winner, extra \\ %{}) do
+    event(
+      "battle",
+      Map.merge(
+        %{
+          "attacker_faction" => attacker,
+          "defender_faction" => defender,
+          "winner" => winner,
+          "winners" => [],
+          "losers" => []
+        },
+        extra
+      )
+    )
+  end
+
+  describe "seeded slots" do
+    test "post slot is deterministic and lands on a 30-minute mark between 12:00 and 14:00 ET" do
+      for day <- 1..28 do
+        date = Date.new!(2026, 7, day)
+        dt = Bulletin.post_time(date, @salt)
+
+        assert dt == Bulletin.post_time(date, @salt)
+        assert dt.time_zone == "America/New_York"
+        assert dt.minute in [0, 30]
+        assert dt.hour in 12..14
+        refute dt.hour == 14 and dt.minute == 30
+      end
+    end
+
+    test "cutoff slot lands on a 30-minute mark between 07:00 and 11:00 ET" do
+      for day <- 1..28 do
+        date = Date.new!(2026, 7, day)
+        dt = Bulletin.cutoff_time(date, @salt)
+
+        assert dt.minute in [0, 30]
+        assert dt.hour in 7..11
+        refute dt.hour == 11 and dt.minute == 30
+      end
+    end
+
+    test "different salts and different dates shuffle the slots" do
+      dates = for day <- 1..28, do: Date.new!(2026, 7, day)
+
+      # Across a month the slot should not be constant (5 possible
+      # posting slots, 28 days — a stuck implementation returns 1).
+      post_slots = dates |> Enum.map(&Bulletin.post_time(&1, @salt).hour) |> Enum.uniq()
+      assert length(post_slots) > 1
+
+      # And two different matches on the same date generally differ;
+      # assert at least one differing day across the month.
+      assert Enum.any?(dates, fn date ->
+               Bulletin.cutoff_time(date, @salt) != Bulletin.cutoff_time(date, "other-salt")
+             end)
+    end
+  end
+
+  describe "render/4 — vague tier (more than two factions)" do
+    test "battles show per-faction records and ratios but no players or systems" do
+      events = [
+        battle("ark", "cardan", "attackers", %{
+          "winners" => [%{"name" => "Nova", "faction" => "ark"}],
+          "losers" => [%{"name" => "Kael", "faction" => "cardan"}],
+          "system_name" => "Mirba"
+        }),
+        battle("ark", "myrmezir", "attackers"),
+        battle("cardan", "ark", "attackers")
+      ]
+
+      out = Bulletin.render("Legacy One", 3, events, [])
+
+      assert out =~ "**Battles**: 3 engagements"
+      assert out =~ "A.R.K. 2W 1L (67%)"
+      refute out =~ "Nova"
+      refute out =~ "Mirba"
+      refute out =~ "Records:"
+    end
+
+    test "conquests, bombards, and pillages show counts only" do
+      events = [
+        event("conquest", %{"faction" => "ark", "system_name" => "Mirba"}),
+        event("conquest", %{"faction" => "ark", "system_name" => "Vega"}),
+        event("raid", %{"faction" => "cardan", "system_name" => "Nubrae Prime"}),
+        event("loot", %{"faction" => "myrmezir", "system_name" => "Kelvaan"})
+      ]
+
+      out = Bulletin.render("Legacy One", 3, events, [])
+
+      assert out =~ "**Conquests**: <:ark:1521144064374739145>A.R.K. 2"
+      assert out =~ "**Bombards**: <:cardan:1521144119605329961>Cardan 1"
+      assert out =~ "**Pillages**: <:myrmezir:1521144307728519208>Myrmezir 1"
+      refute out =~ "Mirba"
+      refute out =~ "Nubrae Prime"
+    end
+
+    test "empty sections render as none and firsts section is omitted when empty" do
+      out = Bulletin.render("Legacy One", 3, [], [])
+
+      assert out =~ "**Battles**: none reported."
+      assert out =~ "**Conquests**: none."
+      assert out =~ "**Bombards**: none."
+      assert out =~ "**Pillages**: none."
+      refute out =~ "**Firsts**"
+    end
+
+    test "firsts always name the player, even in the vague tier" do
+      lines = [Bulletin.first_line("colonize.first", "Nova", "ark")]
+      out = Bulletin.render("Legacy One", 3, [], lines)
+
+      assert out =~ "**Firsts**: Nova (A.R.K.) was first to found a colony."
+    end
+
+    test "draws count toward the total but nobody's record" do
+      events = [battle("ark", "cardan", "draw")]
+      out = Bulletin.render("Legacy One", 3, events, [])
+
+      assert out =~ "1 engagement (1 inconclusive)"
+      refute out =~ "1W"
+    end
+  end
+
+  describe "render/4 — detailed tier (two factions)" do
+    test "battles include per-player records" do
+      events = [
+        battle("ark", "cardan", "attackers", %{
+          "winners" => [%{"name" => "Nova", "faction" => "ark"}],
+          "losers" => [%{"name" => "Kael", "faction" => "cardan"}]
+        }),
+        battle("cardan", "ark", "attackers", %{
+          "winners" => [%{"name" => "Kael", "faction" => "cardan"}],
+          "losers" => [%{"name" => "Nova", "faction" => "ark"}]
+        })
+      ]
+
+      out = Bulletin.render("Duel", 2, events, [])
+
+      assert out =~ "Records:"
+      assert out =~ "Nova <:ark:1521144064374739145> 1W 1L"
+      assert out =~ "Kael <:cardan:1521144119605329961> 1W 1L"
+    end
+
+    test "strike sections name systems and collapse repeats" do
+      events = [
+        event("raid", %{"faction" => "cardan", "system_name" => "Vega"}),
+        event("raid", %{"faction" => "cardan", "system_name" => "Vega"}),
+        event("raid", %{"faction" => "cardan", "system_name" => "Mirba"}),
+        event("conquest", %{"faction" => "ark", "system_name" => "Kelvaan"})
+      ]
+
+      out = Bulletin.render("Duel", 2, events, [])
+
+      assert out =~ "Cardan bombarded Vega x2, Mirba."
+      assert out =~ "A.R.K. took Kelvaan."
+    end
+  end
+
+  describe "first_line/3" do
+    test "known first keys read as deeds" do
+      assert Bulletin.first_line("dominion.first", "Nova", "ark") =~ "was first to take a dominion"
+
+      assert Bulletin.first_line("building.monument_dome.first", "Nova", nil) ==
+               "Nova was first to complete a Monolith."
+
+      assert Bulletin.first_line("ship.capital.first", nil, "cardan") ==
+               "Cardan was first to field a capital ship."
+
+      assert Bulletin.first_line("income.technology_100.first", "Kael", nil) =~
+               "raise technology output above 100"
+
+      assert Bulletin.first_line("faction.erased_25.first", nil, "synelle") =~ "field 25 Erased"
+    end
+
+    test "unknown keys degrade to humanized text and missing names fall back" do
+      line = Bulletin.first_line("weird.new_thing.first", nil, nil)
+      assert line =~ "Someone was first to"
+      refute line =~ "—"
+    end
+  end
+
+  describe "message hygiene" do
+    test "the bulletin contains no em-dashes" do
+      events = [battle("ark", "cardan", "attackers")]
+      lines = [Bulletin.first_line("colonize.first", "Nova", "ark")]
+
+      refute Bulletin.render("Legacy One", 3, events, lines) =~ "—"
+    end
+
+    test "stays under Discord's 2000-char cap even when flooded" do
+      events =
+        for i <- 1..300 do
+          event("raid", %{"faction" => "cardan", "system_name" => "System #{i}"})
+        end
+
+      out = Bulletin.render("Flood", 2, events, [])
+      assert String.length(out) <= 1990
+    end
+  end
+end

--- a/test/rc/discord/gov_relay_test.exs
+++ b/test/rc/discord/gov_relay_test.exs
@@ -1,0 +1,152 @@
+defmodule RC.Discord.GovRelayTest do
+  @moduledoc """
+  Pure-renderer tests for the faction-government Discord relay. The
+  GenServer itself never runs here — `render/2` is a pure function of
+  (faction_key, event), and the forwarding whitelist is data.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias RC.Discord.GovRelay
+
+  describe "render/2 — election lifecycle" do
+    test "elections opening list the leadership seats" do
+      line =
+        GovRelay.render(:cardan, %{
+          type: :elections_opened,
+          seats: [:leader, :economy, :military],
+          renewal: false
+        })
+
+      assert line =~ "Elections have opened for Cardan"
+      assert line =~ "Leader"
+      assert line =~ "Head of Economy"
+      assert line =~ "Head of Military"
+    end
+
+    test "elections opening for non-leadership seats stay silent" do
+      assert GovRelay.render(:myrmezir, %{type: :elections_opened, seats: [:laws], renewal: true}) ==
+               nil
+    end
+
+    test "a seated player announces with the decorated display name" do
+      event = %{
+        type: :seat_changed,
+        seat: :leader,
+        player_id: 7,
+        name: "Nova",
+        who_display: "Nova (Discord: kurtz)"
+      }
+
+      assert GovRelay.render(:ark, event) ==
+               "Nova (Discord: kurtz) is now the Leader of A.R.K. <:ark:1521144064374739145>."
+    end
+
+    test "a seated player without a Discord link falls back to the in-game name" do
+      event = %{type: :seat_changed, seat: :economy, player_id: 7, name: "Nova"}
+      assert GovRelay.render(:ark, event) =~ "Nova is now the Head of Economy"
+    end
+
+    test "vacated seats do not post on their own" do
+      assert GovRelay.render(:ark, %{type: :seat_changed, seat: :leader, player_id: nil, name: nil}) ==
+               nil
+    end
+
+    test "failed elections broadcast that the seat stays open" do
+      line = GovRelay.render(:cardan, %{type: :election_failed, seat: :leader, reason: :no_votes})
+      assert line =~ "Leader election for Cardan"
+      assert line =~ "failed"
+      assert line =~ "stays open"
+    end
+  end
+
+  describe "render/2 — ceremony events" do
+    test "depositions, dissolutions, and challenges have copy" do
+      assert GovRelay.render(:tetrarchy, %{type: :deposition_started, seat: :leader, by: 1}) =~
+               "vote to depose the Leader of Tetrarchy"
+
+      assert GovRelay.render(:tetrarchy, %{type: :deposed, seat: :leader, name: "Nova", player_id: 1}) =~
+               "Nova has been deposed"
+
+      assert GovRelay.render(:synelle, %{type: :government_dissolved, reason: :strikes}) =~
+               "government of Synelectic Federation"
+
+      assert GovRelay.render(:synelle, %{type: :cabinet_dissolved}) =~ "cabinet of"
+      assert GovRelay.render(:synelle, %{type: :crisis_vote_started}) =~ "crisis vote"
+
+      assert GovRelay.render(:ark, %{type: :challenge_started, name: "Nova", stake: 500}) =~
+               "challenge for the leadership"
+
+      assert GovRelay.render(:ark, %{type: :challenge_defended, name: "Nova"}) =~
+               "defended its position"
+
+      assert GovRelay.render(:ark, %{type: :government_overthrown, name: "Nova"}) =~
+               "has overthrown the government"
+    end
+
+    test "incapacitated holders broadcast the vacancy" do
+      line =
+        GovRelay.render(:cardan, %{
+          type: :seat_incapacitated,
+          seat: :military,
+          name: "Nova",
+          player_id: 3,
+          reason: :afk
+        })
+
+      assert line =~ "Nova no longer holds the Head of Military seat"
+    end
+  end
+
+  describe "render/2 — hygiene and scope" do
+    test "treasury and policy events never broadcast" do
+      assert GovRelay.render(:ark, %{type: :patent_purchased, key: :x, cost: 1, by: 1}) == nil
+      assert GovRelay.render(:ark, %{type: :lex_purchased, key: :x, cost: 1, by: 1}) == nil
+      assert GovRelay.render(:ark, %{type: :taxes_changed, rates: %{}, by: 1}) == nil
+      assert GovRelay.render(:ark, %{type: :laws_changed, laws: [], by: 1}) == nil
+      assert GovRelay.render(:ark, %{type: :sync_effects}) == nil
+    end
+
+    test "the forwarding whitelist excludes economy churn" do
+      refute :patent_purchased in GovRelay.ceremony_events()
+      refute :lex_purchased in GovRelay.ceremony_events()
+      refute :taxes_changed in GovRelay.ceremony_events()
+      refute :laws_changed in GovRelay.ceremony_events()
+
+      assert :elections_opened in GovRelay.ceremony_events()
+      assert :seat_changed in GovRelay.ceremony_events()
+      assert :election_failed in GovRelay.ceremony_events()
+    end
+
+    test "no em-dashes in any ceremony copy" do
+      events = [
+        %{type: :elections_opened, seats: [:leader], renewal: false},
+        %{type: :seat_changed, seat: :leader, player_id: 1, name: "Nova"},
+        %{type: :election_failed, seat: :leader, reason: :no_votes},
+        %{type: :deposition_started, seat: :leader, by: 1},
+        %{type: :deposed, seat: :leader, name: "Nova", player_id: 1},
+        %{type: :government_dissolved, reason: :strikes},
+        %{type: :cabinet_dissolved},
+        %{type: :crisis_vote_started},
+        %{type: :challenge_started, name: "Nova", stake: 1},
+        %{type: :challenge_defended, name: "Nova"},
+        %{type: :government_overthrown, name: "Nova"},
+        %{type: :seat_incapacitated, seat: :leader, name: "Nova", player_id: 1, reason: :afk}
+      ]
+
+      for event <- events do
+        case GovRelay.render(:cardan, event) do
+          nil -> :ok
+          line -> refute line =~ "—", "em-dash in copy for #{inspect(event.type)}: #{line}"
+        end
+      end
+    end
+
+    test "post_async is a silent no-op when the relay is not running" do
+      refute Process.whereis(GovRelay)
+
+      assert GovRelay.post_async(1, :ark, %{type: :seat_changed, seat: :leader, player_id: 1, name: "N"}) ==
+               :ok
+    end
+  end
+end

--- a/test/rc/discord/legacy_match_test.exs
+++ b/test/rc/discord/legacy_match_test.exs
@@ -53,6 +53,43 @@ defmodule RC.Discord.LegacyMatchTest do
     end
   end
 
+  describe "parse_start_time/2" do
+    # Fixed "now" keeps the -1d..+60d sanity window deterministic.
+    @now ~U[2026-07-18 16:00:00Z]
+
+    test "parses US-Eastern wall time to UTC (EDT in July: UTC-4)" do
+      assert {:ok, dt} = LegacyMatch.parse_start_time("2026-07-20 18:00", @now)
+      assert dt == ~U[2026-07-20 22:00:00Z]
+    end
+
+    test "parses winter wall time as EST (UTC-5)" do
+      now = ~U[2026-01-10 16:00:00Z]
+      assert {:ok, dt} = LegacyMatch.parse_start_time("2026-01-15 18:00", now)
+      assert dt == ~U[2026-01-15 23:00:00Z]
+    end
+
+    test "accepts a bare unix timestamp in seconds" do
+      unix = DateTime.to_unix(~U[2026-07-20 22:00:00Z])
+      assert {:ok, dt} = LegacyMatch.parse_start_time(to_string(unix), @now)
+      assert DateTime.to_unix(dt) == unix
+    end
+
+    test "tolerates surrounding whitespace and a T separator" do
+      assert {:ok, _} = LegacyMatch.parse_start_time("  2026-07-20T18:00  ", @now)
+    end
+
+    test "rejects garbage" do
+      assert {:error, :bad_format} = LegacyMatch.parse_start_time("soonish", @now)
+      assert {:error, :bad_format} = LegacyMatch.parse_start_time("2026-07-20", @now)
+      assert {:error, :bad_format} = LegacyMatch.parse_start_time("18:00", @now)
+    end
+
+    test "rejects typo years and far-past times" do
+      assert {:error, :out_of_range} = LegacyMatch.parse_start_time("2062-07-20 18:00", @now)
+      assert {:error, :out_of_range} = LegacyMatch.parse_start_time("2026-07-10 18:00", @now)
+    end
+  end
+
   # Flip discord_ready directly on the persisted row, bypassing the
   # validation-heavy create changeset.
   defp set_discord_ready(instance, value) do

--- a/test/rc/discord/news_test.exs
+++ b/test/rc/discord/news_test.exs
@@ -2,8 +2,10 @@ defmodule RC.Discord.NewsTest do
   @moduledoc """
   Pure-renderer tests for the Discord news relay. No bot, no gateway —
   `RC.Discord.News.render/2` is a pure function of (bulletin_key,
-  payload), and the #news channel is all-factions, so these tests also
-  pin the fog-of-war guarantees (no attacker identity on covert ops).
+  payload). These tests pin the immediate-feed policy (player decision
+  2026-07): only publicly-visible map events post instantly; battles,
+  raids, pillages, conquests, covert ops, and firsts are withheld from
+  the instant feed (they ship via the daily bulletin instead).
   """
 
   use ExUnit.Case, async: true
@@ -19,8 +21,8 @@ defmodule RC.Discord.NewsTest do
   }
 
   describe "render/2 — faction icon handling" do
-    test "appends the faction's guild emoji to its display name" do
-      line = News.render("news.colonize.first", @base)
+    test "appends the faction's game-guild emoji to its display name" do
+      line = News.render("discord.colonized", @base)
       assert line =~ "Tetrarchy <:tetrarchy:1521144218742034463>"
       assert line =~ "Mirba"
     end
@@ -39,48 +41,7 @@ defmodule RC.Discord.NewsTest do
     end
   end
 
-  describe "render/2 — public-tier wording" do
-    test "battle names only the sector, never the belligerents" do
-      payload = Map.merge(@base, %{attacker_faction: "synelle", defender_faction: "myrmezir", winner: "attackers"})
-      line = News.render("news.battle", payload)
-      assert line == "A small skirmish took place in sector Nubrae."
-      refute line =~ "ynelle"
-      refute line =~ "yrmezir"
-    end
-
-    test "assassination names the victim but never a perpetrator" do
-      payload = Map.merge(@base, %{target_name: "Gov Karsis", victim_faction: "tetrarchy"})
-      line = News.render("news.agent.assassinated", payload)
-      assert line =~ "Gov Karsis"
-      assert line =~ "no suspects"
-      refute line =~ "Tetrarchy"
-    end
-
-    test "conversion reads as a resignation, no seducer" do
-      payload = Map.merge(@base, %{target_name: "Gov Karsis", victim_faction: "tetrarchy"})
-      line = News.render("news.agent.converted", payload)
-      assert line =~ "renounced their post"
-      refute line =~ "Tetrarchy"
-    end
-
-    test "building and ship keys map to display names" do
-      assert News.render("news.building.first", Map.put(@base, :building, "monument_dome")) =~ "Monolith"
-
-      assert News.render("news.ship.capital", Map.put(@base, :ship, "capital_2")) =~
-               "employs the Cruiser to mark a new age of ship warfare"
-    end
-
-    test "summaries interpolate counts" do
-      assert News.render("news.battle.summary", Map.put(@base, :count, 7)) =~ "At least 7 more engagements"
-      assert News.render("news.raid.summary", Map.put(@base, :count, 4)) =~ "At least 4 more strikes"
-    end
-
-    test "corps milestones render for all three agent types" do
-      assert News.render("news.faction.erased", @base) =~ "shadow organization"
-      assert News.render("news.faction.navarchs", @base) =~ "corps of Navarchs"
-      assert News.render("news.faction.siderians", @base) =~ "circle of Siderians"
-    end
-
+  describe "render/2 — immediate feed" do
     test "sector flips name both factions with emoji" do
       payload = Map.merge(@base, %{faction: "ark", prev_faction: "myrmezir"})
       line = News.render("news.sector.flipped", payload)
@@ -96,49 +57,89 @@ defmodule RC.Discord.NewsTest do
                "Synelectic Federation <:synelle:1521144259015868577> has lost control of sector Nubrae."
     end
 
-    test "economic firsts" do
-      assert News.render("news.income.first", Map.put(@base, :resource, "technology")) =~
-               "raise its technology output above 100"
+    test "every colonization posts with the system named" do
+      assert News.render("discord.colonized", Map.put(@base, :faction, "ark")) ==
+               "A.R.K. <:ark:1521144064374739145> has colonized Mirba."
+    end
 
-      assert News.render("news.credit.first", @base) =~ "ten million credits"
-      assert News.render("news.doctrine.first", @base) =~ "fifteen lexes"
+    test "dominion flips name the system and the displaced faction" do
+      assert News.render("discord.dominion", @base) =~ "has taken Mirba as a dominion"
+
+      line = News.render("discord.dominion", Map.put(@base, :prev_faction, "cardan"))
+      assert line =~ "has taken the dominion of Mirba"
+      assert line =~ "Cardan"
+    end
+
+    test "victory point changes announce rises and falls" do
+      rise = News.render("discord.vp_changed", %{faction: "ark", vp: 12, prev_vp: 10})
+      assert rise =~ "has risen to 12 victory points"
+
+      fall = News.render("discord.vp_changed", %{faction: "ark", vp: 7, prev_vp: 10})
+      assert fall =~ "has fallen to 7 victory points"
+    end
+
+    test "dominion liberation and system abandonment still post" do
+      assert News.render("news.dominion.liberated", @base) =~ "freely liberated"
+      assert News.render("news.system.abandoned", @base) =~ "has abandoned Mirba"
     end
   end
 
-  describe "battle_rollup/2" do
-    test "single skirmish with participants names victor and vanquished" do
-      records = %{{"Kholvax", "synelle"} => {1, 0}, {"Dan", "myrmezir"} => {0, 1}}
-
-      assert News.battle_rollup(%{"Nubrae" => 1}, records) ==
-               "A skirmish took place in sector Nubrae — " <>
-                 "Kholvax <:synelle:1521144259015868577> defeated Dan <:myrmezir:1521144307728519208>."
+  describe "render/2 — withheld from the instant feed" do
+    test "battles never post immediately" do
+      payload = Map.merge(@base, %{attacker_faction: "synelle", winner: "attackers"})
+      assert News.render("news.battle", payload) == nil
+      assert News.render("news.battle.summary", Map.put(@base, :count, 7)) == nil
     end
 
-    test "single skirmish without participant data keeps the anonymous line" do
-      assert News.battle_rollup(%{"Nubrae" => 1}) == "A small skirmish took place in sector Nubrae."
+    test "raids and conquests never post immediately" do
+      assert News.render("news.raid", @base) == nil
+      assert News.render("news.raid.summary", Map.put(@base, :count, 4)) == nil
+      assert News.render("news.conquest", @base) == nil
     end
 
-    test "repeat fighting in one sector shows the tally with window records" do
-      records = %{{"Kholvax", "synelle"} => {2, 0}, {"Dan", "myrmezir"} => {1, 2}}
-
-      assert News.battle_rollup(%{"Nubrae" => 3}, records) ==
-               "Fleet engagements reported in sector Nubrae ×3 — " <>
-                 "Kholvax <:synelle:1521144259015868577> 2W · Dan <:myrmezir:1521144307728519208> 1W 2L."
+    test "covert ops stay off Discord entirely" do
+      payload = Map.merge(@base, %{target_name: "Gov Karsis"})
+      assert News.render("news.agent.assassinated", payload) == nil
+      assert News.render("news.agent.converted", payload) == nil
     end
 
-    test "multi-sector fighting sorts sectors by count and players by wins" do
-      counts = %{"Kelvaan" => 1, "Nubrae" => 3, "Aldre" => 3}
-      records = %{{"Kaya", "ark"} => {0, 2}, {"Kholvax", "synelle"} => {3, 1}}
+    test "galaxy firsts are daily-bulletin material, not instant posts" do
+      assert News.render("news.colonize.first", @base) == nil
+      assert News.render("news.dominion.first", @base) == nil
+      assert News.render("news.building.first", Map.put(@base, :building, "monument_dome")) == nil
+      assert News.render("news.ship.capital", Map.put(@base, :ship, "capital_2")) == nil
+      assert News.render("news.income.first", Map.put(@base, :resource, "technology")) == nil
+      assert News.render("news.credit.first", @base) == nil
+      assert News.render("news.doctrine.first", @base) == nil
+      assert News.render("news.faction.erased", @base) == nil
+      assert News.render("news.faction.navarchs", @base) == nil
+      assert News.render("news.faction.siderians", @base) == nil
+    end
+  end
 
-      assert News.battle_rollup(counts, records) ==
-               "Fleet engagements reported: sector Aldre ×3, sector Nubrae ×3, sector Kelvaan ×1 — " <>
-                 "Kholvax <:synelle:1521144259015868577> 3W 1L · Kaya <:ark:1521144064374739145> 2L."
+  describe "victory_embed/4" do
+    test "community embed uses community-guild emoji and the spec wording" do
+      embed = News.victory_embed("The Shattered Reach", :cardan, 14, :community)
+
+      assert embed.title == "Congrats to Cardan!"
+
+      assert embed.description ==
+               "The Shattered Reach has concluded in a victory with 14 VP " <>
+                 "in favor of <:cardan:1528019517744091136>Cardan."
     end
 
-    test "unknown faction key renders the player without an emoji" do
-      records = %{{"Bot77", "neutral"} => {1, 0}, {"Dan", "myrmezir"} => {0, 1}}
+    test "game embed uses the Legacy-guild emoji" do
+      embed = News.victory_embed("The Shattered Reach", "ark", 15, :game)
 
-      assert News.battle_rollup(%{"Nubrae" => 1}, records) =~ "Bot77 defeated"
+      assert embed.title == "Congrats to A.R.K.!"
+      assert embed.description =~ "<:ark:1521144064374739145>A.R.K."
+      assert embed.description =~ "15 VP"
+    end
+
+    test "victory copy contains no em-dashes" do
+      embed = News.victory_embed("The Shattered Reach", :synelle, 14, :community)
+      refute embed.title =~ "—"
+      refute embed.description =~ "—"
     end
   end
 
@@ -146,6 +147,11 @@ defmodule RC.Discord.NewsTest do
     test "is a silent no-op when the relay is not running" do
       refute Process.whereis(RC.Discord.NewsRelay)
       assert News.post_async(1, "news.battle", %{sector_name: "Nubrae"}) == :ok
+    end
+
+    test "victory post is a silent no-op when the relay is not running" do
+      refute Process.whereis(RC.Discord.NewsRelay)
+      assert News.post_victory_async(1, %{winner: :ark, victory_points: 14}) == :ok
     end
   end
 
@@ -156,8 +162,8 @@ defmodule RC.Discord.NewsTest do
     end
 
     test "missing payload fields degrade the sentence, never raise" do
-      line = News.render("news.conquest", %{})
-      assert line =~ "an uncharted region"
+      line = News.render("discord.colonized", %{})
+      assert line =~ "an uncharted system"
       assert line =~ "An unknown power"
     end
   end


### PR DESCRIPTION
… bulletin, election news

Batch of bot changes from live-play feedback on the Legacy matches:

* /promote now creates pairwise inter-faction diplomacy channels (#ark-card style) for matches with >2 factions, under the operator's diplo-ground category (DISCORD_DIPLO_CATEGORY_ID) or a bot-made one; /teardown removes exactly what the bot created.
* /promote pops a modal asking for the real start time (US Eastern or unix); announcements and role-sync activation use it over the never-accurate opening_date.
* Victory announcements: "Congrats to [FACTION]!" embeds to the community announce channel and Legacy #news, each with that guild's own faction emoji.
* Immediate #news feed narrowed to publicly-visible map events: sector control, every colonization, every dominion flip, victory-point movement (burst roll-up by message edit). Battles, bombards, pillages, conquests, and firsts moved to a once-a-day summary bulletin posted in a seeded random slot (12:00-14:00 ET) with a hidden seeded cutoff (07:00-11:00 ET, stored random per-match salt so slots can't be predicted). Two-faction games keep full detail; bigger games get faction-level tallies only.
* Faction-government ceremony news in #news (elections opened, seats filled with linked Discord names, failures, depositions, challenges) plus leader/econ/military role assignment; economy/policy churn stays off the wire.
* CLAUDE.md branching section updated: post-1.1, development lands directly on master (no active release branch).

New tables/columns via 20260718000001; new env vars documented in .env.example and docs/discord-bot.md.