### PR TITLE
feat(ui): income tooltip shows hourly/daily rates + projected totals

### DIFF
--- a/front/src/game/components/generic/ResourceDetail.vue
+++ b/front/src/game/components/generic/ResourceDetail.vue
@@ -16,10 +16,11 @@
     </div>
 
     <div
-      v-if="projection !== undefined && projection !== null"
-      class="label-value resource-detail-projection">
-      <span>{{ projectionLabel || $t('resource-detail.projection_24h') }}</span>
-      <span>{{ projection | float(0) }}</span>
+      v-for="(rate, i) in rates"
+      :key="`rate-${i}`"
+      class="label-value resource-detail-rate">
+      <span>{{ rate.label }}</span>
+      <span>{{ rate.value | float(0, true) }}</span>
     </div>
 
     <template v-if="Array.isArray(details)">
@@ -110,6 +111,17 @@
         <span>{{ $t(`resource-detail.minimum.min`, [minimum[0].value]) }}</span>
       </div>
     </template>
+
+    <template v-if="totals && totals.length > 0">
+      <hr />
+      <div
+        v-for="(total, i) in totals"
+        :key="`total-${i}`"
+        class="label-value resource-detail-total">
+        <span>{{ total.label }}</span>
+        <span>{{ total.value | float(0) }}</span>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -132,15 +144,20 @@ export default {
       type: String,
       default: undefined,
     },
-    projection: {
-      type: Number,
+    // Income rates shown directly under the main line (e.g. per hour / per
+    // day). Each entry is { label, value }; value is a signed per-real-time
+    // rate, not a stockpile.
+    rates: {
+      type: Array,
       required: false,
-      default: undefined,
+      default: () => [],
     },
-    projectionLabel: {
-      type: String,
+    // Projected stockpile totals shown at the very bottom (e.g. total in 1h /
+    // 24h). Each entry is { label, value }; value is an absolute amount.
+    totals: {
+      type: Array,
       required: false,
-      default: undefined,
+      default: () => [],
     },
   },
   methods: {

--- a/front/src/game/components/navbar/Bottombar.vue
+++ b/front/src/game/components/navbar/Bottombar.vue
@@ -72,8 +72,8 @@
               :title="$t('data.bonus_pipeline_in.player_credit.name')"
               :description="$t(`resource-description.credit`)"
               :value="player.credit.change"
-              :projection="projectIncome(player.credit)"
-              :projection-label="projectionLabel"
+              :rates="resourceRates(player.credit)"
+              :totals="resourceTotals(player.credit)"
               :details="player.credit.details" />
           </v-popover>
 
@@ -89,8 +89,8 @@
               :title="$t('data.bonus_pipeline_in.player_technology.name')"
               :description="$t(`resource-description.technology`)"
               :value="player.technology.change"
-              :projection="projectIncome(player.technology)"
-              :projection-label="projectionLabel"
+              :rates="resourceRates(player.technology)"
+              :totals="resourceTotals(player.technology)"
               :details="player.technology.details" />
           </v-popover>
 
@@ -106,8 +106,8 @@
               :title="$t('data.bonus_pipeline_in.player_ideology.name')"
               :description="$t(`resource-description.ideology`)"
               :value="player.ideology.change"
-              :projection="projectIncome(player.ideology)"
-              :projection-label="projectionLabel"
+              :rates="resourceRates(player.ideology)"
+              :totals="resourceTotals(player.ideology)"
               :details="player.ideology.details" />
           </v-popover>
         </div>
@@ -342,9 +342,6 @@ export default {
     theme() { return this.$store.getters['game/theme']; },
     view() { return this.$store.state.game.view; },
     isDaily() { return this.$store.state.game.time.speed === 'daily'; },
-    projectionLabel() {
-      return this.$t(this.isDaily ? 'resource-detail.projection_3min' : 'resource-detail.projection_24h');
-    },
     player() { return this.$store.state.game.player; },
     ownSystems() { return this.player.stellar_systems; },
     ownDominions() { return this.player.dominions; },
@@ -463,19 +460,48 @@ export default {
     setHoveredResource(name) {
       this.$root.$emit('hoveredResource', name);
     },
-    // Project a player resource forward at the current per-UT income rate,
-    // over a real-time horizon. Speed-aware: UTs accumulate at 480 * the
-    // effective factor (base speed × runtime speed cheat) per 24 real hours.
-    // Dailies run on a 30-minute clock, so a 24h projection is meaningless —
-    // they get a near-term 3-minute one instead. Ignores future buildings,
-    // conquests, agent losses — purely "if nothing changes."
-    projectIncome(resource) {
-      if (!resource || typeof resource.value !== 'number') return undefined;
+    // How many game ticks (UTs) elapse per real hour, at the speed actually
+    // in effect (base speed × runtime speed cheat). At 1× a tick is 3 real
+    // minutes, so 20 ticks/hour. Undefined until the join payload primes the
+    // speed data.
+    ticksPerHour() {
       const factor = this.$store.getters['game/effectiveSpeedFactor'];
-      if (!factor) return undefined;
-      const minutes = this.isDaily ? 3 : 24 * 60;
-      const uts = 480 * factor * (minutes / (24 * 60));
-      return resource.value + (resource.change || 0) * uts;
+      return factor ? 20 * factor : undefined;
+    },
+    // Per-real-time income rates shown directly under the main (per-tick) line.
+    // These translate the raw per-tick change into the figures players
+    // actually reason about. Dailies run on a ~30-minute clock, so hourly/daily
+    // rates are meaningless — they get a per-minute rate instead.
+    resourceRates(resource) {
+      const perHour = this.ticksPerHour();
+      if (!resource || typeof resource.change !== 'number' || !perHour) return [];
+      const rateHour = resource.change * perHour;
+      if (this.isDaily) {
+        return [{ label: this.$t('resource-detail.rate_minute'), value: rateHour / 60 }];
+      }
+      return [
+        { label: this.$t('resource-detail.rate_hour'), value: rateHour },
+        { label: this.$t('resource-detail.rate_day'), value: rateHour * 24 },
+      ];
+    },
+    // Projected stockpile totals shown at the foot of the tooltip: current
+    // amount plus the income that would accrue over the horizon if nothing
+    // changed (ignores future buildings, conquests, agent losses). Dailies
+    // last 30 minutes, so they get a near-term 3-minute projection instead.
+    resourceTotals(resource) {
+      const perHour = this.ticksPerHour();
+      if (!resource || typeof resource.value !== 'number' || !perHour) return [];
+      const change = resource.change || 0;
+      if (this.isDaily) {
+        // 3 real minutes = a twentieth of an hour's worth of ticks.
+        const per3min = change * (perHour / 20);
+        return [{ label: this.$t('resource-detail.projection_3min'), value: resource.value + per3min }];
+      }
+      const rateHour = change * perHour;
+      return [
+        { label: this.$t('resource-detail.total_1h'), value: resource.value + rateHour },
+        { label: this.$t('resource-detail.total_24h'), value: resource.value + rateHour * 24 },
+      ];
     },
   },
   mounted() {

--- a/front/src/locales/en/game.json
+++ b/front/src/locales/en/game.json
@@ -1377,6 +1377,11 @@
     },
     "projection_24h": "In 24h",
     "projection_3min": "In 3 min",
+    "rate_minute": "Income / minute",
+    "rate_hour": "Income / hour",
+    "rate_day": "Income / day",
+    "total_1h": "Total in 1h",
+    "total_24h": "Total in 24h",
     "unknown_detail": "Details unknown",
     "government": {
       "tax": "Faction income tax",

--- a/front/src/locales/fr/game.json
+++ b/front/src/locales/fr/game.json
@@ -1342,6 +1342,12 @@
       "government": "Gouvernement de faction"
     },
     "projection_24h": "Dans 24h",
+    "projection_3min": "Dans 3 min",
+    "rate_minute": "Revenu / minute",
+    "rate_hour": "Revenu / heure",
+    "rate_day": "Revenu / jour",
+    "total_1h": "Total dans 1h",
+    "total_24h": "Total dans 24h",
     "unknown_detail": "Détail inconnu",
     "government": {
       "tax": "Impôt de faction",

--- a/front/src/styles/shared/plugins/v-popover.scss
+++ b/front/src/styles/shared/plugins/v-popover.scss
@@ -41,14 +41,16 @@
       text-transform: uppercase;
     }
 
-    &.resource-detail-projection {
-      margin-top: 2px;
-      padding-top: 3px;
-      padding-bottom: 3px;
-      border-top: dashed 1px rgba(255, 255, 255, .15);
-      border-bottom: dashed 1px rgba(255, 255, 255, .15);
-      color: rgba(255, 255, 255, .8);
+    // Derived income rates sitting right under the main line — muted so the
+    // per-tick figure above stays the anchor.
+    &.resource-detail-rate {
+      color: rgba(255, 255, 255, .7);
       font-style: italic;
+    }
+
+    // Projected stockpile totals at the foot of the tooltip.
+    &.resource-detail-total {
+      color: rgba(255, 255, 255, .8);
     }
   }
 


### PR DESCRIPTION
Rework the credit/tech/ideology income tooltip so income rates and projected stockpiles read as distinct ideas. The old single "In 24h" line (current amount + 24h of income) sat under the header and was routinely misread as an hourly rate.

Now the per-tick line is followed directly by Income/hour and Income/day rate rows, and the projected Total in 1h / Total in 24h sit at the foot of the tooltip. Dailies (fast 240x clock, ~30min sessions) get an Income/minute rate and keep the near-term "In 3 min" projection. Also drops the doubled solid+dashed separators near the header for a single divider above the totals.