### PR TITLE
chore(privacy): remove orphaned third-party tracking scripts

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -13,45 +13,13 @@
 </head>
 
 <body>
-  <% if (process.env.NODE_ENV==='production' ) { %>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-162887658-1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
+  <noscript>
+    <strong>We're sorry but this site doesn't work properly without JavaScript enabled. Please enable it to
+      continue.</strong>
+  </noscript>
 
-      gtag('config', 'UA-162887658-1');
-    </script>
-
-    <!-- Facebook Pixel Code -->
-    <script>
-      !function (f, b, e, v, n, t, s) {
-        if (f.fbq) return; n = f.fbq = function () {
-          n.callMethod ?
-            n.callMethod.apply(n, arguments) : n.queue.push(arguments)
-        };
-        if (!f._fbq) f._fbq = n; n.push = n; n.loaded = !0; n.version = '2.0';
-        n.queue = []; t = b.createElement(e); t.async = !0;
-        t.src = v; s = b.getElementsByTagName(e)[0];
-        s.parentNode.insertBefore(t, s)
-      }(window, document, 'script',
-        'https://connect.facebook.net/en_US/fbevents.js');
-      fbq('init', '213184800126811');
-      fbq('track', 'PageView');
-    </script>
-    <noscript><img height="1" width="1" style="display:none"
-        src="https://www.facebook.com/tr?id=213184800126811&ev=PageView&noscript=1" /></noscript>
-    <!-- End Facebook Pixel Code -->
-    <% } %>
-
-      <noscript>
-        <strong>We're sorry but this site doesn't work properly without JavaScript enabled. Please enable it to
-          continue.</strong>
-      </noscript>
-
-      <div id="app"></div>
-      <!-- built files will be auto injected -->
+  <div id="app"></div>
+  <!-- built files will be auto injected -->
 </body>
 
 </html>

--- a/lib/portal/templates/public_layout/live.html.leex
+++ b/lib/portal/templates/public_layout/live.html.leex
@@ -1,21 +1,3 @@
-<!-- Facebook Pixel Code -->
-<script>
-  !function(f,b,e,v,n,t,s)
-  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-  n.queue=[];t=b.createElement(e);t.async=!0;
-  t.src=v;s=b.getElementsByTagName(e)[0];
-  s.parentNode.insertBefore(t,s)}(window, document,'script',
-  'https://connect.facebook.net/en_US/fbevents.js');
-  fbq('init', '385066709658253');
-  fbq('track', 'PageView');
-</script>
-<noscript><img height="1" width="1" style="display:none"
-  src="https://www.facebook.com/tr?id=385066709658253&ev=PageView&noscript=1"
-/></noscript>
-<!-- End Facebook Pixel Code -->
-
 <div class="alert-container">
   <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"


### PR DESCRIPTION
Drop all ad-tech holdovers from the pre-takeover era; none of these accounts are accessible to the current maintainer:

- Google Analytics tag UA-162887658-1 (front/public/index.html) — a Universal Analytics property, dead since Google ended UA processing in July 2023, so it recorded nothing while still loading Google's script for every player.
- Facebook pixel 213184800126811 (front/public/index.html, production builds only).
- Facebook pixel 385066709658253 (public portal LiveView layout), firing on every server-rendered public page.

The site now loads no third-party scripts.