### PR TITLE
feat(victory): per-instance win-points target + dynamic star tracker

### DIFF
--- a/front/src/game/components/mini-panel/VictoryMiniPanel.vue
+++ b/front/src/game/components/mini-panel/VictoryMiniPanel.vue
@@ -82,9 +82,11 @@
                 <div class="rank">{{ numberToRoman(i + 1) }}</div>
                 <div class="title">{{ $t(`data.faction.${f.key}.name`) }}</div>
               </div>
-              <div class="body">
+              <div
+                class="body"
+                :class="{ 'is-dense': winTarget > 14 }">
                 <span
-                  v-for="j in 14"
+                  v-for="j in winTarget"
                   :class="{ 'is-active': j <= f.victory_points }"
                   :key="`f${f.key}-c${j}`">
                   ★
@@ -123,6 +125,10 @@ export default {
     ownFaction() { return this.$store.state.game.faction; },
     victory() { return this.$store.state.game.victory; },
     ownVictory() { return this.victory.factions.find((f) => f.key === this.ownFaction.key); },
+    // Points needed for the victory_track win. Server-configurable per
+    // instance (win_points_target); older servers/snapshots omit the field,
+    // so fall back to the historical 14.
+    winTarget() { return this.victory.win_points_target || 14; },
     orderedFactions() {
       return Array.from(this.victory.factions).sort((a, b) => b.victory_points - a.victory_points);
     },

--- a/front/src/styles/game/components/mini-panels/victory.scss
+++ b/front/src/styles/game/components/mini-panels/victory.scss
@@ -150,6 +150,32 @@
         font-size: 2.6rem;
       }
     }
+
+    // Dense mode for win targets above the classic 14 stars (marathon
+    // instances, up to the achievable ceiling of 30): flat wrapping rows,
+    // no zigzag offset, smaller glyphs so up to 10 stars fit per row.
+    &.is-dense {
+      flex-direction: row;
+      align-content: center;
+      justify-content: center;
+      padding: 2px 6px;
+
+      span {
+        width: 26px;
+        height: 18px;
+        line-height: 18px;
+        font-size: 1.6rem;
+
+        &:nth-child(even) {
+          position: static;
+          left: auto;
+        }
+
+        &.is-active {
+          font-size: 2rem;
+        }
+      }
+    }
   }
 }
 

--- a/lib/game/instance/manager.ex
+++ b/lib/game/instance/manager.ex
@@ -512,6 +512,15 @@ defmodule Instance.Manager do
         metadata[:daily]
       )
 
+    # Optional per-instance points-win override (marathon/stress games).
+    # Only honoured when it's a sane integer; anything else keeps the
+    # Victory default of 14.
+    data =
+      case game_data["win_points_target"] do
+        target when is_integer(target) and target > 0 -> %{data | win_points_target: target}
+        _ -> data
+      end
+
     channel = "instance:global:#{instance_id}"
     state = Core.GenState.new(:victory, instance_id, :master, data, channel)
     DynamicSupervisor.start_child(supervisor_pid, {Instance.Victory.Agent, state: state})

--- a/lib/game/instance/victory/victory.ex
+++ b/lib/game/instance/victory/victory.ex
@@ -20,11 +20,19 @@ defmodule Instance.Victory.Victory do
     field(:instance_id, integer())
     field(:next_update, %Core.DynamicValue{})
     # When true the game can end *only* on the clock — the points-based win
-    # (victory_points >= 14) is ignored. Set for daily challenges, which reuse
-    # this agent but must run their full timer. Defaults to false / optional so
-    # a pre-field snapshot (a multiplayer instance restored across this change)
-    # deserializes cleanly and keeps the normal points-win behaviour.
+    # (victory_points >= the win target, default 14) is ignored. Set for daily
+    # challenges, which reuse this agent but must run their full timer.
+    # Defaults to false / optional so a pre-field snapshot (a multiplayer
+    # instance restored across this change) deserializes cleanly and keeps the
+    # normal points-win behaviour.
     field(:time_only, boolean(), default: false, enforce: false)
+    # Points needed for the victory_track win. nil (and any pre-field
+    # snapshot) falls back to the historical default of 14. Deliberately a
+    # NEW field: the `victory_points` config field above carries legacy
+    # scenario-editor values (some scenarios store 2) that were never read
+    # by the win check — honouring them retroactively would end live games
+    # on the spot. Achievable ceiling is 30 (three tracks x 10).
+    field(:win_points_target, integer() | nil, default: nil, enforce: false)
   end
 
   def new(ut_time_left, victory_points, inhabitable_systems, sectors, factions, instance_id, time_only \\ false) do
@@ -155,12 +163,17 @@ defmodule Instance.Victory.Victory do
 
     # Daily challenges (time_only) end *only* when the clock runs out: they
     # reuse this agent but must ignore the points-based win. A solo player on a
-    # single-system daily trips `victory_points >= 14` almost for free — owning
-    # the lone sector already maxes the conquest track (10 pts), so a little
+    # single-system daily trips the points win almost for free — owning the
+    # lone sector already maxes the conquest track (10 pts), so a little
     # population growth (+5) ends the run minutes before the deadline. Map.get
     # keeps a pre-field snapshot defaulting to the normal points-win behaviour.
     # See lib/daily + docs/daily-challenge.md.
-    has_winner = not Map.get(state, :time_only, false) and leader.victory_points >= 14
+    #
+    # The points target is per-instance overridable (win_points_target, e.g.
+    # 20 for marathon/stress instances); nil or pre-field snapshots keep the
+    # historical 14.
+    win_target = Map.get(state, :win_points_target) || 14
+    has_winner = not Map.get(state, :time_only, false) and leader.victory_points >= win_target
 
     victory_type =
       cond do

--- a/test/game/instance/victory/victory_test.exs
+++ b/test/game/instance/victory/victory_test.exs
@@ -234,6 +234,56 @@ defmodule Instance.Victory.VictoryTest do
     end
   end
 
+  describe "next_tick/2 win_points_target" do
+    test "raising the target to 20 keeps a 14-VP leader from winning" do
+      state = %{single_faction_victory(14, 500.0, false) | win_points_target: 20}
+      {change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == nil
+      refute MapSet.member?(change, :victory)
+      assert export == nil
+    end
+
+    test "a 20-VP leader wins when the target is 20" do
+      state = %{single_faction_victory(20, 500.0, false) | win_points_target: 20}
+      {change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == :tetrarchy
+      assert MapSet.member?(change, :victory)
+      assert export.victory_type == "victory_track"
+    end
+
+    test "nil target keeps the historical 14 threshold" do
+      state = single_faction_victory(14, 500.0, false)
+      assert state.win_points_target == nil
+
+      {_change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == :tetrarchy
+      assert export.victory_type == "victory_track"
+    end
+
+    test "a pre-field snapshot (key entirely absent) falls back to 14" do
+      # Snapshot restore rebuilds the struct from a stored map; a snapshot
+      # taken before this field existed comes back with the key missing, not
+      # nil — exactly what Map.delete produces.
+      state = Map.delete(single_faction_victory(14, 500.0, false), :win_points_target)
+      {_change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == :tetrarchy
+      assert export.victory_type == "victory_track"
+    end
+
+    test "a raised target still loses to the clock" do
+      state = %{single_faction_victory(14, 0.5, false) | win_points_target: 20}
+      {change, new_state, export} = Victory.next_tick(state, 1.0)
+
+      assert new_state.winner == :tetrarchy
+      assert MapSet.member?(change, :victory)
+      assert export.victory_type == "win_on_time"
+    end
+  end
+
   describe "update_tracks/1 milestone thresholds" do
     # Build a real Victory struct via new/7, inject player/possession counts,
     # then recompute the tracks through the public update_visibility/3 — the


### PR DESCRIPTION
The victory_track win was hardcoded at 14 VP and the mini-panel drew a fixed 14 stars per faction. Add a snapshot-tolerant win_points_target field on the Victory struct (nil / pre-field snapshots keep 14), honoured by check_for_victory and wired from game_data at creation.

Deliberately a NEW field: the legacy victory_points config value comes from the scenario editor with untrusted small values (some scenarios store 2) and was never read by the win check — honouring it would end live games instantly.

The mini-panel now draws win_points_target stars (fallback 14) and switches to a dense flat-row layout above 14 so up to 20+ stars fit the 294px faction card.