### PR TITLE
feat(deploy): player-facing deployment notices, /cleardeploy, early s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,36 @@ accidental terminate.
 ./deploy/release.sh <git-ref> # build a specific ref and ship it
 ```
 
-That's the whole deploy. The script does: stamp `priv/VERSION` → build
-arm64 tarballs (`--no-cache` by default) → extract → `deploy/bin/deploy.sh`
-→ verify the deployed revision against the request → run a per-instance
-maintenance-state recovery pass → print a pass/fail summary.
+That's the whole deploy. The script does: stamp `priv/VERSION` → preflight
+ssh to prod (fail-fast reachability check + raise the player-facing
+deploy notice via `RC.Deploy`) → build arm64 tarballs (`--no-cache` by
+default) → extract → `deploy/bin/deploy.sh` → verify the deployed
+revision against the request → run a per-instance maintenance-state
+recovery pass → clear/finish the deploy notice → print a pass/fail
+summary.
+
+The preflight connection also triggers the SSH-key approval prompt
+(1Password) at the start of the run — while you're still watching —
+instead of after a half-hour build.
+
+### Deploy notice
+
+The preflight calls `RC.Deploy.start_deploy()` on prod, which flips a
+persistent flag (survives the mid-deploy restart) and announces the
+upcoming interruption to players: the portal news marquee switches to a
+deployment banner, every live game's chat gets a SYSTEM line, late
+joiners get the line re-asserted on join, and while an instance is
+paused mid-deploy the in-game "Paused" headband reads "Interruption for
+updates. Please reconnect" instead. On success (`PASS`/`PARTIAL`) the
+script calls `finish_deploy()` — flag down plus an "update applied,
+refresh recommended" chat line. On failures, interrupts (ctrl-C), and
+`set -e` aborts, it best-effort calls `clear_deploy()`.
+
+If the script dies without clearing (killed terminal, network gone), the
+notice stays up: an admin clears it with the **`/cleardeploy`** Discord
+slash command (admin-linked accounts only, registered on the game
+guild), or via rpc on the host:
+`./rc/bin/rc rpc 'RC.Deploy.clear_deploy()'` (env-source first).
 
 A successful run ends with:
 

--- a/deploy/release.ps1
+++ b/deploy/release.ps1
@@ -117,8 +117,49 @@ function Step([string]$msg) {
   Write-Host "[release] $msg"
 }
 
+# --- deploy-notice helpers ---------------------------------------------------
+# The preflight (section 2c) raises a player-facing "deployment ongoing"
+# flag on prod via RC.Deploy; these helpers clear/finish it on the way
+# out. $script:deployNoticeSet tracks whether WE raised it, so failure
+# paths that never reached the preflight stay no-ops. All three RC.Deploy
+# entry points are zero-arg so the remote command needs no nested quoting.
+$script:deployNoticeSet = $false
+
+function Invoke-DeployNoticeRpc([string]$fn) {
+  $remoteCmd = "set -e; cd /home/rc; set -a; . /etc/rc/env; set +a; ./rc/bin/rc rpc 'RC.Deploy.$fn()'"
+  $eapSaved = $ErrorActionPreference
+  $ErrorActionPreference = 'Continue'
+  try {
+    $null = & ssh @sshArgs -o ConnectTimeout=15 $sshHost $remoteCmd 2>&1
+    return $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $eapSaved
+  }
+}
+
+function Clear-DeployNotice {
+  if (-not $script:deployNoticeSet) { return }
+  Step "clearing deploy notice on prod"
+  $code = Invoke-DeployNoticeRpc 'clear_deploy'
+  if ($code -ne 0) {
+    Write-Host "[release] WARNING: could not clear the deploy notice -- run /cleardeploy on Discord" -ForegroundColor Yellow
+  }
+  $script:deployNoticeSet = $false
+}
+
+function Complete-DeployNotice {
+  if (-not $script:deployNoticeSet) { return }
+  Step "finishing deploy notice on prod (update-applied message)"
+  $code = Invoke-DeployNoticeRpc 'finish_deploy'
+  if ($code -ne 0) {
+    Write-Host "[release] WARNING: could not send the deploy-finished notice -- run /cleardeploy on Discord" -ForegroundColor Yellow
+  }
+  $script:deployNoticeSet = $false
+}
+
 function Fail([string]$msg, [int]$code = 1) {
   Write-Host "[release] fatal: $msg" -ForegroundColor Red
+  Clear-DeployNotice
   exit $code
 }
 
@@ -173,6 +214,48 @@ try {
 
   # === 2. derived options ====================================================
   $backOnlyBool = if ($BackOnly) { 'true' } else { 'false' }
+
+  # === 2b. resolve SSH connection params (mirror nodes.sh) ===================
+  # Resolved BEFORE the build now -- the preflight below contacts prod
+  # first. Also used by the verify + recovery sections later.
+  $sshHost  = if ($env:RC_SSH_HOST)  { $env:RC_SSH_HOST }  else { 'rc@ec2-98-91-16-141.compute-1.amazonaws.com' }
+  $sshKey   = if ($env:SSH_KEY)      { $env:SSH_KEY }       else { Join-Path $HOME '.ssh\rc-prod.pem' }
+  $sshPort  = if ($env:RC_SSH_PORT)  { $env:RC_SSH_PORT }  else { '22' }
+
+  $sshArgs = @('-i', $sshKey, '-o', 'StrictHostKeyChecking=accept-new', '-p', $sshPort)
+  if ($env:RC_SSH_EXTRA_OPTS) {
+    $sshArgs += ($env:RC_SSH_EXTRA_OPTS -split '\s+' | Where-Object { $_ })
+  }
+
+  # === 2c. preflight: reach prod + raise the deploy notice ===================
+  # Contact prod BEFORE the (long) build. This
+  #   * fails fast when prod is unreachable -- no point building,
+  #   * triggers the operator's SSH-key approval (1Password) now, while
+  #     they are still watching, so the post-build connections reuse it,
+  #   * raises the deploy-notice flag (RC.Deploy) so players get the
+  #     heads-up in the news ticker and in-game chat for the whole
+  #     build+deploy window.
+  # ssh exit 255 = transport failure -> abort. Any other failure only
+  # warns: the app may be stopped, or prod may still run a release that
+  # predates RC.Deploy -- the deploy itself can proceed either way.
+  if ($BuildOnly) {
+    Step "-BuildOnly -- skipping prod preflight (no deploy will happen)"
+  }
+  else {
+    Step "preflight: connecting to prod ($sshHost)"
+    $preflightExit = Invoke-DeployNoticeRpc 'start_deploy'
+    if ($preflightExit -eq 255) {
+      Fail "cannot reach $sshHost over SSH (exit 255) -- aborting before the build. Fix reachability first (security group / VPN / instance state), then re-run." 3
+    }
+    elseif ($preflightExit -ne 0) {
+      Write-Host "[release] WARNING: prod reachable but deploy notice not raised (exit $preflightExit)" -ForegroundColor Yellow
+      Write-Host "[release]   likely: app stopped, or prod release predates RC.Deploy -- continuing without notice" -ForegroundColor Yellow
+    }
+    else {
+      $script:deployNoticeSet = $true
+      Step "deploy notice raised -- players see the heads-up now"
+    }
+  }
 
   # === 3. build ==============================================================
   if ($SkipBuild) {
@@ -352,15 +435,7 @@ try {
     Step "skipping local deploy.sh -- deploy was run on the builder"
   }
 
-  # === 6. resolve SSH connection params (mirror nodes.sh) ===================
-  $sshHost  = if ($env:RC_SSH_HOST)  { $env:RC_SSH_HOST }  else { 'rc@ec2-98-91-16-141.compute-1.amazonaws.com' }
-  $sshKey   = if ($env:SSH_KEY)      { $env:SSH_KEY }       else { Join-Path $HOME '.ssh\rc-prod.pem' }
-  $sshPort  = if ($env:RC_SSH_PORT)  { $env:RC_SSH_PORT }  else { '22' }
-
-  $sshArgs = @('-i', $sshKey, '-o', 'StrictHostKeyChecking=accept-new', '-p', $sshPort)
-  if ($env:RC_SSH_EXTRA_OPTS) {
-    $sshArgs += ($env:RC_SSH_EXTRA_OPTS -split '\s+' | Where-Object { $_ })
-  }
+  # === 6. (SSH connection params now resolved in section 2b, pre-build) =====
 
   # === 7. verify deployed revision (read priv/VERSION on prod, NOT journal) =
   Step "verifying deployed revision on $sshHost"
@@ -402,6 +477,10 @@ try {
     Write-Host ""
     Write-Host "  Your deploy most likely succeeded. Confirm once SSH is reachable:"
     Write-Host "    ssh -i `"$sshKey`" -p $sshPort $sshHost 'cat /home/rc/rc/lib/rc-*/priv/VERSION'"
+    Write-Host ""
+    Write-Host "  The deploy notice may still be active on prod -- once reachability"
+    Write-Host "  is back, clear it with /cleardeploy on Discord (or re-run verify)."
+    Clear-DeployNotice
     exit 3
   }
 
@@ -419,6 +498,7 @@ try {
     Write-Host "  The deploy itself ran but prod is on the wrong revision. Likely cause:"
     Write-Host "  Docker layer cache served a stale COPY layer. Re-run without -AllowCache"
     Write-Host "  and verify rc_build_image was rebuilt (not cache-hit)."
+    Clear-DeployNotice
     exit 1
   }
 
@@ -553,6 +633,9 @@ set -a; . /etc/rc/env; set +a
     Write-Host "  (instances still in maintenance -- investigate via ssh)"
     Write-Host "========================================"
     Write-Host "  RELEASE: PARTIAL -- recovery incomplete" -ForegroundColor Yellow
+    # New code is live -- send the update-applied notice despite the
+    # stuck instances.
+    Complete-DeployNotice
     exit 2
   }
 
@@ -564,13 +647,24 @@ set -a; . /etc/rc/env; set +a
     }
     Write-Host "========================================"
     Write-Host "  RELEASE: PARTIAL -- recovery rpc errored" -ForegroundColor Yellow
+    Complete-DeployNotice
     exit 2
   }
+
+  Complete-DeployNotice
 
   Write-Host "  failed        : none"
   Write-Host "========================================"
   Write-Host "  RELEASE: PASS" -ForegroundColor Green
 }
 finally {
+  # Runs on ctrl-C and on unexpected termination too. Normal paths have
+  # already cleared/finished the notice (flag false -> no-op); reaching
+  # here with it still set means we bailed mid-flight.
+  if ($script:deployNoticeSet) {
+    Write-Host ""
+    Step "exiting with the deploy notice still up -- attempting to clear"
+    Clear-DeployNotice
+  }
   Pop-Location
 }

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -96,6 +96,103 @@ fi
 echo "$REVISION" > priv/VERSION
 echo "[release] target revision: $REVISION"
 
+# === preflight: reach prod + raise the deploy notice ==========================
+# Contact prod BEFORE the (long) build. This
+#   * fails fast when prod is unreachable — no point building,
+#   * triggers the operator's SSH-key approval (1Password) now, while
+#     they are still watching, so the post-build connections reuse it,
+#   * raises the deploy-notice flag (RC.Deploy) so players get the
+#     heads-up in the news ticker and in-game chat for the whole
+#     build+deploy window.
+# ssh exit 255 = transport failure → abort. Any other failure only warns:
+# the app may be stopped, or prod may still run a release that predates
+# RC.Deploy — the deploy itself can proceed either way.
+
+source ./nodes.sh
+HOST="${NODES[0]}"
+DEPLOY_NOTICE_SET=0
+
+# Run one of RC.Deploy's zero-arg entry points (start_deploy /
+# finish_deploy / clear_deploy) on prod via the env-source + rc rpc
+# idiom. Stdout+stderr combined for the caller to report.
+deploy_notice_rpc() {
+  local fn="$1"
+  ssh "${SSH_OPTS[@]}" -o ConnectTimeout=15 "$HOST" bash -s <<REMOTE 2>&1
+set -e
+cd /home/rc
+set -a; . /etc/rc/env; set +a
+./rc/bin/rc rpc "RC.Deploy.${fn}()"
+REMOTE
+}
+
+# Best-effort flag clear for failure paths (no player-facing message).
+clear_deploy_notice() {
+  [[ "$DEPLOY_NOTICE_SET" != "1" ]] && return 0
+  echo "[release] clearing deploy notice on prod"
+  if ! deploy_notice_rpc clear_deploy >/dev/null; then
+    echo "[release] WARNING: could not clear the deploy notice — run /cleardeploy on Discord" >&2
+  fi
+  DEPLOY_NOTICE_SET=0
+}
+
+# Flag down + "update applied" chat message. For PASS and PARTIAL paths
+# (the new code is live either way).
+finish_deploy_notice() {
+  [[ "$DEPLOY_NOTICE_SET" != "1" ]] && return 0
+  echo "[release] finishing deploy notice on prod (update-applied message)"
+  if ! deploy_notice_rpc finish_deploy >/dev/null; then
+    echo "[release] WARNING: could not send the deploy-finished notice — run /cleardeploy on Discord" >&2
+  fi
+  DEPLOY_NOTICE_SET=0
+}
+
+on_interrupt() {
+  trap - INT TERM
+  echo
+  echo "[release] interrupted — attempting to clear the deploy notice"
+  clear_deploy_notice
+  exit 130
+}
+trap on_interrupt INT TERM
+
+# Safety net for every other failure exit (set -e aborts, explicit exit
+# 1/2/3 paths). Success/failure paths that already finished or cleared
+# the notice set DEPLOY_NOTICE_SET=0 first, making this a no-op.
+on_exit() {
+  local code=$?
+  if [[ "$code" -ne 0 && "$DEPLOY_NOTICE_SET" == "1" ]]; then
+    echo "[release] exiting (code $code) with the deploy notice still up — attempting to clear"
+    clear_deploy_notice
+  fi
+}
+trap on_exit EXIT
+
+if [[ "$BUILD_ONLY" == "1" ]]; then
+  echo "[release] --build-only — skipping prod preflight (no deploy will happen)"
+else
+  echo "[release] preflight: connecting to prod ($HOST)"
+  set +e
+  PREFLIGHT_OUTPUT=$(deploy_notice_rpc start_deploy)
+  PREFLIGHT_EXIT=$?
+  set -e
+
+  if [[ "$PREFLIGHT_EXIT" -eq 255 ]]; then
+    cat >&2 <<EOF
+[release] fatal: cannot reach $HOST over SSH (exit 255) — aborting before
+  the build. Fix reachability first (security group / VPN / instance
+  state), then re-run.
+EOF
+    exit 3
+  elif [[ "$PREFLIGHT_EXIT" -ne 0 ]]; then
+    echo "[release] WARNING: prod reachable but deploy notice not raised (exit $PREFLIGHT_EXIT)"
+    echo "[release]   likely: app stopped, or prod release predates RC.Deploy — continuing without notice"
+    echo "$PREFLIGHT_OUTPUT" | tail -3 | sed 's/^/[release]   rpc: /'
+  else
+    DEPLOY_NOTICE_SET=1
+    echo "[release] deploy notice raised — players see the heads-up now"
+  fi
+fi
+
 # === 2. build =================================================================
 if [[ "$BACK_ONLY" == "1" ]]; then BACK_ONLY_BOOL=true; else BACK_ONLY_BOOL=false; fi
 REMOTE_USED=0
@@ -173,8 +270,7 @@ fi
 # === 4. verify deployed revision (read priv/VERSION on prod, NOT journal) =====
 # Reading from the static file is immune to journalctl rollover, which is
 # what masked the wrong-revision incident on 2026-06-07.
-source ./nodes.sh
-HOST="${NODES[0]}"
+# (nodes.sh already sourced by the preflight section.)
 echo "[release] verifying deployed revision on $HOST"
 # The remote command ends in `|| true` so the ONLY source of a non-zero
 # exit is ssh's own transport failure (255 — timeout, no route, refused).
@@ -208,7 +304,11 @@ if [[ "$SSH_EXIT" -ne 0 ]]; then
 
   Your deploy most likely succeeded. Confirm once SSH is reachable:
     ssh ${SSH_OPTS[*]} $HOST 'cat /home/rc/rc/lib/rc-*/priv/VERSION'
+
+  The deploy notice may still be active on prod — once reachability is
+  back, clear it with /cleardeploy on Discord (or re-run the verify).
 EOF
+  clear_deploy_notice
   exit 3
 fi
 
@@ -225,6 +325,7 @@ if [[ "$PROD_REV" != "$REVISION" ]]; then
   Docker layer cache served a stale COPY layer. Re-run with RC_NO_CACHE=1
   (default) and verify rc_build_image was rebuilt (not cache-hit).
 EOF
+  clear_deploy_notice
   exit 1
 fi
 
@@ -300,6 +401,9 @@ if [[ -n "$FAILED_LINES" ]]; then
   echo "  (instances still in maintenance — investigate via ssh)"
   echo "========================================"
   echo "  RELEASE: PARTIAL — recovery incomplete"
+  # New code is live — send the update-applied notice despite the
+  # stuck instances.
+  finish_deploy_notice
   exit 2
 fi
 
@@ -309,6 +413,7 @@ if [[ "$RPC_PROBABLY_BROKEN" -eq 1 ]]; then
   echo "$RECOVERY_OUTPUT" | sed 's/^/    /' | head -20
   echo "========================================"
   echo "  RELEASE: PARTIAL — recovery rpc errored"
+  finish_deploy_notice
   exit 2
 fi
 
@@ -333,6 +438,8 @@ if [[ "$REMOTE_USED" == "1" && "$BACK_ONLY" != "1" ]]; then
       || echo "[release] WARNING: invalidation failed — edge caches will age out naturally"
   fi
 fi
+
+finish_deploy_notice
 
 echo "  failed        : none"
 echo "========================================"

--- a/front/src/game/components/navbar/Topbar.vue
+++ b/front/src/game/components/navbar/Topbar.vue
@@ -46,8 +46,13 @@
           {{ $t('navbar.topbar.bankrupt') }}
         </div>
         <div
+          class="headband headband-deploy"
+          v-if="$config.MODE && !time.is_running && deployOngoing">
+          {{ $t('navbar.topbar.deploy_interruption') }}
+        </div>
+        <div
           class="headband"
-          v-if="$config.MODE && !time.is_running">
+          v-else-if="$config.MODE && !time.is_running">
           {{ $t('navbar.topbar.supervisor_paused') }}
         </div>
         <div
@@ -167,6 +172,9 @@ export default {
   },
   computed: {
     time() { return this.$store.state.game.time; },
+    // Deploy-related pause: the portal socket flips this before the game
+    // socket drops, so the "Paused" headband can name the real cause.
+    deployOngoing() { return this.$store.state.portal.deployOngoing; },
     isDead() { return this.$store.state.game.isDead; },
     faction() { return this.$store.state.game.faction; },
     victory() { return this.$store.state.game.victory; },

--- a/front/src/locales/de/game.json
+++ b/front/src/locales/de/game.json
@@ -304,6 +304,7 @@
       "bankrupt_tooltip": "Ihr Imperium verfügt nicht mehr über die finanziellen Mittel, um Ihre Agenten zu unterstützen. Sie sind in den Streik getreten und gehorchen nicht mehr den Anweisungen. Die Navarchs haben auch ihre Reaktion auf \"Flucht\" geändert.",
       "character_market_panel": "Agentenmarkt",
       "defeat": "Sie wurden besiegt",
+      "deploy_interruption": "Unterbrechung für Updates. Bitte neu verbinden",
       "supervisor_paused": "Pausiert",
       "victory_of": "Sieg von",
       "victory_panel": "Siege",

--- a/front/src/locales/de/portal.json
+++ b/front/src/locales/de/portal.json
@@ -12,6 +12,9 @@
       "registered": "Ungültig"
     }
   },
+  "deploy": {
+    "ongoing_banner": "Server-Update läuft. In den nächsten 10 Minuten ist mit einer kurzen Unterbrechung zu rechnen."
+  },
   "instance": {
     "registration_state": {
       "can_play": "Spielen",

--- a/front/src/locales/en/game.json
+++ b/front/src/locales/en/game.json
@@ -456,6 +456,7 @@
       "daily_seconds": "seconds",
       "daily_time_left": "Time left in today's daily",
       "defeat": "You were defeated",
+      "deploy_interruption": "Interruption for updates. Please reconnect",
       "help_panel": "Help",
       "market_panel": "Market",
       "supervisor_paused": "Paused",

--- a/front/src/locales/en/portal.json
+++ b/front/src/locales/en/portal.json
@@ -85,6 +85,9 @@
     "update": "Update",
     "update_restricted": "Updated"
   },
+  "deploy": {
+    "ongoing_banner": "Server deployment is on-going. Expect momentary service interruption within the next 10 minutes."
+  },
   "news": {
     "agent": {
       "assassinated": {

--- a/front/src/locales/fr/game.json
+++ b/front/src/locales/fr/game.json
@@ -456,6 +456,7 @@
       "bankrupt_tooltip": "Votre empire n'a plus les moyens de soutenir vos agents. Ces derniers se sont mis en grève et ne répondent plus aux ordres. Les navarques se sont également mis en mode fuyard.",
       "character_market_panel": "Marché des agents",
       "defeat": "Vous avez été défait",
+      "deploy_interruption": "Interruption pour mise à jour. Veuillez vous reconnecter",
       "help_panel": "Aide",
       "market_panel": "Marché",
       "supervisor_paused": "En pause",

--- a/front/src/locales/fr/portal.json
+++ b/front/src/locales/fr/portal.json
@@ -12,6 +12,9 @@
       "registered": "Non validé"
     }
   },
+  "deploy": {
+    "ongoing_banner": "Déploiement serveur en cours. Une brève interruption de service est à prévoir dans les 10 prochaines minutes."
+  },
   "instance": {
     "registration_state": {
       "can_play": "Jouer",

--- a/front/src/plugins/websockets.js
+++ b/front/src/plugins/websockets.js
@@ -79,13 +79,23 @@ const socket = {
 
     // connect to portal channel for all users and this user
     this.users = this.ws.channel('portal:user:*', {});
-    this.users.join(CHANNEL_JOIN_TIMEOUT);
+    // The join reply carries the current deploy flag: broadcasts predate
+    // a late join, so a client connecting mid-deploy learns about it
+    // here (and again on every automatic rejoin after a reconnect).
+    this.users.join(CHANNEL_JOIN_TIMEOUT).receive('ok', (data = {}) => {
+      if (typeof data.deploy_flag !== 'undefined') {
+        store.commit('portal/deployOngoing', data.deploy_flag);
+      }
+    });
     this.users.on('broadcast', (data = {}) => {
       if (typeof data.maintenance_flag !== 'undefined') {
         store.commit('portal/isInMaintenance', data.maintenance_flag);
       }
       if (typeof data.min_client_version !== 'undefined') {
         store.dispatch('portal/updateVersion', data.min_client_version);
+      }
+      if (typeof data.deploy_flag !== 'undefined') {
+        store.commit('portal/deployOngoing', data.deploy_flag);
       }
     });
     this.user = this.ws.channel(`portal:user:${store.state.portal.account.id}`, {});

--- a/front/src/portal/components/NewsMarquee.vue
+++ b/front/src/portal/components/NewsMarquee.vue
@@ -1,6 +1,18 @@
 <template>
+  <!-- Deploy override: while a server deployment is in flight the
+       marquee stops scrolling news and shows the interruption notice. -->
   <div
-    v-if="items.length > 0"
+    v-if="deployOngoing"
+    class="news-marquee is-deploy">
+    <span class="news-marquee-label">
+      <svgicon class="icon" name="disc" />
+    </span>
+    <div class="news-marquee-viewport">
+      <span class="news-marquee-item is-deploy-notice">{{ $t('deploy.ongoing_banner') }}</span>
+    </div>
+  </div>
+  <div
+    v-else-if="items.length > 0"
     class="news-marquee"
     :title="$t('page.instance.news_heading')">
     <span class="news-marquee-label">
@@ -50,6 +62,9 @@ export default {
     };
   },
   computed: {
+    deployOngoing() {
+      return this.$store.state.portal.deployOngoing;
+    },
     scrollSeconds() {
       return Math.max(20, this.items.length * SECONDS_PER_ITEM);
     },
@@ -136,6 +151,21 @@ export default {
 
     &:hover {
       animation-play-state: paused;
+    }
+  }
+
+  // Deploy override: amber (matches the in-game SYSTEM chat color),
+  // static — a critical notice shouldn't scroll off-screen.
+  &.is-deploy {
+    color: #ffc95e;
+
+    .news-marquee-viewport {
+      mask-image: none;
+    }
+
+    .news-marquee-item.is-deploy-notice {
+      opacity: 1;
+      font-weight: bold;
     }
   }
 

--- a/front/src/portal/store.js
+++ b/front/src/portal/store.js
@@ -13,6 +13,9 @@ const portalStore = {
   state: {
     isSignedIn: null,
     isInMaintenance: null,
+    // Server deployment in flight (RC.Deploy flag, portal:user:* socket).
+    // Drives the news-marquee override and the in-game deploy headband.
+    deployOngoing: false,
     hasCorrectVersion: null,
     requiredVersion: '',
     hasConnectivity: true,
@@ -74,6 +77,9 @@ const portalStore = {
     },
     isInMaintenance(state, payload) {
       state.isInMaintenance = payload;
+    },
+    deployOngoing(state, payload) {
+      state.deployOngoing = payload === true;
     },
     hasCorrectVersion(state, payload) {
       if (config.IS_STEAM) {

--- a/front/src/styles/game/components/navbar/main.scss
+++ b/front/src/styles/game/components/navbar/main.scss
@@ -530,6 +530,16 @@ $navbar-b10: rgba(0, 0, 0, .1);
     text-transform: uppercase;
     font-size: 1.4rem;
     font-weight: bold;
+
+    // Deploy-related pause: amber (same as SYSTEM chat lines), wider to
+    // fit the reconnect instruction. !important beats the per-faction
+    // `.navbar.top .headband { color: $color; }` theme override below.
+    &.headband-deploy {
+      width: 340px;
+      left: -170px;
+      color: #ffc95e !important;
+      border-color: #ffc95e !important;
+    }
   }
 }
 

--- a/lib/game/instance/faction/agent.ex
+++ b/lib/game/instance/faction/agent.ex
@@ -1124,6 +1124,33 @@ defmodule Instance.Faction.Agent do
     {:noreply, state}
   end
 
+  # Server-originated system chat line (deploy notices, etc.). Same wire
+  # shape as the genesis CHEAT announcement: from "SYSTEM", from_id nil.
+  # Only ever cast from trusted server code (RC.Deploy fan-out), never
+  # from a channel's client-facing handlers.
+  @decorate tick()
+  def on_cast({:push_system_message, message}, state) when is_binary(message) do
+    data = Faction.push_system_message(state.data, message)
+    FactionChannel.broadcast_change(state.channel, %{faction_faction: data})
+
+    {:noreply, %{state | data: data}}
+  end
+
+  # Idempotent variant: no-op when the exact line is already in the ring.
+  # Used for the deploy-ongoing notice, which is re-asserted on every
+  # late faction-channel join while the flag is up.
+  @decorate tick()
+  def on_cast({:push_system_message_once, message}, state) when is_binary(message) do
+    if Faction.has_system_message?(state.data, message) do
+      {:noreply, state}
+    else
+      data = Faction.push_system_message(state.data, message)
+      FactionChannel.broadcast_change(state.channel, %{faction_faction: data})
+
+      {:noreply, %{state | data: data}}
+    end
+  end
+
   def on_cast({:radar_update, system}, state) do
     data =
       case Faction.radar_update(state.data, system) do

--- a/lib/game/instance/faction/faction.ex
+++ b/lib/game/instance/faction/faction.ex
@@ -235,6 +235,13 @@ defmodule Instance.Faction.Faction do
     append_chat_message(state, Faction.ChatMessage.new("SYSTEM", nil, message))
   end
 
+  # True when the exact system line is already in the chat ring — lets
+  # re-asserted notices (deploy watcher on every late join) stay
+  # idempotent instead of spamming the ring.
+  def has_system_message?(state, message) when is_binary(message) do
+    Enum.any?(state.chat, fn m -> is_nil(m.from_id) and m.message == message end)
+  end
+
   defp append_chat_message(state, %Faction.ChatMessage{} = message) do
     chat = List.flatten(state.chat, [message])
 

--- a/lib/portal/channels/controllers/faction_channel.ex
+++ b/lib/portal/channels/controllers/faction_channel.ex
@@ -97,6 +97,19 @@ defmodule Portal.Controllers.FactionChannel do
     {:ok, _} = Presence.track(socket, socket.assigns.player_id, %{})
     push(socket, "presence_state", Presence.list(socket))
 
+    # Deploy-notice watcher: while a deployment is in flight, re-assert
+    # the SYSTEM chat line on every join so players who load the match
+    # after the initial fan-out still see it. The agent-side dedup
+    # (:push_system_message_once) makes this idempotent.
+    if RC.Deploy.get_flag() do
+      Game.cast(
+        socket.assigns.instance_id,
+        :faction,
+        socket.assigns.faction_id,
+        {:push_system_message_once, RC.Deploy.ongoing_message()}
+      )
+    end
+
     {:noreply, socket}
   end
 

--- a/lib/portal/channels/controllers/portal_channel.ex
+++ b/lib/portal/channels/controllers/portal_channel.ex
@@ -8,7 +8,11 @@ defmodule Portal.Controllers.PortalChannel do
   # but no per-user binding — the payload is global and non-sensitive.
   # See Portal.Config / RC.Maintenance for the broadcast call sites.
   def join("portal:user:*", _data, socket) do
-    {:ok, %{resp: "ok"}, socket}
+    # The topic has no join-time replay of broadcasts, so hand the client
+    # the current deploy flag here — a client connecting mid-deploy would
+    # otherwise never learn about it (the set-time broadcast predates its
+    # join).
+    {:ok, %{resp: "ok", deploy_flag: RC.Deploy.get_flag()}, socket}
   end
 
   def join("portal:user:" <> account_id, _data, socket) do

--- a/lib/portal/config.ex
+++ b/lib/portal/config.ex
@@ -15,13 +15,19 @@ defmodule Portal.Config do
         login_mode: Application.get_env(:rc, :login_mode),
         maintenance_flag: flag,
         min_client_version: version,
+        # Deploy notice. Persisted via deploy_log rows so it survives the
+        # mid-deploy restart; the deploy script clears it when done.
+        deploy_flag: RC.Deploy.get_flag_from_db(),
         # Stress-test fleet on/off. Persisted via bot_events lifecycle
         # rows; defaults to false so a restart never silently re-enables
         # a paused fleet.
         stress_test_enabled: RC.BotControl.initial_state()
       }
 
-      PortalChannel.broadcast_change("portal:user:*", Map.take(config, [:maintenance_flag, :min_client_version]))
+      PortalChannel.broadcast_change(
+        "portal:user:*",
+        Map.take(config, [:maintenance_flag, :min_client_version, :deploy_flag])
+      )
 
       Horde.Registry.put_meta(Game.Registry, @meta_key, config)
     end
@@ -52,7 +58,10 @@ defmodule Portal.Config do
   def update_key(key, value) do
     case fetch() do
       {:ok, config} ->
-        new_config = Map.update!(config, key, fn _ -> value end)
+        # Map.put (not update!): a cached map seeded by an older node may
+        # lack a newly-introduced key, and a raise here would take the
+        # caller (channel process, rpc) down with it.
+        new_config = Map.put(config, key, value)
         Horde.Registry.put_meta(Game.Registry, @meta_key, new_config)
 
       :error ->

--- a/lib/rc/deploy.ex
+++ b/lib/rc/deploy.ex
@@ -1,0 +1,131 @@
+defmodule RC.Deploy do
+  @moduledoc """
+  Deployment-notice flag: player-facing "a deploy is happening" signal.
+
+  Storage follows the `RC.Maintenance` / `RC.BotControl` dual-storage
+  idiom: `Portal.Config` is the fast in-memory cache, the append-only
+  `deploy_log` table is the durable truth (the flag must survive the
+  mid-deploy app restart), and every change is broadcast on the public
+  `portal:user:*` topic so connected clients react live. Clients that
+  connect later pick the flag up from the `portal:user:*` join reply
+  (see `Portal.Controllers.PortalChannel`).
+
+  The deploy script drives this over ssh + `rc rpc`:
+
+    * `start_deploy/1`  — preflight, before the build: raises the flag
+      and announces the upcoming interruption in every live game's chat.
+    * `finish_deploy/1` — after a verified deploy: clears the flag and
+      announces that an update was applied.
+    * `clear_deploy/1`  — aborted/failed deploy (or Discord
+      `/cleardeploy`): clears the flag with no announcement.
+
+  All three are zero-arity-callable from `rc rpc` (the `source` argument
+  defaults to `"script"`) so the remote command needs no nested quoting.
+  """
+
+  import Ecto.Query, warn: false
+
+  require Logger
+
+  alias Portal.Config
+  alias Portal.Controllers.PortalChannel
+  alias RC.Repo
+
+  @ongoing_message "Server deployment is on-going. Expect momentary service interruption within the next 10 minutes."
+  @finished_message "An update has been applied, a client refresh is recommended."
+
+  def ongoing_message, do: @ongoing_message
+  def finished_message, do: @finished_message
+
+  @doc """
+  Raise the deploy notice: flag up + SYSTEM chat line in every faction of
+  every live instance. Idempotent — re-running re-broadcasts the flag but
+  the chat line is only inserted once per faction ring.
+  """
+  def start_deploy(source \\ "script") do
+    set_flag(true, source)
+    broadcast_system_chat(@ongoing_message, :once)
+    :ok
+  end
+
+  @doc """
+  Deploy verified complete: flag down + "update applied" SYSTEM chat line
+  in every faction of every live instance.
+  """
+  def finish_deploy(source \\ "script") do
+    set_flag(false, source)
+    broadcast_system_chat(@finished_message, :always)
+    :ok
+  end
+
+  @doc """
+  Deploy aborted or failed: flag down, no chat announcement. Also the
+  manual kill-switch behind Discord's `/cleardeploy`.
+  """
+  def clear_deploy(source \\ "script") do
+    set_flag(false, source)
+    :ok
+  end
+
+  @doc """
+  Write flag to DB and update cache + broadcast (cache is warmed up from
+  DB at startup by `Portal.Config.init_config/0`).
+  """
+  def set_flag(flag, source) when is_boolean(flag) do
+    Config.update_key(:deploy_flag, flag)
+
+    PortalChannel.broadcast_change("portal:user:*", %{deploy_flag: flag})
+
+    %RC.Deploy.Log{}
+    |> RC.Deploy.Log.changeset(%{flag: flag, source: to_string(source)})
+    |> Repo.insert()
+  end
+
+  @doc """
+  Get flag from cache, fallback to DB. Never raises — this sits on the
+  faction-channel join path.
+  """
+  def get_flag do
+    case Config.fetch() do
+      {:ok, %{deploy_flag: flag}} -> flag
+      _ -> get_flag_from_db()
+    end
+  end
+
+  def get_flag_from_db do
+    case from(l in RC.Deploy.Log, order_by: [desc: :id], limit: 1) |> Repo.one() do
+      nil -> false
+      %RC.Deploy.Log{flag: flag} -> flag
+    end
+  end
+
+  @doc """
+  Push a SYSTEM chat line into every faction chat ring of every live
+  instance. `mode` is `:always` (plain append) or `:once` (skip factions
+  whose ring already holds the exact line — used for the ongoing notice,
+  which is also re-asserted on every late channel join).
+  """
+  def broadcast_system_chat(message, mode) when is_binary(message) and mode in [:always, :once] do
+    op =
+      case mode do
+        :always -> {:push_system_message, message}
+        :once -> {:push_system_message_once, message}
+      end
+
+    ["running", "paused"]
+    |> RC.Instances.list_instances_with_state()
+    |> Enum.filter(fn instance -> Instance.Manager.get_status(instance.id) in [:running, :instantiated] end)
+    |> Enum.each(fn instance ->
+      Enum.each(faction_ids(instance.id), fn faction_id ->
+        Game.cast(instance.id, :faction, faction_id, op)
+      end)
+    end)
+  end
+
+  defp faction_ids(instance_id) do
+    case RC.Instances.get_instance(instance_id) do
+      %{factions: factions} when is_list(factions) -> Enum.map(factions, & &1.id)
+      _ -> []
+    end
+  end
+end

--- a/lib/rc/deploy/log.ex
+++ b/lib/rc/deploy/log.ex
@@ -1,0 +1,23 @@
+defmodule RC.Deploy.Log do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  # `source` records who flipped the flag: "script" (the deploy script's
+  # rpc), "discord:<snowflake>" (/cleardeploy), etc. Append-only — the
+  # newest row is the current flag state (same idiom as maintenance_log).
+  schema "deploy_log" do
+    field(:flag, :boolean)
+    field(:source, :string)
+
+    timestamps(type: :utc_datetime_usec, updated_at: false)
+  end
+
+  @doc false
+  def changeset(log, attrs) do
+    log
+    |> cast(attrs, [:flag, :source])
+    |> validate_required([:flag, :source])
+    |> validate_length(:source, max: 255)
+  end
+end

--- a/lib/rc/discord/commands.ex
+++ b/lib/rc/discord/commands.ex
@@ -170,6 +170,11 @@ defmodule RC.Discord.Commands do
           type: @opt_type_subcommand
         }
       ]
+    },
+    %{
+      name: "cleardeploy",
+      description: "Admin: clear a stuck deployment notice (aborted or crashed deploy).",
+      type: @cmd_type_chat_input
     }
   ]
 
@@ -342,6 +347,35 @@ defmodule RC.Discord.Commands do
 
       true ->
         reply_ephemeral(interaction, "❌ Unknown teardown subcommand: #{inspect(sub)}")
+    end
+  end
+
+  # /cleardeploy — admin kill-switch for a stuck deployment notice. The
+  # deploy script normally clears the flag itself (finish on success,
+  # clear on a caught failure); this covers the ctrl-C / crashed-script
+  # case where it never does. Same auth model as /promote & /teardown.
+  defp handle_command("cleardeploy", interaction) do
+    discord_id = interaction_user_id(interaction)
+
+    cond do
+      is_nil(discord_id) ->
+        reply_ephemeral(interaction, "❌ Couldn't identify your Discord account.")
+
+      not RC.Discord.LegacyMatch.authorized?(discord_id) ->
+        reply_ephemeral(
+          interaction,
+          "❌ This command is restricted. Link a game-admin account via `/link` first."
+        )
+
+      true ->
+        was_active = RC.Deploy.get_flag()
+        RC.Deploy.clear_deploy("discord:#{discord_id}")
+
+        if was_active do
+          reply_ephemeral(interaction, "✅ Deployment notice cleared.")
+        else
+          reply_ephemeral(interaction, "ℹ️ No deployment notice was active — flag re-cleared anyway.")
+        end
     end
   end
 

--- a/priv/repo/migrations/20260719000001_create_deploy_log.exs
+++ b/priv/repo/migrations/20260719000001_create_deploy_log.exs
@@ -1,0 +1,12 @@
+defmodule RC.Repo.Migrations.CreateDeployLog do
+  use Ecto.Migration
+
+  def change do
+    create table(:deploy_log) do
+      add(:flag, :boolean, null: false)
+      add(:source, :string, null: false)
+
+      timestamps(type: :utc_datetime_usec, updated_at: false)
+    end
+  end
+end

--- a/test/game/instance/faction/faction_chat_test.exs
+++ b/test/game/instance/faction/faction_chat_test.exs
@@ -46,6 +46,26 @@ defmodule Instance.Faction.FactionChatTest do
     assert [%{from: "SYSTEM", from_id: nil, message: "hello"}] = faction.chat
   end
 
+  test "has_system_message? matches only system lines with the exact text" do
+    faction =
+      db_faction()
+      |> Faction.new(@plain_iid)
+      |> Faction.push_system_message("deploy incoming")
+      |> Faction.push_message("Alice", 42, "deploy incoming")
+
+    assert Faction.has_system_message?(faction, "deploy incoming")
+    refute Faction.has_system_message?(faction, "other text")
+
+    # A player-authored line with the same text does not count as a
+    # system line (from_id present).
+    only_player =
+      db_faction()
+      |> Faction.new(@plain_iid)
+      |> Faction.push_message("Alice", 42, "deploy incoming")
+
+    refute Faction.has_system_message?(only_player, "deploy incoming")
+  end
+
   test "cheat helpers default to disabled / 1x outside a live instance" do
     refute Instance.Cheats.enabled?(123_456_789)
     assert Instance.Cheats.speedup(123_456_789) == 1

--- a/test/rc/deploy_test.exs
+++ b/test/rc/deploy_test.exs
@@ -1,0 +1,51 @@
+defmodule RC.DeployTest do
+  use RC.DataCase
+
+  alias RC.Deploy
+
+  @moduledoc """
+  Deployment-notice flag: DB log persistence + flag lifecycle. The
+  Portal.Config cache and channel broadcast sides are exercised
+  implicitly (they no-op harmlessly when the cache/endpoint audience is
+  empty); the durable DB truth is what must survive the mid-deploy
+  restart, so that is what we pin here.
+  """
+
+  test "flag defaults to false with an empty log" do
+    assert Deploy.get_flag_from_db() == false
+  end
+
+  test "set_flag persists an append-only log row" do
+    assert {:ok, _} = Deploy.set_flag(true, "test")
+    assert Deploy.get_flag_from_db() == true
+
+    assert {:ok, _} = Deploy.set_flag(false, "test")
+    assert Deploy.get_flag_from_db() == false
+
+    # Append-only: both rows kept, newest wins.
+    assert Repo.aggregate(RC.Deploy.Log, :count) == 2
+  end
+
+  test "start/finish/clear lifecycle drives the flag" do
+    assert :ok = Deploy.start_deploy("test")
+    assert Deploy.get_flag_from_db() == true
+
+    assert :ok = Deploy.finish_deploy("test")
+    assert Deploy.get_flag_from_db() == false
+
+    assert :ok = Deploy.start_deploy("test")
+    assert :ok = Deploy.clear_deploy("discord:123")
+    assert Deploy.get_flag_from_db() == false
+  end
+
+  test "source is recorded on the log row" do
+    assert {:ok, log} = Deploy.set_flag(true, "discord:42")
+    assert log.source == "discord:42"
+    assert log.flag == true
+  end
+
+  test "changeset rejects a missing source" do
+    changeset = RC.Deploy.Log.changeset(%RC.Deploy.Log{}, %{flag: true})
+    refute changeset.valid?
+  end
+end


### PR DESCRIPTION
…sh preflight

RC.Deploy: persistent deploy-notice flag (append-only deploy_log + Portal.Config cache + portal:user:* broadcast) with zero-arg rpc entry points start_deploy/finish_deploy/clear_deploy for the deploy script.

Surfaces: portal news marquee overrides to a deployment banner; every live game's chat gets a SYSTEM line (new push_system_message casts on Faction.Agent, idempotent once-variant re-asserted on late faction- channel joins); the portal:user:* join reply carries the flag for clients connecting mid-deploy; the in-game Paused headband reads "Interruption for updates. Please reconnect" while the flag is up.

release.sh/release.ps1: preflight ssh before the build (fail-fast reachability + triggers the 1Password key prompt early + raises the notice), finish on PASS/PARTIAL (update-applied chat line), best-effort clear on FAIL/INCONCLUSIVE, ctrl-C traps and exit-path safety nets.

Discord /cleardeploy (admin-gated, game guild) is the manual kill-switch for a stuck notice when the script dies without cleaning up.