### PR TITLE
Per-planet population apportionment + stale deploy-notice suppression

### DIFF
--- a/lib/game/instance/stellar_system/stellar_system.ex
+++ b/lib/game/instance/stellar_system/stellar_system.ex
@@ -1066,39 +1066,73 @@ defmodule Instance.StellarSystem.StellarSystem do
   defp compute_local_population(state) do
     buildings_data = Data.Querier.all(Data.Game.Building, state.instance_id)
 
-    bodies =
+    local_habitations =
       Enum.map(state.bodies, fn body ->
-        local_habitation =
-          Enum.reduce(body.tiles, 0, fn tile, acc ->
-            if tile.building_status == :empty do
-              acc
-            else
-              building_data = Enum.find(buildings_data, fn b -> b.key == tile.building_key end)
-              building_level_data = Enum.find(building_data.levels, fn l -> l.level == tile.building_level end)
+        Enum.reduce(body.tiles, 0, fn tile, acc ->
+          if tile.building_status == :built do
+            building_data = Enum.find(buildings_data, fn b -> b.key == tile.building_key end)
+            building_level_data = Enum.find(building_data.levels, fn l -> l.level == tile.building_level end)
 
-              tile_habitations =
-                Enum.reduce(building_level_data.bonus, 0, fn bonus, acc2 ->
-                  out_data = Data.Querier.one(Data.Game.BonusPipelineOut, state.instance_id, bonus.to)
+            tile_habitations =
+              Enum.reduce(building_level_data.bonus, 0, fn bonus, acc2 ->
+                out_data = Data.Querier.one(Data.Game.BonusPipelineOut, state.instance_id, bonus.to)
 
-                  acc2 +
-                    if out_data.to_key == :habitation,
-                      do: bonus.value,
-                      else: 0
-                end)
+                acc2 +
+                  if out_data.to_key == :habitation,
+                    do: bonus.value,
+                    else: 0
+              end)
 
-              acc + tile_habitations
-            end
-          end)
-
-        local_population =
-          if state.habitation.value > 0,
-            do: Kernel.trunc(state.workforce * local_habitation / state.habitation.value),
-            else: 0
-
-        %{body | population: local_population}
+            acc + tile_habitations
+          else
+            acc
+          end
+        end)
       end)
 
+    bodies =
+      state.bodies
+      |> Enum.zip(apportion_workforce(state.workforce, local_habitations))
+      |> Enum.map(fn {body, local_population} -> %{body | population: local_population} end)
+
     %{state | bodies: bodies}
+  end
+
+  @doc false
+  # Largest-remainder apportionment: each body gets the floor of its exact
+  # habitation share, then the unassigned points (at most one per body) go to
+  # the bodies with the largest fractional remainders, so the per-body values
+  # always sum to the system workforce. Kept public (with `@doc false`) so the
+  # rounding contract can be unit-tested without the Data.Querier machinery —
+  # see StellarSystemTest.
+  def apportion_workforce(workforce, local_habitations) do
+    total_habitation = Enum.sum(local_habitations)
+
+    if total_habitation > 0 do
+      shares =
+        Enum.map(local_habitations, fn local_habitation ->
+          exact = workforce * local_habitation / total_habitation
+          {Kernel.trunc(exact), exact - Kernel.trunc(exact)}
+        end)
+
+      leftover = Enum.max([workforce - (shares |> Enum.map(&elem(&1, 0)) |> Enum.sum()), 0])
+
+      topped_up =
+        shares
+        |> Enum.with_index()
+        |> Enum.sort_by(fn {{_floored, remainder}, _index} -> -remainder end)
+        |> Enum.take(leftover)
+        |> Enum.map(fn {_share, index} -> index end)
+        |> MapSet.new()
+
+      shares
+      |> Enum.with_index()
+      |> Enum.map(fn {{floored, _remainder}, index} ->
+        if MapSet.member?(topped_up, index), do: floored + 1, else: floored
+      end)
+    else
+      Enum.map(local_habitations, fn _ -> 0 end)
+    end
   end
 
   defp compute_used_workforce(state) do

--- a/lib/portal/channels/controllers/faction_channel.ex
+++ b/lib/portal/channels/controllers/faction_channel.ex
@@ -66,6 +66,7 @@ defmodule Portal.Controllers.FactionChannel do
               |> assign(:channel_name, "faction")
               |> assign(:is_tutorial, Galaxy.is_tutorial(galaxy))
               |> assign(:has_replay, has_replay)
+              |> assign(:joined_at, :os.system_time(:seconds))
 
             case Game.call(instance_id, :faction, faction_id, :get_state) do
               {:ok, faction} ->
@@ -74,7 +75,12 @@ defmodule Portal.Controllers.FactionChannel do
                 # detected_objects directly with the joining player's id
                 # so the same {faction, position, angle} contract applies
                 # to the initial state the client receives.
-                {:ok, %{faction_faction: sanitize_faction_for_viewer(faction, profile_id)}, socket}
+                faction =
+                  faction
+                  |> sanitize_faction_for_viewer(profile_id)
+                  |> filter_stale_deploy_chat(socket)
+
+                {:ok, %{faction_faction: faction}, socket}
 
               _ ->
                 {:error, %{reason: "instance_unavailable"}}
@@ -826,9 +832,40 @@ defmodule Portal.Controllers.FactionChannel do
   # `detected_objects`, not a change here. The channel boundary stays
   # narrow: "your own characters never appear as anonymous blips".
   def handle_out("broadcast", payload, socket) do
-    push(socket, "broadcast", sanitize_for_viewer(payload, socket.assigns.player_id))
+    payload =
+      payload
+      |> sanitize_for_viewer(socket.assigns.player_id)
+      |> filter_deploy_chat_payload(socket)
+
+    push(socket, "broadcast", payload)
     {:noreply, socket}
   end
+
+  # Deploy-notice chat hygiene, applied per recipient at serve time (join
+  # reply + every faction_faction push). The ring itself is never touched
+  # and nothing extra is broadcast, so a client that was connected during
+  # the deploy keeps its copy until it refreshes — while a client that
+  # loads the game later never receives the stale lines:
+  #   * the "deployment on-going" line is only real while the deploy flag
+  #     is up (late joiners during the window still get it via the
+  #     after_join re-assert);
+  #   * the "update applied, refresh" line only makes sense for sockets
+  #     that were already connected when it fired — a freshly loaded
+  #     client is already running the new code.
+  defp filter_deploy_chat_payload(%{faction_faction: faction} = payload, socket) do
+    %{payload | faction_faction: filter_stale_deploy_chat(faction, socket)}
+  end
+
+  defp filter_deploy_chat_payload(payload, _socket), do: payload
+
+  defp filter_stale_deploy_chat(%{chat: chat} = faction, socket) when is_list(chat) do
+    # Missing assign (shouldn't happen) fails open to the old behavior.
+    joined_at = Map.get(socket.assigns, :joined_at, 0)
+
+    %{faction | chat: RC.Deploy.filter_stale_chat(chat, joined_at, RC.Deploy.get_flag())}
+  end
+
+  defp filter_stale_deploy_chat(faction, _socket), do: faction
 
   defp sanitize_for_viewer(%{detected_objects: blips} = payload, viewer_player_id) do
     %{payload | detected_objects: sanitize_blips(blips, viewer_player_id)}

--- a/lib/rc/deploy.ex
+++ b/lib/rc/deploy.ex
@@ -100,6 +100,34 @@ defmodule RC.Deploy do
   end
 
   @doc """
+  Serve-time staleness filter for a faction chat ring, applied per
+  recipient at the channel boundary (join reply + every faction push).
+  Pure — the ring itself is never mutated and nothing is broadcast, so a
+  client that was connected during the deploy keeps its copy until it
+  refreshes, while a client that loads the game later never receives the
+  stale lines:
+
+    * the ongoing notice is only real while `deploy_flag?` is up;
+    * the finished ("refresh recommended") notice is only for sockets
+      that were already connected when it fired — a freshly loaded
+      client is already running the new code.
+
+  Only SYSTEM lines (`from_id: nil`) are eligible: a player pasting the
+  exact notice text is never filtered.
+  """
+  def filter_stale_chat(chat, joined_at, deploy_flag?)
+      when is_list(chat) and is_integer(joined_at) and is_boolean(deploy_flag?) do
+    ongoing = @ongoing_message
+    finished = @finished_message
+
+    Enum.filter(chat, fn
+      %{from_id: nil, message: ^ongoing} -> deploy_flag?
+      %{from_id: nil, message: ^finished, timestamp: timestamp} -> timestamp >= joined_at
+      _ -> true
+    end)
+  end
+
+  @doc """
   Push a SYSTEM chat line into every faction chat ring of every live
   instance. `mode` is `:always` (plain append) or `:once` (skip factions
   whose ring already holds the exact line — used for the ongoing notice,

--- a/test/game/instance/stellar_system/stellar_system_test.exs
+++ b/test/game/instance/stellar_system/stellar_system_test.exs
@@ -86,4 +86,60 @@ defmodule Instance.StellarSystem.StellarSystemTest do
       assert refund == 30
     end
   end
+
+  describe "apportion_workforce/2 per-body population split" do
+    test "equal habitation shares always sum to the workforce (uhex's 20 over 3 planets)" do
+      # Plain truncation gave 6/6/6 = 18 for a 20-pop system; largest-remainder
+      # must hand the 2 missing points to two of the planets.
+      assert StellarSystem.apportion_workforce(20, [10, 10, 10]) == [7, 7, 6]
+    end
+
+    test "uneven shares sum to the workforce (Granite's 31 over 3 planets)" do
+      # 31 * [8, 10, 15]/33 = 7.51 / 9.39 / 14.09 — truncation showed 30 total.
+      populations = StellarSystem.apportion_workforce(31, [8, 10, 15])
+      assert Enum.sum(populations) == 31
+      assert populations == [8, 9, 14]
+    end
+
+    test "every body gets either the floor or the ceiling of its exact share" do
+      for workforce <- 0..60, habitations = [7, 0, 13, 3, 25] do
+        populations = StellarSystem.apportion_workforce(workforce, habitations)
+        total = Enum.sum(habitations)
+
+        assert Enum.sum(populations) == workforce
+
+        for {population, habitation} <- Enum.zip(populations, habitations) do
+          exact = workforce * habitation / total
+          assert population in [Kernel.trunc(exact), Kernel.trunc(exact) + 1]
+        end
+      end
+    end
+
+    test "a body with no habitation never receives population" do
+      assert StellarSystem.apportion_workforce(17, [5, 0, 5]) |> Enum.at(1) == 0
+    end
+
+    test "no habitation anywhere means no local population" do
+      assert StellarSystem.apportion_workforce(12, [0, 0, 0]) == [0, 0, 0]
+      assert StellarSystem.apportion_workforce(12, []) == []
+    end
+
+    test "zero workforce assigns nothing" do
+      assert StellarSystem.apportion_workforce(0, [10, 20]) == [0, 0]
+    end
+
+    test "single body takes the whole workforce" do
+      assert StellarSystem.apportion_workforce(31, [26]) == [31]
+    end
+
+    test "remainder ties resolve deterministically in body order" do
+      # 5 over four equal shares: 1.25 each — one +1 point, first body wins.
+      assert StellarSystem.apportion_workforce(5, [10, 10, 10, 10]) == [2, 1, 1, 1]
+    end
+
+    test "fractional habitation values (e.g. 3.25 hab_open levels) still sum exactly" do
+      populations = StellarSystem.apportion_workforce(23, [3.25, 10.0, 6.5])
+      assert Enum.sum(populations) == 23
+    end
+  end
 end

--- a/test/rc/deploy_test.exs
+++ b/test/rc/deploy_test.exs
@@ -48,4 +48,63 @@ defmodule RC.DeployTest do
     changeset = RC.Deploy.Log.changeset(%RC.Deploy.Log{}, %{flag: true})
     refute changeset.valid?
   end
+
+  describe "filter_stale_chat/3 serve-time chat hygiene" do
+    alias Instance.Faction.ChatMessage
+
+    defp system_line(message, timestamp) do
+      %ChatMessage{from: "SYSTEM", from_id: nil, timestamp: timestamp, message: message}
+    end
+
+    defp player_line(message, timestamp) do
+      %ChatMessage{from: "somePlayer", from_id: 42, timestamp: timestamp, message: message}
+    end
+
+    test "ongoing notice is served only while the deploy flag is up" do
+      chat = [system_line(Deploy.ongoing_message(), 1_000)]
+
+      assert Deploy.filter_stale_chat(chat, 2_000, true) == chat
+      assert Deploy.filter_stale_chat(chat, 2_000, false) == []
+    end
+
+    test "finished notice is served only to sockets connected when it fired" do
+      chat = [system_line(Deploy.finished_message(), 1_000)]
+
+      # joined before (or at) the push: was connected through the deploy — keep
+      assert Deploy.filter_stale_chat(chat, 900, false) == chat
+      assert Deploy.filter_stale_chat(chat, 1_000, false) == chat
+
+      # loaded the game after the deploy finished: already on new code — drop
+      assert Deploy.filter_stale_chat(chat, 1_001, false) == []
+    end
+
+    test "a fresh post-deploy load sees neither notice, whatever the order" do
+      chat = [
+        player_line("hello", 500),
+        system_line(Deploy.ongoing_message(), 1_000),
+        system_line(Deploy.finished_message(), 1_100),
+        player_line("gg", 1_200)
+      ]
+
+      assert Deploy.filter_stale_chat(chat, 2_000, false) == [
+               player_line("hello", 500),
+               player_line("gg", 1_200)
+             ]
+    end
+
+    test "player messages quoting the notice text verbatim are never filtered" do
+      chat = [
+        player_line(Deploy.ongoing_message(), 1_000),
+        player_line(Deploy.finished_message(), 1_000)
+      ]
+
+      assert Deploy.filter_stale_chat(chat, 2_000, false) == chat
+    end
+
+    test "other system lines pass through untouched" do
+      chat = [system_line("CHEAT enabled for this game", 1_000)]
+
+      assert Deploy.filter_stale_chat(chat, 2_000, false) == chat
+    end
+  end
 end


### PR DESCRIPTION
Two fixes from the same session (second one bundled per discussion):

## Per-planet population loses points to truncation

Each planet's displayed population was `trunc(workforce x planet_hab / system_hab)`, rounded down independently per planet, so up to n-1 points of a system's population vanished from the per-planet view — a 20-pop system over three equal planets showed 6/6/6 (RARRA, instance 85: Granite 31 → 7/9/14 = 30, uhex 20 → 6/6/6 = 18). Not cosmetic: `body_pop` building bonuses (credit, technology, ideology, production, defense, happiness maluses) multiply by this integer, so the missing points were lost output. Present since the 2022 release; the July collapse-bodies QoL view just made it visible.

**Fix:** largest-remainder apportionment. Every planet gets the floor of its exact habitation-weighted share (weighting unchanged), then the unassigned points — at most one per planet — go to the planets with the largest fractional remainders, ties resolved in body order. Per-planet values now always sum to the system workforce; each planet shows either the floor or the ceiling of its true share. Configurations that were previously exact (single planet, integer shares) are unchanged.

Also aligns the split's building filter with the system habitation total: both now count only `:built` buildings, so damaged habitation no longer skews the weights.

No migration needed — planet populations recompute from state on the next workforce change.

## Stale deploy notices greet freshly loaded clients

The SYSTEM chat lines a deploy leaves in every faction ring ("deployment on-going", "update applied, refresh recommended") persisted for hours; a player freshly loading the game — already on the new client — still saw both.

**Fix:** per-recipient serve-time filter at the faction-channel boundary (join reply + every `faction_faction` push). The ring is never mutated and nothing is broadcast, so clients connected during the deploy keep the notices until they refresh:

- the on-going notice is served only while the deploy flag is up (late joiners during the window still get it via the after_join re-assert);
- the finished notice is served only to sockets whose join predates the line's timestamp — anyone loading later never sees it.

Rules live in `RC.Deploy.filter_stale_chat/3` (pure, unit-tested, next to the strings it matches). Only `from_id: nil` lines are eligible — a player pasting the notice text verbatim is never filtered.

## Testing

- 9 new apportionment tests (both reported cases, sum/floor-ceil invariant sweep over workforces 0-60, ties, zero-hab, fractional hab values)
- 5 new filter tests (flag gating, join-time gating, mixed rings, verbatim-paste spoof, other SYSTEM lines untouched)
- Full suite: 998 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)