### PR TITLE
feat(cheats+gov): per-player cheat access with creator-only ops; Fact…

### DIFF
--- a/docs/faction-government.md
+++ b/docs/faction-government.md
@@ -4,6 +4,13 @@ Status: analysis / pre-design. Source: "TF Government" design doc (July 2026) +
 full codebase survey. Scope: Legacy games only (`game_data["speed"] == "slow"`;
 dailies use the `:daily` speed key so they are excluded automatically).
 
+> **Beta gate (July 2026):** the feature is additionally a creation-time
+> opt-in — the "Faction Government (Beta)" checkbox on the new-game form
+> (Legacy scenarios only, default OFF) → `game_data["faction_gov_enabled"]`
+> → instance metadata → `Instance.Faction.Government.enabled?/2`. Instances
+> created without the field (pre-feature games, harness scripts, API
+> clients) grandfather the historical always-on-Legacy behavior.
+
 This document covers three things:
 
 1. An implementation analysis of the government system as written — what the

--- a/front/src/game/components/panel/EmpirePanel.vue
+++ b/front/src/game/components/panel/EmpirePanel.vue
@@ -43,8 +43,9 @@ export default {
     theme() { return this.$store.getters['game/theme']; },
     // The Mutators tab only exists for daily challenges (speed === 'daily').
     isDaily() { return this.$store.state.game.time.speed === 'daily'; },
-    // The Cheats tab only exists for the game creator of a cheats-enabled
-    // instance (the server independently gates every cheat op).
+    // The Cheats tab exists for every player of a cheats-enabled instance;
+    // creator-only sections are gated inside the tab and the server
+    // independently gates every cheat op.
     cheatsAvailable() { return this.$store.getters['game/cheatsAvailable']; },
     panels() {
       const base = ['overall', 'possessions', 'galactic_survey'];

--- a/front/src/game/components/panel/empire/Cheats.vue
+++ b/front/src/game/components/panel/empire/Cheats.vue
@@ -38,8 +38,10 @@
         </div>
       </section>
 
-      <!-- settle system -->
-      <section class="cheat-section">
+      <!-- settle system (creator only) -->
+      <section
+        v-if="isCreator"
+        class="cheat-section">
         <h2 class="cheat-subtitle">{{ $t('panel.empire.cheats_settle_title') }}</h2>
         <div class="cheat-row">
           <select v-model="settle.target" class="cheat-select">
@@ -87,24 +89,27 @@
       <section class="cheat-section">
         <h2 class="cheat-subtitle">{{ $t('panel.empire.cheats_gov_title') }}</h2>
         <div class="cheat-row">
-          <button
-            class="cheat-button"
-            :disabled="busy"
-            @click="simplePush('skip_election_timer')">
-            {{ $t('panel.empire.cheats_skip_founding') }}
-          </button>
-          <button
-            class="cheat-button"
-            :disabled="busy"
-            @click="simplePush('conclude_elections')">
-            {{ $t('panel.empire.cheats_conclude_elections') }}
-          </button>
-          <button
-            class="cheat-button"
-            :disabled="busy"
-            @click="simplePush('reopen_elections')">
-            {{ $t('panel.empire.cheats_reopen_elections') }}
-          </button>
+          <!-- election-timer manipulation is creator-only (server-enforced) -->
+          <template v-if="isCreator">
+            <button
+              class="cheat-button"
+              :disabled="busy"
+              @click="simplePush('skip_election_timer')">
+              {{ $t('panel.empire.cheats_skip_founding') }}
+            </button>
+            <button
+              class="cheat-button"
+              :disabled="busy"
+              @click="simplePush('conclude_elections')">
+              {{ $t('panel.empire.cheats_conclude_elections') }}
+            </button>
+            <button
+              class="cheat-button"
+              :disabled="busy"
+              @click="simplePush('reopen_elections')">
+              {{ $t('panel.empire.cheats_reopen_elections') }}
+            </button>
+          </template>
           <button
             class="cheat-button"
             :disabled="busy"
@@ -114,8 +119,10 @@
         </div>
       </section>
 
-      <!-- game speed -->
-      <section class="cheat-section">
+      <!-- game speed (creator only) -->
+      <section
+        v-if="isCreator"
+        class="cheat-section">
         <h2 class="cheat-subtitle">
           {{ $t('panel.empire.cheats_speed_title') }}
           <span class="cheat-speed-current">
@@ -170,6 +177,11 @@ export default {
     };
   },
   computed: {
+    // Game-shaping sections (settle, speed, election timers) only render
+    // for the game creator; the server re-checks on every op regardless.
+    isCreator() {
+      return this.$store.getters['game/cheatCreator'];
+    },
     players() {
       const players = this.$store.state.game.galaxy.players || {};
       return Object.values(players).slice(0).sort((a, b) => a.name.localeCompare(b.name));

--- a/front/src/game/store.js
+++ b/front/src/game/store.js
@@ -102,8 +102,9 @@ const defaultState = () => {
     },
 
     // per-socket instance info from the global-channel join payload:
-    // cheats_enabled (game-wide flag), cheat_creator (am I the game
-    // creator — gates the Cheats tab), speedup (runtime speed-cheat
+    // cheats_enabled (game-wide flag — gates the Cheats tab for every
+    // player), cheat_creator (am I the game creator — unlocks the
+    // creator-only cheat sections), speedup (runtime speed-cheat
     // multiplier, rescales every client-side timer).
     instanceInfo: {
       cheats_enabled: false,
@@ -168,7 +169,13 @@ const gameStore = {
     tickToSecondFactor(state, getters) {
       return (180 / getters.effectiveSpeedFactor);
     },
+    // Cheats tab: visible to every player of a cheats-enabled instance.
     cheatsAvailable(state) {
+      return !!state.instanceInfo.cheats_enabled;
+    },
+    // Creator-only cheat sections (speed, settle, election timers) — the
+    // server independently re-checks this on every op.
+    cheatCreator(state) {
       return !!(state.instanceInfo.cheats_enabled && state.instanceInfo.cheat_creator);
     },
   },

--- a/front/src/locales/en/portal.json
+++ b/front/src/locales/en/portal.json
@@ -722,9 +722,10 @@
       },
       "new": {
         "button_seed": "Use the same seed as the scenario",
-        "field_cheats_enabled": "Enable cheat access (creator gets an in-game cheat panel; announced in chat)",
+        "field_cheats_enabled": "Enable cheat access (every player gets an in-game cheat panel; announced in chat)",
         "field_description": "Description",
         "field_discord_ready": "Discord promotable (Legacy match)",
+        "field_faction_gov_enabled": "Faction Government (Beta)",
         "field_factions": "Players by factions",
         "field_mode": "Mode",
         "field_name": "Name",

--- a/front/src/locales/fr/portal.json
+++ b/front/src/locales/fr/portal.json
@@ -597,9 +597,10 @@
       },
       "new": {
         "button_seed": "Utiliser la graine du scénario",
-        "field_cheats_enabled": "Activer les triches (panneau de triche pour le créateur ; annoncé dans le chat)",
+        "field_cheats_enabled": "Activer les triches (panneau de triche pour tous les joueurs ; annoncé dans le chat)",
         "field_description": "Description",
         "field_discord_ready": "Promouvoir sur Discord (partie Legacy)",
+        "field_faction_gov_enabled": "Gouvernement de faction (Bêta)",
         "field_factions": "Joueurs par faction",
         "field_mode": "Mode",
         "field_name": "Nom",

--- a/front/src/plugins/websockets.js
+++ b/front/src/plugins/websockets.js
@@ -249,9 +249,10 @@ const socket = {
     store.commit('game/statusChannel', { channel, status: false });
   },
 
-  // Lazily joined by the Cheats tab (only rendered for the game creator
-  // of a cheats-enabled instance — the server re-checks both on join and
-  // on every push). Idempotent: returns the existing channel once joined.
+  // Lazily joined by the Cheats tab (rendered for every player of a
+  // cheats-enabled instance; creator-only sections gated inside — the
+  // server re-checks access on join and on every push). Idempotent:
+  // returns the existing channel once joined.
   joinCheat() {
     if (this.cheat) return this.cheat;
 

--- a/front/src/portal/pages/play/New.vue
+++ b/front/src/portal/pages/play/New.vue
@@ -188,6 +188,14 @@
             v-model="instance.cheats_enabled">
           <label for="cheats_enabled">{{ $t('page.play.new.field_cheats_enabled') }}</label>
         </div>
+        <div class="checkbox-input">
+          <input
+            type="checkbox"
+            id="faction_gov_enabled"
+            :disabled="!isLegacy"
+            v-model="instance.faction_gov_enabled">
+          <label for="faction_gov_enabled">{{ $t('page.play.new.field_faction_gov_enabled') }}</label>
+        </div>
       </div>
 
       <div
@@ -261,6 +269,7 @@ export default {
         public: true,
         discord_ready: false,
         cheats_enabled: false,
+        faction_gov_enabled: false,
         factions: [],
         seed: null,
       },
@@ -287,6 +296,10 @@ export default {
     },
     canBeRanked() {
       return this.scenario && this.isAdmin && this.scenario.game_data.speed === 'fast';
+    },
+    // Faction government (beta) only exists in Legacy games.
+    isLegacy() {
+      return !!this.scenario && this.scenario.game_data.speed === 'slow';
     },
   },
   methods: {
@@ -326,6 +339,14 @@ export default {
         // server-side in RC.Instances.create_instance).
         if (this.instance.game_mode_type === 'ranked') {
           this.instance.cheats_enabled = false;
+        }
+
+        // Faction government (beta) is Legacy-only. Omit the field
+        // entirely on non-Legacy scenarios — the server treats a missing
+        // key like a pre-feature client (and enforces the speed gate
+        // itself in RC.Instances.create_instance).
+        if (!this.isLegacy) {
+          delete this.instance.faction_gov_enabled;
         }
 
         try {

--- a/lib/game/instance/faction/agent.ex
+++ b/lib/game/instance/faction/agent.ex
@@ -205,16 +205,16 @@ defmodule Instance.Faction.Agent do
 
   # Lazy init doubling as snapshot back-fill: fresh instances and
   # pre-feature snapshots both arrive here without a government, and get
-  # one if (and only if) this instance's speed runs the feature. The
-  # founding countdown therefore starts at first tick after creation —
-  # or, for existing Legacy games, at the first tick after the deploy
-  # that ships the feature.
+  # one if (and only if) this instance runs the feature (Legacy speed +
+  # the creation-time opt-in). The founding countdown therefore starts at
+  # first tick after creation — or, for existing Legacy games, at the
+  # first tick after the deploy that ships the feature.
   defp ensure_government(data, speed) do
     data = hydrate_government(data, speed)
 
     case Map.get(data, :government) do
       nil ->
-        if Government.enabled?(speed),
+        if Government.enabled?(data.instance_id, speed),
           do: Map.put(data, :government, Government.new(Government.build_ctx(data))),
           else: Map.put(data, :government, nil)
 
@@ -234,7 +234,7 @@ defmodule Instance.Faction.Agent do
       Process.get(:government_hydrated) ->
         data
 
-      not Government.enabled?(speed) ->
+      not Government.enabled?(data.instance_id, speed) ->
         data
 
       true ->

--- a/lib/game/instance/faction/government.ex
+++ b/lib/game/instance/faction/government.ex
@@ -116,11 +116,35 @@ defmodule Instance.Faction.Government do
   @relaxed_threshold 4
 
   @doc """
-  Government runs only in Legacy games (`:slow`). The config flag lets
-  dev/test environments exercise it at faster speeds; it is off in prod.
+  Government runs only in Legacy games (`:slow`) that opted in at
+  creation — the "Faction Government (Beta)" checkbox on the new-game
+  form, merged into `game_data` and cached in the per-instance metadata
+  (`Instance.Manager.init_from_model/4`), same plumbing as
+  `Instance.Cheats.enabled?/1`.
+
+  The metadata flag is tri-state: instances created before the flag
+  existed (and non-UI creators that don't send it — harness scripts, bare
+  test processes) have no key (`nil`) and keep the historical
+  always-on-Legacy behavior; only an explicit `false` disables the
+  feature. The config flag lets dev/test environments exercise it at
+  faster speeds; it is off in prod.
   """
-  def enabled?(speed),
-    do: speed == :slow or Application.get_env(:rc, :government_all_speeds, false)
+  def enabled?(instance_id, speed) do
+    (speed == :slow or Application.get_env(:rc, :government_all_speeds, false)) and
+      creation_flag(instance_id) != false
+  end
+
+  # Rescue-guarded metadata read (same pattern as Instance.Cheats): nil
+  # when the key is absent or there is no live instance storage at all.
+  defp creation_flag(instance_id) when is_integer(instance_id) do
+    try do
+      Data.Data.get(instance_id, :metadata)[:faction_gov_enabled]
+    rescue
+      _ -> nil
+    end
+  end
+
+  defp creation_flag(_), do: nil
 
   def new(ctx) do
     %Government{

--- a/lib/game/instance/manager.ex
+++ b/lib/game/instance/manager.ex
@@ -365,9 +365,14 @@ defmodule Instance.Manager do
       # score without re-reading the instance row on every stats tick.
       daily_objective: get_in(game_data, ["daily", "objective"]),
       daily_date: get_in(game_data, ["daily", "date"]),
-      # Cheat access: opt-in at game creation. Gates the creator-only cheat
+      # Cheat access: opt-in at game creation. Gates the in-game cheat
       # panel (CheatChannel) and the engine-side cheat handlers.
-      cheats_enabled: game_data["cheats_enabled"] == true
+      cheats_enabled: game_data["cheats_enabled"] == true,
+      # Faction government (beta): opt-in at game creation, Legacy-only.
+      # Tri-state on purpose — nil (pre-feature instances, clients that
+      # didn't send the field) grandfathers the historical always-on-Legacy
+      # behavior. See Instance.Faction.Government.enabled?/2.
+      faction_gov_enabled: game_data["faction_gov_enabled"]
     ]
 
     # PREPARATION STEP

--- a/lib/portal/channels/controllers/cheat_channel.ex
+++ b/lib/portal/channels/controllers/cheat_channel.ex
@@ -2,16 +2,22 @@ defmodule Portal.Controllers.CheatChannel do
   @moduledoc """
   Out-of-band channel that short-circuits normal game economics.
 
-  Two authorized caller classes, each re-asserted by every handler so a
+  Three authorized caller classes, each re-asserted by every handler so a
   config slip can't accidentally expose cheats to real players:
 
     * stress-test bots (`account.is_bot`) — the original consumer, allowed
-      on any instance;
-    * the game creator (`instances.account_id`) — but only on an instance
-      created with cheat access (`Instance.Cheats.enabled?/1`). This powers
-      the in-game Cheats tab used to test faction governments, game modes,
-      and "game DM" scenarios. Cheat-enabled games announce themselves in
-      every faction's chat at genesis.
+      on any instance (but only for the member-level ops below on
+      non-cheat instances: the panel ops all require the instance flag);
+    * any player of an instance created with cheat access
+      (`Instance.Cheats.enabled?/1`) — member-level ops: giving (strictly
+      positive) resources and clearing lex cooldowns;
+    * the game creator (`instances.account_id`) — additionally the
+      game-shaping ops: runtime speed, instant settle, and the election
+      fast-forward/reopen cheats.
+
+  This powers the in-game Cheats tab used to test faction governments,
+  game modes, and "game DM" scenarios. Cheat-enabled games announce
+  themselves in every faction's chat at genesis.
 
   Topic format: `cheat:player:{instance_id}:{player_id}`. Caller must
   already be authorised to act AS that player — same registration check the
@@ -67,14 +73,19 @@ defmodule Portal.Controllers.CheatChannel do
   end
 
   # Original bot cheat: grant resources to the topic's own player.
+  # Amounts are validated non-negative — the channel never debits anyone,
+  # no matter who is calling.
   record("grant_resources", payload, socket) do
-    with :ok <- assert_cheat_access(socket) do
-      amounts = %{
-        credit: Map.get(payload, "credit", 0),
-        technology: Map.get(payload, "technology", 0),
-        ideology: Map.get(payload, "ideology", 0)
-      }
+    amounts = %{
+      credit: Map.get(payload, "credit", 0),
+      technology: Map.get(payload, "technology", 0),
+      ideology: Map.get(payload, "ideology", 0)
+    }
 
+    with :ok <- assert_member_access(socket),
+         true <-
+           Enum.all?(Map.values(amounts), &(is_number(&1) and &1 >= 0 and &1 <= @max_grant)) or
+             {:error, "invalid_amount"} do
       case Game.call(iid(socket), :player, pid(socket), {:cheat, :grant_resources, amounts}) do
         {:error, reason} -> {:error, %{reason: reason}}
         _ -> :ok
@@ -87,7 +98,7 @@ defmodule Portal.Controllers.CheatChannel do
   # Cheats tab: give one resource to one player, or to every player in the
   # instance ("target": "all").
   record("give_resources", %{"target" => target, "resource" => resource, "amount" => amount}, socket) do
-    with :ok <- assert_cheat_access(socket),
+    with :ok <- assert_member_access(socket),
          :ok <- assert_cheats_enabled(socket),
          true <- resource in @resources or {:error, "unknown_resource"},
          true <- (is_number(amount) and amount > 0 and amount <= @max_grant) or {:error, "invalid_amount"},
@@ -116,7 +127,7 @@ defmodule Portal.Controllers.CheatChannel do
   # loser through {:lose_system, _}, and losing a last system kills that
   # player. Settling is for neutral/uninhabited/uninhabitable systems.
   record("settle_system", %{"target" => target, "system_id" => system_id}, socket) do
-    with :ok <- assert_cheat_access(socket),
+    with :ok <- assert_creator_access(socket),
          :ok <- assert_cheats_enabled(socket),
          true <- (is_integer(target) and is_integer(system_id)) or {:error, "invalid_payload"},
          {:ok, player_ids} <- resolve_targets(socket, "all"),
@@ -152,7 +163,7 @@ defmodule Portal.Controllers.CheatChannel do
   # Cheats tab: clear lex-locking cooldowns for everyone — the per-faction
   # law-change cooldown and every player's policy re-lock cooldown.
   record("clear_lex_cooldowns", %{}, socket) do
-    with :ok <- assert_cheat_access(socket),
+    with :ok <- assert_member_access(socket),
          :ok <- assert_cheats_enabled(socket),
          {:ok, player_ids} <- resolve_targets(socket, "all") do
       faction_results =
@@ -177,7 +188,7 @@ defmodule Portal.Controllers.CheatChannel do
 
   # Cheats tab: retime the running instance (multiplier × base speed).
   record("set_speed", %{"multiplier" => multiplier}, socket) do
-    with :ok <- assert_cheat_access(socket),
+    with :ok <- assert_creator_access(socket),
          :ok <- assert_cheats_enabled(socket),
          true <- multiplier in @allowed_speed_multipliers or {:error, "invalid_multiplier"} do
       case Instance.Manager.call(iid(socket), {:cheat_set_speedup, multiplier}) do
@@ -191,21 +202,33 @@ defmodule Portal.Controllers.CheatChannel do
 
   # ---- authorization ---------------------------------------------------
 
+  # Member level: stress-test bots (any instance — grant_resources compat)
+  # or any player of a cheats-enabled instance. Join already proved the
+  # caller owns the topic's player (own_player?/3), so the flag is all
+  # that's left to check.
   defp cheat_access?(socket, instance_id) do
-    is_bot?(socket) or creator_with_cheats?(socket, instance_id)
+    is_bot?(socket) or Instance.Cheats.enabled?(instance_id)
   end
 
-  defp creator_with_cheats?(socket, instance_id) do
-    Instance.Cheats.enabled?(instance_id) and
-      RC.Instances.own_instance?(socket.assigns.account.id, instance_id)
-  end
-
-  defp assert_cheat_access(socket) do
+  defp assert_member_access(socket) do
     if cheat_access?(socket, iid(socket)), do: :ok, else: {:error, "cheat_access_denied"}
   end
 
-  # The creator-facing ops (unlike the bot-only grant_resources) must never
-  # run on a non-cheat instance, even for bots.
+  # Creator level: the game-shaping ops (runtime speed, instant settle,
+  # election fast-forwards) stay restricted to the instance creator —
+  # every player shares one clock and one map, so only the "game DM" gets
+  # to rewrite them. Bots keep full access for stress scenarios.
+  defp assert_creator_access(socket) do
+    creator =
+      is_bot?(socket) or
+        (Instance.Cheats.enabled?(iid(socket)) and
+           RC.Instances.own_instance?(socket.assigns.account.id, iid(socket)))
+
+    if creator, do: :ok, else: {:error, "cheat_creator_only"}
+  end
+
+  # The panel ops (unlike the bot-oriented grant_resources) must never run
+  # on a non-cheat instance, even for bots.
   defp assert_cheats_enabled(socket) do
     if Instance.Cheats.enabled?(iid(socket)), do: :ok, else: {:error, "cheats_disabled"}
   end
@@ -223,8 +246,9 @@ defmodule Portal.Controllers.CheatChannel do
 
   # ---- helpers ---------------------------------------------------------
 
+  # Election-timer manipulation is creator-only — see assert_creator_access.
   defp gov_cheat_fanout(socket, op) do
-    with :ok <- assert_cheat_access(socket),
+    with :ok <- assert_creator_access(socket),
          :ok <- assert_cheats_enabled(socket) do
       results = Enum.map(faction_ids(socket), fn faction_id -> Game.call(iid(socket), :faction, faction_id, op) end)
       applied = Enum.count(results, &(&1 == :ok))

--- a/lib/portal/channels/controllers/global_channel.ex
+++ b/lib/portal/channels/controllers/global_channel.ex
@@ -48,9 +48,11 @@ defmodule Portal.Controllers.GlobalChannel do
             # join payload is huge, garbage collect after a few seconds
             Portal.Socket.gc(socket)
 
-            # Per-socket instance info: cheat access (cheat_creator is
-            # personalised — only the game creator sees the Cheats tab) and
-            # the runtime speed-cheat multiplier so client timers rescale.
+            # Per-socket instance info: cheat access (cheats_enabled shows
+            # the Cheats tab to every player; cheat_creator is personalised
+            # and unlocks the creator-only sections — speed, settle,
+            # election timers) and the runtime speed-cheat multiplier so
+            # client timers rescale.
             cheats_enabled = Instance.Cheats.enabled?(instance_id)
 
             global_instance = %{

--- a/lib/rc/instances.ex
+++ b/lib/rc/instances.ex
@@ -570,6 +570,20 @@ defmodule RC.Instances do
         game_data
       end
 
+    # Faction government (beta) is a creation-time opt-in, never on
+    # non-Legacy games (the engine gate in Instance.Faction.Government
+    # re-checks the speed). Deliberately only written when the client sent
+    # the field: instances created without it (pre-feature games, harness
+    # scripts, older clients) keep the historical always-on-Legacy behavior
+    # via the missing-key grandfather in Government.enabled?/2.
+    game_data =
+      if Map.has_key?(attrs, "faction_gov_enabled") do
+        enabled = attrs["faction_gov_enabled"] == true and game_data["speed"] == "slow"
+        Map.put(game_data, "faction_gov_enabled", enabled)
+      else
+        game_data
+      end
+
     instance_attrs =
       attrs
       |> Map.put("state", "created")

--- a/test/game/instance/faction/government_test.exs
+++ b/test/game/instance/faction/government_test.exs
@@ -27,6 +27,38 @@ defmodule Instance.Faction.GovernmentTest do
     :ok
   end
 
+  describe "enabled?/2" do
+    # Own instance id: these tests mutate the metadata flag, and the
+    # shared @test_instance_id metadata must stay untouched.
+    @gov_flag_instance_id 999_999_998
+
+    test "requires Legacy speed (dev all-speeds flag is off in test)" do
+      assert Government.enabled?(@test_instance_id, :slow)
+      refute Government.enabled?(@test_instance_id, :fast)
+    end
+
+    test "missing metadata key grandfathers pre-feature instances and bare processes" do
+      # @test_instance_id's metadata has no :faction_gov_enabled key
+      assert Government.enabled?(@test_instance_id, :slow)
+      # no instance storage at all → rescue-guarded read
+      assert Government.enabled?(123_456_789_000, :slow)
+      assert Government.enabled?(nil, :slow)
+    end
+
+    test "creation-time opt-out disables; opt-in re-enables (Legacy only)" do
+      # :fast content (same as the shared fixture) — enabled?/2 takes the
+      # speed as an argument, the metadata :speed is irrelevant to it.
+      Data.Data.insert(@gov_flag_instance_id, speed: :fast, mode: :prod, faction_gov_enabled: false)
+      on_exit(fn -> Data.Data.clear(@gov_flag_instance_id) end)
+
+      refute Government.enabled?(@gov_flag_instance_id, :slow)
+
+      Data.Data.update_metadata(@gov_flag_instance_id, :faction_gov_enabled, true)
+      assert Government.enabled?(@gov_flag_instance_id, :slow)
+      refute Government.enabled?(@gov_flag_instance_id, :fast)
+    end
+  end
+
   defp players(0), do: []
 
   defp players(count) do

--- a/test/rc/instances_test.exs
+++ b/test/rc/instances_test.exs
@@ -187,6 +187,37 @@ defmodule RC.InstancesTest do
       assert instance.game_data["cheats_enabled"] == false
     end
 
+    test "create_instance/3 merges faction_gov_enabled into game_data on Legacy scenarios" do
+      scenario = scenario_fixture(%{game_data: %{"speed" => "slow"}})
+      {:ok, account: account} = create_account_user(%{})
+
+      attrs = Map.put(@instance_valid_attrs, "faction_gov_enabled", true)
+      {:ok, %{instance: instance}} = Instances.create_instance(attrs, scenario, account.id)
+
+      assert instance.game_data["faction_gov_enabled"] == true
+    end
+
+    test "create_instance/3 refuses faction government on non-Legacy scenarios" do
+      scenario = scenario_fixture(%{game_data: %{"speed" => "fast"}})
+      {:ok, account: account} = create_account_user(%{})
+
+      attrs = Map.put(@instance_valid_attrs, "faction_gov_enabled", true)
+      {:ok, %{instance: instance}} = Instances.create_instance(attrs, scenario, account.id)
+
+      assert instance.game_data["faction_gov_enabled"] == false
+    end
+
+    test "create_instance/3 leaves faction_gov_enabled absent when the client doesn't send it" do
+      # Missing key = pre-feature client → the engine grandfathers the
+      # historical always-on-Legacy behavior (Government.enabled?/2).
+      scenario = scenario_fixture(%{game_data: %{"speed" => "slow"}})
+      {:ok, account: account} = create_account_user(%{})
+
+      {:ok, %{instance: instance}} = Instances.create_instance(@instance_valid_attrs, scenario, account.id)
+
+      refute Map.has_key?(instance.game_data, "faction_gov_enabled")
+    end
+
     test "create_instance/1 with nil attrs returns error ArgumentError" do
       scenario = scenario_fixture()
       {:ok, account: account} = create_account_user(%{})


### PR DESCRIPTION
…ion Government (Beta) creation toggle

Cheat panel: every player of a cheats-enabled match can now join the CheatChannel and use the member-tier ops (give strictly-positive resources, clear lex cooldowns; the bot-era grant_resources is now validated non-negative). The game-shaping ops stay creator-only and return cheat_creator_only otherwise: runtime speed, instant settle, and the election-timer cheats (skip founding / conclude / reopen). Client: Cheats tab shows for everyone (cheatsAvailable), creator-only sections gated by the new cheatCreator getter.

Faction government: new "Faction Government (Beta)" checkbox on the new-game form — Legacy scenarios only, default OFF (ranked is excluded by construction: ranked requires fast speed). Plumbed like the cheat button: attrs -> game_data["faction_gov_enabled"] (server re-forces false unless speed=="slow") -> instance metadata -> Government.enabled?(instance_id, speed). The metadata flag is tri-state: a missing key (pre-feature instances, harness scripts, API clients that don't send the field) grandfathers the historical always-on-Legacy behavior; only an explicit false disables the feature, and it also beats the dev :government_all_speeds flag.

Verified: government + instances + faction/diplomacy suites green (6 new tests), bin/gov-e2e.ps1 fully green on the grandfathered path, live flag-off instance reports :government_disabled, and both channel tiers exercised over a real websocket (member allowed/denied per spec, creator speed change applied).