### PR TITLE
fix(front): rescale every client timer by the runtime speed-cheat mul…

### DIFF
--- a/front/src/game/components/card/ClosedCharacterCard.vue
+++ b/front/src/game/components/card/ClosedCharacterCard.vue
@@ -85,8 +85,7 @@ export default {
   computed: {
     army_tile_count() { return this.$store.state.game.data.constant[0].army_tile_count; },
     speedFactor() {
-      return this.$store.state.game.data.speed
-        .find((s) => s.key === this.$store.state.game.time.speed).factor;
+      return this.$store.getters['game/effectiveSpeedFactor'];
     },
     actions() {
       if (!this.character.actions) {

--- a/front/src/game/components/galaxy/selection/View.vue
+++ b/front/src/game/components/galaxy/selection/View.vue
@@ -155,7 +155,7 @@ export default {
     constant() { return this.$store.state.game.data.constant[0]; },
     speed() { return this.$store.state.game.time.speed; },
     speedFactor() {
-      return this.$store.state.game.data.speed.find((s) => s.key === this.speed).factor;
+      return this.$store.getters['game/effectiveSpeedFactor'];
     },
     tickToMilisecondFactor() { return this.$store.getters['game/tickToMilisecondFactor']; },
     theme() { return this.$store.getters['game/theme']; },

--- a/front/src/game/components/navbar/Bottombar.vue
+++ b/front/src/game/components/navbar/Bottombar.vue
@@ -464,17 +464,17 @@ export default {
       this.$root.$emit('hoveredResource', name);
     },
     // Project a player resource forward at the current per-UT income rate,
-    // over a real-time horizon. Speed-aware: UTs accumulate at 480 * factor per
-    // 24 real hours. Dailies run on a 30-minute clock, so a 24h projection is
-    // meaningless — they get a near-term 3-minute one instead. Ignores future
-    // buildings, conquests, agent losses — purely "if nothing changes."
+    // over a real-time horizon. Speed-aware: UTs accumulate at 480 * the
+    // effective factor (base speed × runtime speed cheat) per 24 real hours.
+    // Dailies run on a 30-minute clock, so a 24h projection is meaningless —
+    // they get a near-term 3-minute one instead. Ignores future buildings,
+    // conquests, agent losses — purely "if nothing changes."
     projectIncome(resource) {
       if (!resource || typeof resource.value !== 'number') return undefined;
-      const speed = this.$store.state.game.data.speed
-        .find((s) => s.key === this.$store.state.game.time.speed);
-      if (!speed) return undefined;
+      const factor = this.$store.getters['game/effectiveSpeedFactor'];
+      if (!factor) return undefined;
       const minutes = this.isDaily ? 3 : 24 * 60;
-      const uts = 480 * speed.factor * (minutes / (24 * 60));
+      const uts = 480 * factor * (minutes / (24 * 60));
       return resource.value + (resource.change || 0) * uts;
     },
   },

--- a/front/src/game/components/panel/EventPanel.vue
+++ b/front/src/game/components/panel/EventPanel.vue
@@ -107,8 +107,7 @@ export default {
   computed: {
     theme() { return this.$store.getters['game/theme']; },
     time() { return this.$store.state.game.time; },
-    speed() { return this.$store.state.game.data.speed.find((i) => i.key === this.time.speed); },
-    utInSeconds() { return this.speed.factor / this.$config.TIME.UNIT_TIME_DIVIDER; },
+    utInSeconds() { return this.$store.getters['game/effectiveSpeedFactor'] / this.$config.TIME.UNIT_TIME_DIVIDER; },
     calendar() { return this.$store.state.game.data.calendar.find((i) => i.key === 'tetrarch'); },
     groupedEvents() { return this.groupByMonth(this.events); },
   },

--- a/front/src/game/map/blocks/block.js
+++ b/front/src/game/map/blocks/block.js
@@ -21,10 +21,6 @@ export default class Block {
     */
     this.animationCallbacks = [];
 
-    const { time } = store.state.game;
-    const speed = store.state.game.data.speed.find((s) => s.key === time.speed);
-    const speedFactor = speed.factor;
-
     // Clock-based progress, anchored on the server's monotonic clock with
     // `timeOffset` as the wall-clock-to-server-monotonic translation. Has
     // to be clock-based and NOT `(totalTime - remainingTime) / totalTime`,
@@ -41,6 +37,8 @@ export default class Block {
     // rebases every in-flight action's `started_at` into the new frame
     // at instance start. That keeps this formula simple and frame-rate
     // smooth.
+    // The speed factor is read per call (not captured at construction) so a
+    // runtime speed-cheat change rescales in-flight animations immediately.
     this.progress = (startedAt, remainingTime, totalTime) => {
       if (!startedAt) return 0;
       if (remainingTime <= 0) return 1;
@@ -48,7 +46,7 @@ export default class Block {
       const elapsed = ((map.timeOffset + Date.now()) - (startedAt));
       const total = (180000 * totalTime);
 
-      return (speedFactor * elapsed) / total;
+      return (store.getters['game/effectiveSpeedFactor'] * elapsed) / total;
     };
   }
 

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -273,8 +273,7 @@ export default class Map {
     if (character.system) {
       this.centerToSystem(character.system, config.MAP.Z_DEFAULT, 600);
     } else {
-      const speed = store.state.game.data.speed.find((i) => i.key === store.state.game.time.speed);
-      const speedFactor = speed.factor;
+      const speedFactor = store.getters['game/effectiveSpeedFactor'];
 
       const action = character.actions.queue[0];
       const p1 = action.data.source_position;

--- a/front/src/game/mixins/TimeMixin.js
+++ b/front/src/game/mixins/TimeMixin.js
@@ -7,8 +7,7 @@ const TimeMixin = {
   },
   computed: {
     time() { return this.$store.state.game.time; },
-    speed() { return this.$store.state.game.data.speed.find((i) => i.key === this.time.speed); },
-    utInSeconds() { return this.speed.factor / this.$config.TIME.UNIT_TIME_DIVIDER; },
+    utInSeconds() { return this.$store.getters['game/effectiveSpeedFactor'] / this.$config.TIME.UNIT_TIME_DIVIDER; },
   },
   methods: {
     startWorker() {

--- a/front/src/game/store.js
+++ b/front/src/game/store.js
@@ -152,13 +152,21 @@ const gameStore = {
     onlinePlayersNumber(state) {
       return Object.keys(state.onlinePlayers).length;
     },
-    tickToMilisecondFactor(state) {
-      const speedup = state.instanceInfo.speedup || 1;
-      return (180 / (state.data.speed.find((s) => s.key === state.time.speed).factor * speedup)) * 1000;
+    // The wall-clock↔game-time rate actually in effect: base speed factor ×
+    // the runtime speed-cheat multiplier. Every client-side conversion
+    // between real time and game time must go through this (or the tickTo*
+    // getters below) — reading data.speed's raw factor renders 1× on
+    // speed-cheated games. Undefined until the join payload primes the store.
+    effectiveSpeedFactor(state) {
+      if (!state.data.speed || !state.time.speed) return undefined;
+      const speed = state.data.speed.find((s) => s.key === state.time.speed);
+      return speed ? speed.factor * (state.instanceInfo.speedup || 1) : undefined;
     },
-    tickToSecondFactor(state) {
-      const speedup = state.instanceInfo.speedup || 1;
-      return (180 / (state.data.speed.find((s) => s.key === state.time.speed).factor * speedup));
+    tickToMilisecondFactor(state, getters) {
+      return (180 / getters.effectiveSpeedFactor) * 1000;
+    },
+    tickToSecondFactor(state, getters) {
+      return (180 / getters.effectiveSpeedFactor);
     },
     cheatsAvailable(state) {
       return !!(state.instanceInfo.cheats_enabled && state.instanceInfo.cheat_creator);


### PR DESCRIPTION
…tiplier

The set_speed cheat retimes every server TickServer (verified 2x on instance 85), but only the tickTo* store getters folded the multiplier into client-side time math. Everything driven by TimeMixin's utInSeconds (calendar, resource tickers, cooldowns, countdown decrement rates), the map's movement animation, character travel cards, and the income projection still converted with the base speed factor - so countdowns ticked at half real speed and builds visibly completed at the 50% mark while the game clock crawled at 1x.

Add a single game/effectiveSpeedFactor getter (base factor x speedup) as the only raw-factor read, rewire the tickTo* getters and all seven base-factor call sites through it, and read it per call in block.js's progress closure (was captured at map construction) so a live speed change rescales in-flight animations immediately.

Verified in a dev daily: flipping instanceInfo.speedup from the console doubled the calendar's advance rate (1.34 -> 2.67 UT/s, 1.99x).