### PR TITLE
Bare-basics mobile support: portal reflow + touch tapping on the galaxy map

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -30,6 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ubuntu-latest (24.04) no longer preinstalls ImageMagick, which
+      # Waffle shells out to (`convert`) in the upload/thumbnail tests;
+      # librsvg2-bin provides rsvg-convert for the Forge scenario
+      # thumbnail renderer (missing since that feature landed — tests
+      # only warned, but it spams the log).
+      - name: Install image tooling
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends imagemagick librsvg2-bin
+
       - name: Set up Elixir / OTP
         uses: erlef/setup-beam@v1
         with:

--- a/assets/css/layouts/_public.scss
+++ b/assets/css/layouts/_public.scss
@@ -190,3 +190,26 @@
     }
   }
 }
+
+// Phone-width navbar: at ~400px the five nav items no longer fit at
+// full size, so each item's own text wraps ("PATCH / NOTES", "LOG /
+// IN"). Keep items on one line, shrink them, and let the bar swipe
+// sideways if a narrow screen still can't fit everything.
+@media screen and (max-width: 600px) {
+  .main-container {
+    .navbar {
+      overflow-x: auto;
+      overflow-y: hidden;
+
+      section {
+        flex: 0 0 auto;
+      }
+
+      .nav-item {
+        white-space: nowrap;
+        padding: 10px 8px;
+        font-size: 1.3rem;
+      }
+    }
+  }
+}

--- a/assets/css/views/_home-generic.scss
+++ b/assets/css/views/_home-generic.scss
@@ -104,12 +104,16 @@
 }
 
 @media screen and (max-width: $mobile-breakpoint) {
+  // No side margins here: width:100% + 20px margins overflowed the
+  // viewport by 40px (the bloc hugged/spilled past the right edge on
+  // phones). The mobile .fixed-container / .fluid-container already
+  // provide the side gutters.
   .home-bloc {
     width: 100%;
-    margin: 0 20px 20px 20px;
+    margin: 0 0 20px 0;
 
     &.is-left {
-      margin: 0 20px 20px 20px;
+      margin: 0 0 20px 0;
     }
   }
 }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,6 +6,14 @@ config :rc,
   environment: :dev,
   disallow_mp3: true
 
+# Dev serves plain HTTP. Without this, Portal.Plug.MaybeSession falls back
+# to its secure-by-default and stamps `secure` on the _portal_key session
+# cookie — which browsers silently DROP on any non-localhost HTTP origin
+# (http://<lan-ip>:8940 from a phone), producing an endless login loop.
+# localhost masks the bug: browsers treat it as a trustworthy origin and
+# accept Secure cookies there.
+config :rc, force_ssl: false
+
 # Faction government is Legacy-only (:slow) in prod; in dev, run it at
 # every speed so :fast instances can demo elections in minutes.
 config :rc, :government_all_speeds, true

--- a/front/src/game/Game.vue
+++ b/front/src/game/Game.vue
@@ -117,6 +117,7 @@ import { TimelineLite, Expo } from 'gsap';
 import Typed from 'typed.js';
 import MapData from '@/game/map/map-data';
 import eventBus from '@/plugins/event-bus';
+import viewport from '@/utils/viewport';
 
 import UniverseMap from '@/game/components/galaxy/Map.vue';
 import EmpirePanel from '@/game/components/panel/EmpirePanel.vue';
@@ -156,7 +157,10 @@ export default {
       showSplash: true,
       activePanel: {},
       somePanelIsOpen: false,
-      isChatOpen: true,
+      // Phones: chat starts hidden (it overlays the whole top of the
+      // screen there) and lives behind the topbar chat toggle as a
+      // pull-out drawer. Desktop keeps it always-on.
+      isChatOpen: !viewport.isMobile,
       isSettingsOpen: false,
       mapData,
       // 'credit' | 'technology' | 'ideology' | null — set by Bottombar

--- a/front/src/game/components/galaxy/Container.vue
+++ b/front/src/game/components/galaxy/Container.vue
@@ -4,17 +4,23 @@
       v-if="selectedSystem"
       @closeStellarSystem="closeStellarSystemView" />
 
-    <selection-view v-if="selection" />
+    <!-- Phones: the selection panel minimizes into a draggable bubble
+         (map orders come from long-pressing a target system). -->
+    <selection-view v-if="selection && !isMobileView" />
+    <mobile-selected-agent v-if="selection && isMobileView" />
   </div>
 </template>
 
 <script>
+import viewport from '@/utils/viewport';
 import SystemView from '@/game/components/galaxy/system/View.vue';
 import SelectionView from '@/game/components/galaxy/selection/View.vue';
+import MobileSelectedAgent from '@/game/components/galaxy/MobileSelectedAgent.vue';
 
 export default {
   name: 'galaxy-container',
   computed: {
+    isMobileView() { return viewport.isMobile; },
     selectedSystem() { return this.$store.state.game.selectedSystem; },
     selection() { return this.$store.state.game.selectedCharacter; },
   },
@@ -37,6 +43,7 @@ export default {
   components: {
     SystemView,
     SelectionView,
+    MobileSelectedAgent,
   },
 };
 </script>

--- a/front/src/game/components/galaxy/Map.vue
+++ b/front/src/game/components/galaxy/Map.vue
@@ -58,6 +58,7 @@
       <sector-card :sector="activeSector" />
     </div>
     <system-icon-picker />
+    <map-action-radial :data="data" />
     <div ref="mapcontainer"></div>
   </div>
 </template>
@@ -68,6 +69,7 @@ import Map from '@/game/map/map';
 
 import SectorCard from '@/game/components/card/SectorCard.vue';
 import SystemIconPicker from '@/game/components/galaxy/system/SystemIconPicker.vue';
+import MapActionRadial from '@/game/components/galaxy/MapActionRadial.vue';
 
 // declare it outside of the component because we don't want it to be 'Observe'd by Vue,
 // it would slow things down and potentially mess with the map object.
@@ -170,6 +172,7 @@ export default {
   components: {
     SectorCard,
     SystemIconPicker,
+    MapActionRadial,
   },
 };
 </script>

--- a/front/src/game/components/galaxy/MapActionRadial.vue
+++ b/front/src/game/components/galaxy/MapActionRadial.vue
@@ -1,0 +1,139 @@
+<template>
+  <!-- Long-press action wheel: with an agent selected, holding a
+       system on the galaxy map fans out that agent's possible orders
+       around the press point. Availability here is coarse (class +
+       system status); the server remains the real validator and
+       rejections surface as the usual error toast. -->
+  <div
+    v-if="visible"
+    class="map-action-radial"
+    :style="{ left: `${screen.x}px`, top: `${screen.y}px` }">
+    <div
+      v-for="(action, i) in actions"
+      :key="action.key"
+      class="map-action-radial-item"
+      :style="fanPosition(i, actions.length)"
+      @click="pick(action)">
+      <div class="radial-icon">
+        <svgicon :name="`action/${action.key}_alt`" />
+      </div>
+      <div class="radial-label">{{ $t(`galaxy.system.actions.${action.name}`) }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import eventBus from '@/plugins/event-bus';
+
+const INHABITED = ['inhabited_neutral', 'inhabited_dominion', 'inhabited_player'];
+
+export default {
+  name: 'map-action-radial',
+  props: {
+    data: Object, // MapData — systems carry id/status/owner/position
+  },
+  data() {
+    return {
+      visible: false,
+      screen: { x: 0, y: 0 },
+      system: null,
+    };
+  },
+  computed: {
+    character() { return this.$store.state.game.selectedCharacter; },
+    player() { return this.$store.state.game.player; },
+    actions() {
+      const character = this.character;
+      const system = this.system;
+      if (!character || !system) return [];
+
+      const list = [];
+      const own = system.owner && system.owner.id === this.player.id;
+      const inhabited = INHABITED.includes(system.status);
+
+      if (character.actions && character.actions.virtual_position !== system.id) {
+        list.push({ key: 'jump', name: 'move' });
+      }
+
+      if (!own) {
+        if (character.type === 'admiral') {
+          if (system.status === 'uninhabited' && !system.owner) {
+            list.push({ key: 'colonization', name: 'colonize' });
+          }
+          if (inhabited) {
+            list.push({ key: 'conquest', name: 'conquer' });
+            list.push({ key: 'raid', name: 'raid' });
+            list.push({ key: 'loot', name: 'loot' });
+          }
+        }
+
+        if (character.type === 'spy' && inhabited) {
+          list.push({ key: 'infiltrate', name: 'infiltrate' });
+        }
+
+        if (character.type === 'speaker') {
+          if (['inhabited_neutral', 'inhabited_dominion'].includes(system.status)) {
+            list.push({ key: 'make_dominion', name: 'make_dominion' });
+          }
+          if (inhabited) {
+            list.push({ key: 'encourage_hate', name: 'encourage_hate' });
+          }
+        }
+      }
+
+      return list;
+    },
+  },
+  methods: {
+    show({ systemId, screen }) {
+      const system = this.data && this.data.systems
+        ? this.data.systems.find((s) => s.id === systemId)
+        : null;
+      if (!system || !this.character) return;
+      this.system = system;
+      if (this.actions.length === 0) {
+        this.system = null;
+        return;
+      }
+      this.screen = {
+        x: Math.min(Math.max(80, screen.x), window.innerWidth - 80),
+        y: Math.min(Math.max(140, screen.y), window.innerHeight - 120),
+      };
+      this.visible = true;
+    },
+    hide() {
+      this.visible = false;
+      this.system = null;
+    },
+    // Fan the items over the upper semi-circle around the press point.
+    fanPosition(i, count) {
+      const radius = 84;
+      const angle = count === 1
+        ? Math.PI / 2
+        : (Math.PI / 6) + (i * ((Math.PI * 4) / 6) / (count - 1));
+      const x = Math.round(radius * Math.cos(Math.PI - angle));
+      const y = -Math.round(radius * Math.sin(angle));
+      return { transform: `translate(${x}px, ${y}px)` };
+    },
+    pick(action) {
+      const system = this.system;
+      this.hide();
+      this.$root.$emit('map:addAction', action.key, { system });
+    },
+    onDocumentPointerDown(event) {
+      if (!this.visible) return;
+      if (this.$el && this.$el.contains && this.$el.contains(event.target)) return;
+      this.hide();
+    },
+  },
+  mounted() {
+    eventBus.$on('map:action-radial:show', this.show);
+    this.onDocumentPointerDownBound = this.onDocumentPointerDown.bind(this);
+    document.addEventListener('pointerdown', this.onDocumentPointerDownBound, true);
+  },
+  beforeDestroy() {
+    eventBus.$off('map:action-radial:show', this.show);
+    document.removeEventListener('pointerdown', this.onDocumentPointerDownBound, true);
+  },
+};
+</script>

--- a/front/src/game/components/galaxy/MobileSelectedAgent.vue
+++ b/front/src/game/components/galaxy/MobileSelectedAgent.vue
@@ -1,0 +1,96 @@
+<template>
+  <!-- Phone replacement for the desktop selection panel: the selected
+       agent minimizes into a draggable floating bubble. Tap centers
+       the map on the agent; the corner ✕ deselects. Map actions come
+       from long-pressing a target system (MapActionRadial). -->
+  <div
+    v-if="character"
+    class="mobile-agent-bubble"
+    :class="`f-${theme}`"
+    :style="{ left: `${x}px`, top: `${y}px` }"
+    @pointerdown="onPointerDown"
+    @contextmenu.prevent>
+    <div class="bubble-icon">
+      <svgicon :name="`agent/${character.type}`" />
+      <span class="number">{{ character.level }}</span>
+    </div>
+    <div class="bubble-name">{{ character.name }}</div>
+    <button
+      class="bubble-close"
+      @pointerdown.stop
+      @click.stop="unselect">
+      <svgicon name="close" />
+    </button>
+  </div>
+</template>
+
+<script>
+const DRAG_SLOP_PX = 8;
+
+export default {
+  name: 'mobile-selected-agent',
+  data() {
+    return {
+      x: 12,
+      y: Math.max(80, window.innerHeight - 160),
+      dragging: false,
+      moved: false,
+      startX: 0,
+      startY: 0,
+      offsetX: 0,
+      offsetY: 0,
+    };
+  },
+  computed: {
+    character() { return this.$store.state.game.selectedCharacter; },
+    theme() {
+      return this.character
+        ? this.$store.getters['game/themeByKey'](this.character.owner.faction)
+        : null;
+    },
+  },
+  methods: {
+    onPointerDown(event) {
+      this.dragging = true;
+      this.moved = false;
+      this.startX = event.clientX;
+      this.startY = event.clientY;
+      this.offsetX = event.clientX - this.x;
+      this.offsetY = event.clientY - this.y;
+      document.addEventListener('pointermove', this.onPointerMoveBound, true);
+      document.addEventListener('pointerup', this.onPointerUpBound, true);
+    },
+    onPointerMove(event) {
+      if (!this.dragging) return;
+      if (Math.abs(event.clientX - this.startX) > DRAG_SLOP_PX
+        || Math.abs(event.clientY - this.startY) > DRAG_SLOP_PX) {
+        this.moved = true;
+      }
+      if (this.moved) {
+        this.x = Math.min(Math.max(0, event.clientX - this.offsetX), window.innerWidth - 56);
+        this.y = Math.min(Math.max(44, event.clientY - this.offsetY), window.innerHeight - 100);
+      }
+    },
+    onPointerUp() {
+      const wasTap = this.dragging && !this.moved;
+      this.dragging = false;
+      document.removeEventListener('pointermove', this.onPointerMoveBound, true);
+      document.removeEventListener('pointerup', this.onPointerUpBound, true);
+      if (wasTap && this.character) {
+        this.$root.$emit('map:centerToCharacter', this.character);
+      }
+    },
+    unselect() {
+      this.$store.dispatch('game/unselectCharacter');
+    },
+  },
+  created() {
+    this.onPointerMoveBound = this.onPointerMove.bind(this);
+    this.onPointerUpBound = this.onPointerUp.bind(this);
+  },
+  beforeDestroy() {
+    document.removeEventListener('pointermove', this.onPointerMoveBound, true);
+    document.removeEventListener('pointerup', this.onPointerUpBound, true);
+  },
+};
+</script>

--- a/front/src/game/components/galaxy/system/ActionsLegacy.vue
+++ b/front/src/game/components/galaxy/system/ActionsLegacy.vue
@@ -1,8 +1,112 @@
 <template>
   <div ref="container">
+    <!-- Phone layout: flat list instead of the orbital arrangement.
+         Own agents anchor left, everyone else anchors right, and the
+         action buttons sit opposite the identity — the mirroring reads
+         as "mine vs theirs" before color does. Actions stay contextual
+         on the currently selected own agent, same computeds as
+         desktop. -->
     <div
-      class="system-actions-legacy top-shifted"
-      v-if="actions.length > 0">
+      v-if="isMobileView"
+      class="mobile-agents">
+      <div class="mobile-agents-header">
+        <span>{{ $t('navbar.bottombar.agents') }}</span>
+        <button
+          v-if="isOwnSystem"
+          class="mobile-agent-deploy"
+          @click="prepareAgentAssignment()">
+          {{ $t('galaxy.system.actions.deploy') }}
+        </button>
+      </div>
+
+      <div
+        v-if="system.siege !== null"
+        class="mobile-siege">
+        <svgicon :name="`action/${system.siege.type}_alt`" />
+        <span>{{ $t(`data.character_action_status.${system.siege.type}.name`) }}</span>
+        <counter
+          class="counter"
+          :current="system.siege.days.value"
+          :receivedAt="system.receivedAt" />
+        <span>/ {{ system.siege.duration }}</span>
+      </div>
+
+      <div
+        v-if="selectedCharacter && actions.length > 0"
+        class="mobile-system-orders">
+        <div class="mobile-orders-label">{{ selectedCharacter.name }}</div>
+        <button
+          v-for="action in actions"
+          :key="`sys-${action.name}`"
+          class="mobile-order-button"
+          :class="{ 'is-disabled': action.status !== 'available' }"
+          v-tooltip="action.status === 'available' ? action.tooltip : action.reasons"
+          @click="action.status === 'available' && doAction(action.icon)">
+          <svgicon :name="`action/${action.icon}_alt`" />
+          {{ $t(`galaxy.system.actions.${action.name}`) }}
+        </button>
+      </div>
+
+      <div
+        v-for="{ character, actions: characterActions } in sortedSystemCharacters"
+        :key="`m-${character.id}`"
+        class="mobile-agent-row"
+        :class="[
+          `force-${getTheme(character.owner.faction)}`,
+          character.owner.id === player.id ? 'is-mine' : 'is-other',
+          { 'is-selected': selectedCharacter && selectedCharacter.id === character.id },
+        ]">
+        <div
+          class="mobile-agent-identity"
+          @click="clickCharacter(character)">
+          <div class="mobile-agent-icon">
+            <svgicon :name="`agent/${character.type}`" />
+            <span class="number">{{ character.level }}</span>
+          </div>
+          <div class="mobile-agent-name">
+            <div class="name">{{ character.name }}</div>
+            <div
+              v-if="character.owner.id !== player.id"
+              class="info"
+              @click.stop="openPlayer(character.owner.id)">
+              {{ character.owner.name }}
+            </div>
+            <div
+              v-else
+              class="info">
+              {{ $tc(`data.character.${character.type}.name`, 1) }}
+            </div>
+          </div>
+        </div>
+
+        <div class="mobile-agent-buttons">
+          <button
+            v-if="character.owner.id === player.id"
+            class="mobile-order-button"
+            @click="clickCharacter(character)">
+            {{ selectedCharacter && selectedCharacter.id === character.id
+              ? $t('galaxy.system.actions.selected')
+              : $t('galaxy.system.actions.select') }}
+          </button>
+          <template v-else>
+            <button
+              v-for="action in characterActions"
+              :key="`m-${character.id}-${action.name}`"
+              class="mobile-order-button"
+              :class="{ 'is-disabled': action.status !== 'available' }"
+              v-tooltip="action.status === 'available' ? action.tooltip : action.reasons"
+              @click="action.status === 'available' && doCharacterAction(action.icon, character.id)">
+              <svgicon :name="`action/${action.icon}_alt`" />
+              {{ $t(`galaxy.system.actions.${action.name}`) }}
+            </button>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="!isMobileView && actions.length > 0"
+      class="system-actions-legacy top-shifted">
       <div
         v-for="action in actions"
         :key="action.icon"
@@ -34,7 +138,9 @@
       </div>
     </div>
 
-    <div class="system-actions-legacy">
+    <div
+      v-if="!isMobileView"
+      class="system-actions-legacy">
       <div
         v-if="isOwnSystem"
         class="action-item">
@@ -126,7 +232,7 @@
     </div>
 
     <div
-      v-if="system.siege !== null"
+      v-if="!isMobileView && system.siege !== null"
       class="siege"
       v-tooltip="$t(`data.character_action_status.${system.siege.type}.name`)">
       <svgicon :name="`action/${system.siege.type}_alt`" />
@@ -149,6 +255,7 @@
 import { TimelineLite, Expo } from 'gsap';
 
 import actionValidation from '@/utils/actionValidation';
+import viewport from '@/utils/viewport';
 
 import ActionOverview from '@/game/components/galaxy/system/ActionOverview.vue';
 import CircleProgressValue from '@/game/components/generic/CircleProgressValue.vue';
@@ -167,6 +274,7 @@ export default {
     };
   },
   computed: {
+    isMobileView() { return viewport.isMobile; },
     tutorialStep() { return this.$store.state.game.tutorialStep; },
     systemTheme() {
       return this.system.owner
@@ -290,6 +398,15 @@ export default {
       }
 
       return [];
+    },
+    // Mobile list order: own agents first, everyone else after —
+    // pairs with the left/right anchoring in the row layout.
+    sortedSystemCharacters() {
+      return [...this.systemCharacters].sort((a, b) => {
+        const aMine = a.character.owner.id === this.player.id ? 0 : 1;
+        const bMine = b.character.owner.id === this.player.id ? 0 : 1;
+        return aMine - bMine;
+      });
     },
     hasSystemSlot() {
       return this.player.stellar_systems.length < this.player.max_systems.value;

--- a/front/src/game/components/galaxy/system/Production.vue
+++ b/front/src/game/components/galaxy/system/Production.vue
@@ -108,6 +108,8 @@
 <script>
 import { i18n } from '@/plugins/i18n';
 
+import viewport from '@/utils/viewport';
+
 import buildingValidation from '@/utils/buildingValidation';
 
 import BuildingCard from '@/game/components/card/BuildingCard.vue';
@@ -254,6 +256,17 @@ export default {
     },
   },
   methods: {
+    // Phone-only outside-tap dismiss: desktop closes this panel via the
+    // SVG backdrop / queue toggle, neither of which exists on mobile.
+    onDocumentPointerDown(event) {
+      if (!viewport.isMobile) return;
+      if (this.$el && this.$el.contains && this.$el.contains(event.target)) return;
+      if (this.production) {
+        this.$store.commit('game/clearProduction');
+      } else if (this.isQueueOpen) {
+        this.$emit('closeQueue');
+      }
+    },
     enterTile(data, message, type) {
       this.hoveredTile = { data, message, type };
     },
@@ -360,6 +373,13 @@ export default {
         return acc || hasTiles || subs;
       }, false);
     },
+  },
+  mounted() {
+    this.onDocumentPointerDownBound = this.onDocumentPointerDown.bind(this);
+    document.addEventListener('pointerdown', this.onDocumentPointerDownBound, true);
+  },
+  beforeDestroy() {
+    document.removeEventListener('pointerdown', this.onDocumentPointerDownBound, true);
   },
   components: {
     BuildingCard,

--- a/front/src/game/components/galaxy/system/ProductionBox.vue
+++ b/front/src/game/components/galaxy/system/ProductionBox.vue
@@ -1,0 +1,88 @@
+<template>
+  <!-- Production readout + queue toggle. Extracted from Properties.vue
+       so the mobile layout can place it independently (above the
+       celestial list) while desktop keeps it pinned in the square. -->
+  <div class="production-box">
+    <div class="production-value">
+      <template v-if="!system.production">
+        <div class="yield-box">
+          ░░░
+          <svgicon name="resource/production" />
+        </div>
+      </template>
+      <v-popover v-else trigger="hover">
+        <div class="yield-box">
+          {{ system.production.value | integer }}
+          <svgicon name="resource/production" />
+        </div>
+        <resource-detail
+          slot="popover"
+          :title="$t('data.bonus_pipeline_in.sys_production.name')"
+          :description="$t(`resource-description.production`)"
+          :value="system.production.value"
+          :details="system.production.details" />
+      </v-popover>
+    </div>
+    <div
+      v-if="isOwnProperty && system.queue && system.queue.queue.length > 0"
+      class="production-counter">
+      <counter
+        :current="system.queue.queue[0].remaining_prod / system.production.value"
+        :receivedAt="system.receivedAt" />
+    </div>
+    <div
+      v-if="system.queue"
+      class="round-icon"
+      :class="{
+        'is-disabled': system.queue.queue.length === 0,
+        'has-hover': system.queue.queue.length > 0,
+        'is-pulsing': system.queue.queue.length > 0,
+      }"
+      @click="$emit('toggleQueue')">
+      <template v-if="system.queue.queue.length > 0">
+        <circle-progress-value
+          :current="system.queue.queue[0].total_prod - system.queue.queue[0].remaining_prod"
+          :total="system.queue.queue[0].total_prod"
+          :increase="system.production.value"
+          :size="46"
+          :width="4"
+          :theme="color" />
+        <svgicon
+          v-if="system.queue.queue[0].type === 'ship'"
+          :name="`ship/${system.queue.queue[0].prod_key}`" />
+        <svgicon
+          v-else
+          :name="`building/${system.queue.queue[0].prod_key}`" />
+        <span
+          v-if="system.queue.queue.length - 1 > 0"
+          class="number">
+          {{ system.queue.queue.length - 1 }}
+        </span>
+      </template>
+    </div>
+    <div
+      v-else
+      class="round-icon is-disabled">
+    </div>
+  </div>
+</template>
+
+<script>
+import ResourceDetail from '@/game/components/generic/ResourceDetail.vue';
+import CircleProgressValue from '@/game/components/generic/CircleProgressValue.vue';
+import Counter from '@/game/components/generic/Counter.vue';
+
+export default {
+  name: 'production-box',
+  props: {
+    system: Object,
+    isOwnProperty: Boolean,
+    color: String,
+  },
+  components: {
+    ResourceDetail,
+    CircleProgressValue,
+    Counter,
+  },
+};
+</script>

--- a/front/src/game/components/galaxy/system/Properties.vue
+++ b/front/src/game/components/galaxy/system/Properties.vue
@@ -225,69 +225,14 @@
         class="governor-box round-icon is-disabled">
       </div>
 
-      <div class="production-box">
-        <div class="production-value">
-          <template v-if="!system.production">
-            <div class="yield-box">
-              ░░░
-              <svgicon name="resource/production" />
-            </div>
-          </template>
-          <v-popover v-else trigger="hover">
-            <div class="yield-box">
-              {{ system.production.value | integer }}
-              <svgicon name="resource/production" />
-            </div>
-            <resource-detail
-              slot="popover"
-              :title="$t('data.bonus_pipeline_in.sys_production.name')"
-              :description="$t(`resource-description.production`)"
-              :value="system.production.value"
-              :details="system.production.details" />
-          </v-popover>
-        </div>
-        <div
-          v-if="isOwnProperty && system.queue && system.queue.queue.length > 0"
-          class="production-counter">
-          <counter
-            :current="this.system.queue.queue[0].remaining_prod / this.system.production.value"
-            :receivedAt="system.receivedAt" />
-        </div>
-        <div
-          v-if="system.queue"
-          class="round-icon"
-          :class="{
-            'is-disabled': system.queue.queue.length === 0,
-            'has-hover': system.queue.queue.length > 0,
-            'is-pulsing': system.queue.queue.length > 0,
-          }"
-          @click="$emit('toggleQueue')">
-          <template v-if="system.queue.queue.length > 0">
-            <circle-progress-value
-              :current="system.queue.queue[0].total_prod - system.queue.queue[0].remaining_prod"
-              :total="system.queue.queue[0].total_prod"
-              :increase="system.production.value"
-              :size="46"
-              :width="4"
-              :theme="color" />
-            <svgicon
-              v-if="this.system.queue.queue[0].type === 'ship'"
-              :name="`ship/${this.system.queue.queue[0].prod_key}`" />
-            <svgicon
-              v-else
-              :name="`building/${this.system.queue.queue[0].prod_key}`" />
-            <span
-              v-if="system.queue.queue.length - 1 > 0"
-              class="number">
-              {{ system.queue.queue.length - 1 }}
-            </span>
-          </template>
-        </div>
-        <div
-          v-else
-          class="round-icon is-disabled">
-        </div>
-      </div>
+      <!-- On phones the production box renders standalone in View.vue's
+           mobile layout (above the celestial list) instead. -->
+      <production-box
+        v-if="!isMobileView"
+        :system="system"
+        :isOwnProperty="isOwnProperty"
+        :color="color"
+        @toggleQueue="$emit('toggleQueue')" />
     </template>
   </div>
 </template>
@@ -297,7 +242,9 @@ import { TimelineLite, Expo } from 'gsap';
 
 import actionValidation from '@/utils/actionValidation';
 
+import viewport from '@/utils/viewport';
 import ActionOverview from '@/game/components/galaxy/system/ActionOverview.vue';
+import ProductionBox from '@/game/components/galaxy/system/ProductionBox.vue';
 import ResourceDetail from '@/game/components/generic/ResourceDetail.vue';
 import CircleProgressValue from '@/game/components/generic/CircleProgressValue.vue';
 import Counter from '@/game/components/generic/Counter.vue';
@@ -316,6 +263,7 @@ export default {
     };
   },
   computed: {
+    isMobileView() { return viewport.isMobile; },
     selectedCharacter() { return this.$store.state.game.selectedCharacter; },
     player() { return this.$store.state.game.player; },
     populationClass() {
@@ -396,6 +344,7 @@ export default {
   },
   components: {
     ActionOverview,
+    ProductionBox,
     ResourceDetail,
     CircleProgressValue,
     Counter,

--- a/front/src/game/components/galaxy/system/View.vue
+++ b/front/src/game/components/galaxy/system/View.vue
@@ -12,6 +12,14 @@
         :isQueueOpen="isQueueOpen" />
 
       <div class="system-content">
+        <!-- Mobile-only (see game/mobile.scss): on touch there is no
+             Esc / scroll-wheel / visible backdrop to close the view. -->
+        <button
+          @click="$emit('closeStellarSystem')"
+          class="system-close-button">
+          <svgicon name="close" />
+        </button>
+
         <component
           :is="agentDisplayComponent"
           :isOwnSystem="isOwnSystem"

--- a/front/src/game/components/galaxy/system/View.vue
+++ b/front/src/game/components/galaxy/system/View.vue
@@ -27,6 +27,13 @@
             :system="system" />
         </div>
 
+        <production-box
+          class="mobile-production"
+          :system="system"
+          :isOwnProperty="isOwnProperty"
+          :color="color"
+          @toggleQueue="toggleProductionQueue" />
+
         <system-content
           :isOwnSystem="isOwnSystem"
           :isOwnProperty="isOwnProperty"
@@ -104,6 +111,7 @@
 <script>
 import viewport from '@/utils/viewport';
 import SystemSvg from '@/game/components/galaxy/system/Svg.vue';
+import ProductionBox from '@/game/components/galaxy/system/ProductionBox.vue';
 import SystemProperties from '@/game/components/galaxy/system/Properties.vue';
 import SystemActions from '@/game/components/galaxy/system/Actions.vue';
 import SystemActionsLegacy from '@/game/components/galaxy/system/ActionsLegacy.vue';
@@ -170,6 +178,7 @@ export default {
     SystemActionsLegacy,
     SystemPopulation,
     SystemProduction,
+    ProductionBox,
   },
 };
 </script>

--- a/front/src/game/components/galaxy/system/View.vue
+++ b/front/src/game/components/galaxy/system/View.vue
@@ -1,50 +1,31 @@
 <template>
   <div :class="`f-${color}`">
+    <!-- Phone layout: an opaque, full-screen, vertically scrolling page
+         (summary, celestials, agents stacked) instead of the desktop
+         square-overlay-plus-side-panels arrangement. Same child
+         components, different frame. -->
     <div
-      @click="$emit('closeStellarSystem')"
-      class="stellar-system-view">
-    </div>
+      v-if="isMobileView && system"
+      class="mobile-system-view">
+      <button
+        @click="$emit('closeStellarSystem')"
+        class="system-close-button">
+        <svgicon name="close" />
+      </button>
 
-    <template v-if="system">
-      <system-production
-        :system="system"
-        :color="color"
-        :isQueueOpen="isQueueOpen" />
+      <div class="mobile-system-scroll">
+        <div class="mobile-system-summary">
+          <system-properties
+            :isOwnSystem="isOwnSystem"
+            :isOwnProperty="isOwnProperty"
+            :system="system"
+            :color="color"
+            @toggleQueue="toggleProductionQueue" />
 
-      <div class="system-content">
-        <!-- Mobile-only (see game/mobile.scss): on touch there is no
-             Esc / scroll-wheel / visible backdrop to close the view. -->
-        <button
-          @click="$emit('closeStellarSystem')"
-          class="system-close-button">
-          <svgicon name="close" />
-        </button>
-
-        <component
-          :is="agentDisplayComponent"
-          :isOwnSystem="isOwnSystem"
-          :isOwnProperty="isOwnProperty"
-          :system="system" />
-
-        <system-properties
-          :isOwnSystem="isOwnSystem"
-          :isOwnProperty="isOwnProperty"
-          :system="system"
-          :color="color"
-          @toggleQueue="toggleProductionQueue" />
-
-        <system-svg
-          :key="rerenderKey"
-          :hoveredOrbit="hoveredOrbit"
-          :system="system"
-          @enterOrbit="enterOrbit"
-          @leaveOrbit="leaveOrbit" />
-      </div>
-
-      <div class="system-info">
-        <system-population
-          :isOwnSystem="isOwnSystem"
-          :system="system" />
+          <system-population
+            :isOwnSystem="isOwnSystem"
+            :system="system" />
+        </div>
 
         <system-content
           :isOwnSystem="isOwnSystem"
@@ -54,12 +35,74 @@
           :hoveredOrbit="hoveredOrbit"
           @enterOrbit="enterOrbit"
           @leaveOrbit="leaveOrbit" />
+
+        <system-actions-legacy
+          :isOwnSystem="isOwnSystem"
+          :isOwnProperty="isOwnProperty"
+          :system="system" />
       </div>
+
+      <system-production
+        :system="system"
+        :color="color"
+        :isQueueOpen="isQueueOpen" />
+    </div>
+
+    <template v-else>
+      <div
+        @click="$emit('closeStellarSystem')"
+        class="stellar-system-view">
+      </div>
+
+      <template v-if="system">
+        <system-production
+          :system="system"
+          :color="color"
+          :isQueueOpen="isQueueOpen" />
+
+        <div class="system-content">
+          <component
+            :is="agentDisplayComponent"
+            :isOwnSystem="isOwnSystem"
+            :isOwnProperty="isOwnProperty"
+            :system="system" />
+
+          <system-properties
+            :isOwnSystem="isOwnSystem"
+            :isOwnProperty="isOwnProperty"
+            :system="system"
+            :color="color"
+            @toggleQueue="toggleProductionQueue" />
+
+          <system-svg
+            :key="rerenderKey"
+            :hoveredOrbit="hoveredOrbit"
+            :system="system"
+            @enterOrbit="enterOrbit"
+            @leaveOrbit="leaveOrbit" />
+        </div>
+
+        <div class="system-info">
+          <system-population
+            :isOwnSystem="isOwnSystem"
+            :system="system" />
+
+          <system-content
+            :isOwnSystem="isOwnSystem"
+            :isOwnProperty="isOwnProperty"
+            :system="system"
+            :color="color"
+            :hoveredOrbit="hoveredOrbit"
+            @enterOrbit="enterOrbit"
+            @leaveOrbit="leaveOrbit" />
+        </div>
+      </template>
     </template>
   </div>
 </template>
 
 <script>
+import viewport from '@/utils/viewport';
 import SystemSvg from '@/game/components/galaxy/system/Svg.vue';
 import SystemProperties from '@/game/components/galaxy/system/Properties.vue';
 import SystemActions from '@/game/components/galaxy/system/Actions.vue';
@@ -78,6 +121,7 @@ export default {
     };
   },
   computed: {
+    isMobileView() { return viewport.isMobile; },
     color() {
       return ['inhabited_player', 'inhabited_dominion'].includes(this.system.status)
         ? this.$store.getters['game/themeByKey'](this.system.owner.faction)

--- a/front/src/game/components/galaxy/system/View.vue
+++ b/front/src/game/components/galaxy/system/View.vue
@@ -52,7 +52,8 @@
       <system-production
         :system="system"
         :color="color"
-        :isQueueOpen="isQueueOpen" />
+        :isQueueOpen="isQueueOpen"
+        @closeQueue="isQueueOpen = false" />
     </div>
 
     <template v-else>

--- a/front/src/game/components/mini-panel/DoctrineMiniPanel.vue
+++ b/front/src/game/components/mini-panel/DoctrineMiniPanel.vue
@@ -165,14 +165,16 @@
                       {{ $t(`data.doctrine.${row.key}.name`) }}
                     </div>
                   </div>
-                  <div class="tree-node-card">
+                  <div
+                    class="tree-node-card"
+                    :class="{ 'is-open': activeCardKey === row.key }">
                     <doctrine-card
                       :doctrine="row"
                       :emptyPolicies="hasEmptyPolicies"
                       :costFactor="costFactor"
                       :theme="theme"
-                      @choose="choosePolicy"
-                      @purchase="purchaseDoctrine" />
+                      @choose="chooseFromCard"
+                      @purchase="purchaseFromCard" />
                   </div>
                 </template>
               </div>
@@ -193,14 +195,16 @@
             <div class="tree-node-label">
               {{ $t(`data.doctrine.${root.key}.name`) }}
             </div>
-            <div class="tree-node-card">
+            <div
+              class="tree-node-card"
+              :class="{ 'is-open': activeCardKey === root.key }">
               <doctrine-card
                 :doctrine="root"
                 :emptyPolicies="hasEmptyPolicies"
                 :costFactor="costFactor"
                 :theme="theme"
-                @choose="choosePolicy"
-                @purchase="purchaseDoctrine" />
+                @choose="chooseFromCard"
+                @purchase="purchaseFromCard" />
             </div>
           </div>
         </div>
@@ -211,6 +215,7 @@
 
 <script>
 import Tree from '@/utils/tree';
+import viewport from '@/utils/viewport';
 
 import MiniPanelMixin from '@/game/mixins/MiniPanelMixin';
 import CircleProgressValue from '@/game/components/generic/CircleProgressValue.vue';
@@ -225,6 +230,8 @@ export default {
     return {
       newPolicies: [],
       hasCooldownFinished: false,
+      // Mobile tap-to-card state (see clickDoctrine).
+      activeCardKey: null,
     };
   },
   computed: {
@@ -273,6 +280,14 @@ export default {
   },
   methods: {
     clickDoctrine(doctrine) {
+      // Touch flow: first tap opens the detail card; its own buttons
+      // purchase/choose. A bare icon tap must never spend or toggle a
+      // lex by accident. Desktop keeps hover-card + 1-click.
+      if (viewport.isMobile) {
+        this.activeCardKey = this.activeCardKey === doctrine.key ? null : doctrine.key;
+        return;
+      }
+
       if (doctrine.status === 'available') {
         this.purchaseDoctrine(doctrine.key);
       }
@@ -284,6 +299,14 @@ export default {
       if (doctrine.status === 'chosen') {
         this.discardPolicy(doctrine.key);
       }
+    },
+    chooseFromCard(doctrineKey) {
+      this.activeCardKey = null;
+      this.choosePolicy(doctrineKey);
+    },
+    purchaseFromCard(doctrineKey) {
+      this.activeCardKey = null;
+      this.purchaseDoctrine(doctrineKey);
     },
     purchaseDoctrine(doctrineKey) {
       this.$socket.player

--- a/front/src/game/components/mini-panel/PatentMiniPanel.vue
+++ b/front/src/game/components/mini-panel/PatentMiniPanel.vue
@@ -82,12 +82,14 @@
                       {{ $t(`data.patent.${row.key}.name`) }}
                     </div>
                   </div>
-                  <div class="tree-node-card">
+                  <div
+                    class="tree-node-card"
+                    :class="{ 'is-open': activeCardKey === row.key }">
                     <patent-card
                       :patent="row"
                       :costFactor="costFactor"
                       :theme="theme"
-                      @purchase="purchasePatent" />
+                      @purchase="purchaseFromCard" />
                   </div>
                 </template>
               </div>
@@ -109,12 +111,14 @@
             <div class="tree-node-label">
               {{ $t(`data.patent.${root.key}.name`) }}
             </div>
-            <div class="tree-node-card">
+            <div
+              class="tree-node-card"
+              :class="{ 'is-open': activeCardKey === root.key }">
               <patent-card
                 :patent="root"
                 :costFactor="costFactor"
                 :theme="theme"
-                @purchase="purchasePatent" />
+                @purchase="purchaseFromCard" />
             </div>
           </div>
         </div>
@@ -125,6 +129,7 @@
 
 <script>
 import Tree from '@/utils/tree';
+import viewport from '@/utils/viewport';
 import MiniPanelMixin from '@/game/mixins/MiniPanelMixin';
 
 import PatentCard from '@/game/components/card/PatentCard.vue';
@@ -132,6 +137,12 @@ import PatentCard from '@/game/components/card/PatentCard.vue';
 export default {
   name: 'patent-mini-panel',
   mixins: [MiniPanelMixin],
+  data() {
+    return {
+      // Mobile tap-to-card state (see tryPurchasePatent).
+      activeCardKey: null,
+    };
+  },
   computed: {
     theme() { return this.$store.getters['game/theme']; },
     constant() { return this.$store.state.game.data.constant[0]; },
@@ -177,9 +188,20 @@ export default {
       return this.patents.filter((patent) => patent.class === name);
     },
     tryPurchasePatent(patent) {
+      // Touch flow: first tap opens the detail card (its Buy button
+      // completes the purchase) — a bare icon tap must never spend
+      // resources on a fat-finger. Desktop keeps hover-card + 1-click.
+      if (viewport.isMobile) {
+        this.activeCardKey = this.activeCardKey === patent.key ? null : patent.key;
+        return;
+      }
       if (patent.status === 'available') {
         this.purchasePatent(patent.key);
       }
+    },
+    purchaseFromCard(patentKey) {
+      this.activeCardKey = null;
+      this.purchasePatent(patentKey);
     },
     purchasePatent(patentKey) {
       this.$socket.player

--- a/front/src/game/components/navbar/Bottombar.vue
+++ b/front/src/game/components/navbar/Bottombar.vue
@@ -522,17 +522,18 @@ export default {
         this.pressFiredLong = true;
         if (kind === 'nes') {
           this.openRadial(event);
-        } else if (kind === 'systems') {
-          this.openSystemsModal('systems');
-        } else if (kind === 'dominions') {
-          this.openSystemsModal('dominions');
         }
       }, 450);
     },
     gaugePressEnd(kind, event) {
       clearTimeout(this.pressTimer);
 
-      if (kind !== 'nes') return;
+      if (kind !== 'nes') {
+        // Systems/dominions: a plain tap opens the list (long-press
+        // proved unreliable on real devices).
+        this.openSystemsModal(kind === 'systems' ? 'systems' : 'dominions');
+        return;
+      }
 
       if (!this.pressFiredLong) {
         // plain tap: toggle the radial

--- a/front/src/game/components/navbar/Bottombar.vue
+++ b/front/src/game/components/navbar/Bottombar.vue
@@ -1,6 +1,71 @@
 <template>
   <div class="navbar-container">
-    <div class="navbar bottom">
+    <!-- Phone bar: ring gauges (fill = usage of cap) and bare resource
+         totals — income rates and the center player block live in
+         tooltips/panels instead. Desktop bar below is untouched. -->
+    <div
+      v-if="isMobileView"
+      class="navbar bottom is-mobile">
+      <div class="mobile-bottombar">
+        <div
+          class="mobile-bb-btn"
+          @click="togglePanel('empire')">
+          <svgicon class="icon" name="empire" />
+        </div>
+
+        <mobile-gauge
+          :value="ownSystems.length"
+          :max="player.max_systems.value"
+          glyph="system"
+          :theme="theme"
+          :tooltip="`${$t('navbar.bottombar.systems')}: ${ownSystems.length}/${player.max_systems.value}`" />
+        <mobile-gauge
+          :value="ownDominions.length"
+          :max="player.max_dominions.value"
+          glyph="dominion"
+          :theme="theme"
+          :tooltip="`${$t('navbar.bottombar.dominions')}: ${ownDominions.length}/${player.max_dominions.value}`" />
+
+        <span class="mobile-bb-divider"></span>
+
+        <mobile-gauge
+          v-for="type in characterData"
+          :key="`gauge-${type.key}`"
+          :value="type.activeNumber"
+          :max="type.maxNumber"
+          :letter="$tc(`data.character.${type.key}.name`, 1).charAt(0)"
+          :tooltip="`${$tc(`data.character.${type.key}.name`, 2)}: ${type.activeNumber}/${type.maxNumber}`" />
+
+        <span class="mobile-bb-spacer"></span>
+
+        <div
+          v-for="res in ['credit', 'technology', 'ideology']"
+          :key="`res-${res}`"
+          class="mobile-bb-resource"
+          v-tooltip="`${$t(`data.bonus_pipeline_in.player_${res}.name`)}: ${Math.floor(player[res].value)}`">
+          <svgicon :name="`resource/${res}`" />
+          {{ compactNumber(player[res].value) }}
+        </div>
+
+        <div
+          class="mobile-bb-btn has-badge"
+          @click="toggleMiniPanel('character-deck')">
+          <svgicon class="icon" name="agent/admiral" />
+          <span
+            v-show="playerDeck.length > 0"
+            class="badge">{{ playerDeck.length }}</span>
+        </div>
+        <div
+          class="mobile-bb-btn"
+          @click="togglePanel('operations')">
+          <svgicon class="icon" name="operation" />
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-else
+      class="navbar bottom">
       <div class="navbar-left">
         <!-- TODO: should be a component -->
         <div class="navbar-main-button">
@@ -299,7 +364,10 @@
 <script>
 import { TimelineLite, Expo } from 'gsap';
 
+import viewport from '@/utils/viewport';
+
 import NavbarDynamicValue from '@/game/components/navbar/NavbarDynamicValue.vue';
+import MobileGauge from '@/game/components/navbar/MobileGauge.vue';
 import NavbarMaxedValue from '@/game/components/navbar/NavbarMaxedValue.vue';
 import NavbarPanelBlock from '@/game/components/navbar/NavbarPanelBlock.vue';
 
@@ -338,6 +406,7 @@ export default {
     };
   },
   computed: {
+    isMobileView() { return viewport.isMobile; },
     tutorialStep() { return this.$store.state.game.tutorialStep; },
     theme() { return this.$store.getters['game/theme']; },
     view() { return this.$store.state.game.view; },
@@ -364,6 +433,14 @@ export default {
     },
   },
   methods: {
+    // Bar space on a phone is too tight for full figures — 300,018
+    // reads as 300k; precision lives in the tooltip.
+    compactNumber(value) {
+      const n = Math.floor(value);
+      if (Math.abs(n) >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+      if (Math.abs(n) >= 10_000) return `${Math.round(n / 1000)}k`;
+      return `${n}`;
+    },
     toggleActiveCharacterList() {
       this.isActiveCharacterListOpen = !this.isActiveCharacterListOpen;
     },
@@ -510,6 +587,7 @@ export default {
     this.$root.$on('switchSystem', (mode) => { this.switchSystem(mode); });
   },
   components: {
+    MobileGauge,
     NavbarDynamicValue,
     NavbarMaxedValue,
     NavbarPanelBlock,

--- a/front/src/game/components/navbar/Bottombar.vue
+++ b/front/src/game/components/navbar/Bottombar.vue
@@ -86,33 +86,9 @@
       </div>
     </div>
 
-    <!-- Long-press radial: N / E / S bubbles over the tri-gauge;
-         release (or tap) on one lists that class's agents. Lives
-         outside .navbar.bottom — its overflow clipping would swallow
-         anything drawn above the 44px bar. -->
-    <div
-      v-if="radialOpen"
-      class="mobile-radial"
-      :style="{ left: `${radialX}px` }">
-      <div
-        v-for="(type, i) in characterData"
-        :key="`radial-${type.key}`"
-        class="mobile-radial-item"
-        :class="`is-pos-${i}`"
-        :data-agent-type="type.key"
-        @click="openAgentsModal(type.key)">
-        <span class="letter">{{ $tc(`data.character.${type.key}.name`, 1).charAt(0) }}</span>
-        <span class="count">{{ type.activeNumber }}/{{ type.maxNumber }}</span>
-      </div>
-    </div>
-
-    <mobile-list-modal
-      v-if="activeListModal"
-      :title="activeListModal.title"
-      :items="activeListModal.items"
-      @select="onModalSelect"
-      @close="activeListModal = null" />
-
+    <!-- The desktop bar must IMMEDIATELY follow the mobile bar's div:
+         v-else detaches from its v-if if any element sits between
+         them, and the desktop bar then renders unconditionally. -->
     <div
       v-else
       class="navbar bottom">
@@ -386,6 +362,33 @@
           @select="selectSystem" />
       </navbar-panel-block>
     </div>
+
+    <!-- Long-press radial: N / E / S bubbles over the tri-gauge;
+         release (or tap) on one lists that class's agents. Lives
+         outside .navbar.bottom — its overflow clipping would swallow
+         anything drawn above the 44px bar. -->
+    <div
+      v-if="radialOpen"
+      class="mobile-radial"
+      :style="{ left: `${radialX}px` }">
+      <div
+        v-for="(type, i) in characterData"
+        :key="`radial-${type.key}`"
+        class="mobile-radial-item"
+        :class="`is-pos-${i}`"
+        :data-agent-type="type.key"
+        @click="openAgentsModal(type.key)">
+        <span class="letter">{{ $tc(`data.character.${type.key}.name`, 1).charAt(0) }}</span>
+        <span class="count">{{ type.activeNumber }}/{{ type.maxNumber }}</span>
+      </div>
+    </div>
+
+    <mobile-list-modal
+      v-if="activeListModal"
+      :title="activeListModal.title"
+      :items="activeListModal.items"
+      @select="onModalSelect"
+      @close="activeListModal = null" />
 
     <div
       class="mini-panels-container"

--- a/front/src/game/components/navbar/Bottombar.vue
+++ b/front/src/game/components/navbar/Bottombar.vue
@@ -13,28 +13,59 @@
           <svgicon class="icon" name="empire" />
         </div>
 
-        <mobile-gauge
-          :value="ownSystems.length"
-          :max="player.max_systems.value"
-          glyph="system"
-          :theme="theme"
-          :tooltip="`${$t('navbar.bottombar.systems')}: ${ownSystems.length}/${player.max_systems.value}`" />
-        <mobile-gauge
-          :value="ownDominions.length"
-          :max="player.max_dominions.value"
-          glyph="dominion"
-          :theme="theme"
-          :tooltip="`${$t('navbar.bottombar.dominions')}: ${ownDominions.length}/${player.max_dominions.value}`" />
+        <div
+          class="mobile-gauge-press"
+          @pointerdown="gaugePressStart('systems', $event)"
+          @pointerup="gaugePressEnd('systems', $event)"
+          @pointercancel="gaugePressCancel"
+          @contextmenu.prevent>
+          <mobile-gauge
+            :value="ownSystems.length"
+            :max="player.max_systems.value"
+            glyph="system"
+            :theme="theme"
+            :tooltip="`${$t('navbar.bottombar.systems')}: ${ownSystems.length}/${player.max_systems.value}`" />
+        </div>
+        <div
+          class="mobile-gauge-press"
+          @pointerdown="gaugePressStart('dominions', $event)"
+          @pointerup="gaugePressEnd('dominions', $event)"
+          @pointercancel="gaugePressCancel"
+          @contextmenu.prevent>
+          <mobile-gauge
+            :value="ownDominions.length"
+            :max="player.max_dominions.value"
+            glyph="dominion"
+            :theme="theme"
+            :tooltip="`${$t('navbar.bottombar.dominions')}: ${ownDominions.length}/${player.max_dominions.value}`" />
+        </div>
 
         <span class="mobile-bb-divider"></span>
 
-        <mobile-gauge
-          v-for="type in characterData"
-          :key="`gauge-${type.key}`"
-          :value="type.activeNumber"
-          :max="type.maxNumber"
-          :letter="$tc(`data.character.${type.key}.name`, 1).charAt(0)"
-          :tooltip="`${$tc(`data.character.${type.key}.name`, 2)}: ${type.activeNumber}/${type.maxNumber}`" />
+        <div
+          ref="nesGauge"
+          class="mobile-gauge-press"
+          @pointerdown="gaugePressStart('nes', $event)"
+          @pointerup="gaugePressEnd('nes', $event)"
+          @pointercancel="gaugePressCancel"
+          @contextmenu.prevent>
+          <mobile-tri-gauge
+            :segments="nesSegments"
+            :tooltip="nesTooltip" />
+        </div>
+
+        <div
+          class="mobile-bb-minipanel"
+          @click="toggleMiniPanel('doctrine')">
+          <svgicon name="doctrine/frame_doctrine" />
+          {{ $t('navbar.bottombar.lexes') }}
+        </div>
+        <div
+          class="mobile-bb-minipanel"
+          @click="toggleMiniPanel('patent')">
+          <svgicon name="patent/frame_patent" />
+          {{ $t('navbar.bottombar.patents') }}
+        </div>
 
         <span class="mobile-bb-spacer"></span>
 
@@ -48,20 +79,39 @@
         </div>
 
         <div
-          class="mobile-bb-btn has-badge"
-          @click="toggleMiniPanel('character-deck')">
-          <svgicon class="icon" name="agent/admiral" />
-          <span
-            v-show="playerDeck.length > 0"
-            class="badge">{{ playerDeck.length }}</span>
-        </div>
-        <div
           class="mobile-bb-btn"
           @click="togglePanel('operations')">
           <svgicon class="icon" name="operation" />
         </div>
       </div>
     </div>
+
+    <!-- Long-press radial: N / E / S bubbles over the tri-gauge;
+         release (or tap) on one lists that class's agents. Lives
+         outside .navbar.bottom — its overflow clipping would swallow
+         anything drawn above the 44px bar. -->
+    <div
+      v-if="radialOpen"
+      class="mobile-radial"
+      :style="{ left: `${radialX}px` }">
+      <div
+        v-for="(type, i) in characterData"
+        :key="`radial-${type.key}`"
+        class="mobile-radial-item"
+        :class="`is-pos-${i}`"
+        :data-agent-type="type.key"
+        @click="openAgentsModal(type.key)">
+        <span class="letter">{{ $tc(`data.character.${type.key}.name`, 1).charAt(0) }}</span>
+        <span class="count">{{ type.activeNumber }}/{{ type.maxNumber }}</span>
+      </div>
+    </div>
+
+    <mobile-list-modal
+      v-if="activeListModal"
+      :title="activeListModal.title"
+      :items="activeListModal.items"
+      @select="onModalSelect"
+      @close="activeListModal = null" />
 
     <div
       v-else
@@ -282,6 +332,7 @@
 
     <div
       class="navbar-panel"
+      v-if="!isMobileView"
       v-show="isActiveCharacterListOpen && onBoardCharacters.length > 0 && !selection">
       <div
         v-for="type in characterData"
@@ -304,6 +355,7 @@
 
     <div
       class="navbar-panel"
+      v-if="!isMobileView"
       v-show="!selectedSystem && isSystemListOpen"
       style="left: 0; right: auto;">
       <navbar-panel-block
@@ -368,6 +420,8 @@ import viewport from '@/utils/viewport';
 
 import NavbarDynamicValue from '@/game/components/navbar/NavbarDynamicValue.vue';
 import MobileGauge from '@/game/components/navbar/MobileGauge.vue';
+import MobileTriGauge from '@/game/components/navbar/MobileTriGauge.vue';
+import MobileListModal from '@/game/components/navbar/MobileListModal.vue';
 import NavbarMaxedValue from '@/game/components/navbar/NavbarMaxedValue.vue';
 import NavbarPanelBlock from '@/game/components/navbar/NavbarPanelBlock.vue';
 
@@ -397,6 +451,14 @@ export default {
       ],
       isActiveCharacterListOpen: true,
       isSystemListOpen: true,
+      // Mobile long-press state: the radial N/E/S picker over the
+      // tri-gauge, and the full-screen list modals that replace the
+      // desktop pull-up docks.
+      radialOpen: false,
+      radialX: 0,
+      activeListModal: null,
+      pressTimer: null,
+      pressFiredLong: false,
       characterDeck: false,
       charactersBonusName: {
         admiral: 'max_admirals',
@@ -418,6 +480,18 @@ export default {
     selectedSystem() { return this.$store.state.game.selectedSystem; },
     onBoardCharacters() { return this.player.characters.filter((p) => p.status === 'on_board'); },
     playerDeck() { return this.$store.state.game.player.character_deck; },
+    nesSegments() {
+      return this.characterData.map((type) => ({
+        letter: this.$tc(`data.character.${type.key}.name`, 1).charAt(0),
+        value: type.activeNumber,
+        max: type.maxNumber,
+      }));
+    },
+    nesTooltip() {
+      return this.characterData
+        .map((t) => `${this.$tc(`data.character.${t.key}.name`, 2)}: ${t.activeNumber}/${t.maxNumber}`)
+        .join(' · ');
+    },
     characterData() {
       return this.$store.state.game.data.character.map((data) => {
         const onBoard = this.onBoardCharacters
@@ -433,6 +507,99 @@ export default {
     },
   },
   methods: {
+    // --- mobile long-press gauges -----------------------------------
+    // Tap the tri-gauge: toggles the radial (then tap a letter).
+    // Long-press: radial opens mid-hold, releasing over a letter picks
+    // it — the gesture the user described. Systems/dominions gauges
+    // long-press straight into their list modal.
+    gaugePressStart(kind, event) {
+      this.pressFiredLong = false;
+      clearTimeout(this.pressTimer);
+      this.pressTimer = setTimeout(() => {
+        this.pressFiredLong = true;
+        if (kind === 'nes') {
+          this.openRadial(event);
+        } else if (kind === 'systems') {
+          this.openSystemsModal('systems');
+        } else if (kind === 'dominions') {
+          this.openSystemsModal('dominions');
+        }
+      }, 450);
+    },
+    gaugePressEnd(kind, event) {
+      clearTimeout(this.pressTimer);
+
+      if (kind !== 'nes') return;
+
+      if (!this.pressFiredLong) {
+        // plain tap: toggle the radial
+        if (this.radialOpen) {
+          this.radialOpen = false;
+        } else {
+          this.openRadial(event);
+        }
+        return;
+      }
+
+      // long-press release: select whichever bubble the finger is on
+      const el = document.elementFromPoint(event.clientX, event.clientY);
+      const bubble = el && el.closest('.mobile-radial-item');
+      if (bubble) {
+        this.openAgentsModal(bubble.dataset.agentType);
+      }
+      // released elsewhere: keep the radial open so a follow-up tap
+      // can still choose (dismiss by tapping the gauge again)
+    },
+    gaugePressCancel() {
+      clearTimeout(this.pressTimer);
+    },
+    openRadial(event) {
+      const rect = (this.$refs.nesGauge || event.target).getBoundingClientRect
+        ? (this.$refs.nesGauge || event.target).getBoundingClientRect()
+        : { left: event.clientX, width: 0 };
+      this.radialX = Math.round(rect.left + rect.width / 2);
+      this.radialOpen = true;
+    },
+    openAgentsModal(typeKey) {
+      this.radialOpen = false;
+      if (!typeKey) return;
+      const items = this.player.characters
+        .filter((c) => c.type === typeKey)
+        .map((c) => ({
+          id: c.id,
+          icon: `agent/${c.type}`,
+          label: c.name,
+          sub: this.$tc(`data.character.${c.type}.name`, 1),
+          right: `lv ${c.level}`,
+          kind: 'character',
+        }));
+      this.activeListModal = {
+        title: this.$tc(`data.character.${typeKey}.name`, 2),
+        items,
+      };
+    },
+    openSystemsModal(which) {
+      const source = which === 'systems' ? this.ownSystems : this.ownDominions;
+      this.activeListModal = {
+        title: this.$t(`navbar.bottombar.${which}`),
+        items: source.map((s) => ({
+          id: s.id,
+          icon: null,
+          label: s.name,
+          sub: `${Math.trunc(s.position.x)}:${Math.trunc(s.position.y)}`,
+          kind: 'system',
+        })),
+      };
+    },
+    onModalSelect(item) {
+      this.activeListModal = null;
+      if (item.kind === 'character') {
+        this.$store.dispatch('game/selectCharacter', { vm: this, id: item.id });
+      } else if (item.kind === 'system') {
+        this.$store.dispatch('game/openSystem', { vm: this, id: item.id });
+      }
+    },
+
     // Bar space on a phone is too tight for full figures — 300,018
     // reads as 300k; precision lives in the tooltip.
     compactNumber(value) {
@@ -588,6 +755,8 @@ export default {
   },
   components: {
     MobileGauge,
+    MobileTriGauge,
+    MobileListModal,
     NavbarDynamicValue,
     NavbarMaxedValue,
     NavbarPanelBlock,

--- a/front/src/game/components/navbar/MobileGauge.vue
+++ b/front/src/game/components/navbar/MobileGauge.vue
@@ -1,0 +1,90 @@
+<template>
+  <div
+    class="mobile-gauge"
+    :class="[
+      theme ? `is-color-${theme}` : '',
+      { 'is-full': max > 0 && value >= max },
+    ]"
+    v-tooltip="tooltip">
+    <svg viewBox="0 0 40 40">
+      <circle
+        class="mg-track"
+        cx="20" cy="20" r="16" />
+      <circle
+        v-if="ratio > 0"
+        class="mg-fill"
+        cx="20" cy="20" r="16"
+        pathLength="100"
+        :stroke-dasharray="`${ratio} 100`"
+        transform="rotate(-90 20 20)" />
+
+      <!-- Identity glyphs: a system is "yours at the center" (filled
+           core, neutral satellites); a dominion is "yours on the edge"
+           (hollow core, faction satellites). -->
+      <g v-if="glyph === 'system'">
+        <circle class="mg-glyph-core" cx="8" cy="7" r="2.2" />
+        <circle
+          v-for="(p, i) in ringDots(6, 8, 7, 5)"
+          :key="`s-${i}`"
+          class="mg-glyph-dot"
+          :cx="p.x" :cy="p.y" r=".9" />
+      </g>
+      <g v-else-if="glyph === 'dominion'">
+        <circle class="mg-glyph-hollow" cx="8" cy="7" r="2" />
+        <circle
+          v-for="(p, i) in ringDots(3, 8, 7, 5)"
+          :key="`d-${i}`"
+          class="mg-glyph-core"
+          :cx="p.x" :cy="p.y" r="1.3" />
+      </g>
+
+      <template v-if="letter">
+        <text
+          class="mg-letter"
+          x="20" y="25.5"
+          text-anchor="middle">{{ letter }}</text>
+      </template>
+      <template v-else>
+        <text
+          class="mg-value"
+          x="19" y="24.5"
+          text-anchor="middle">{{ value }}</text>
+        <text
+          class="mg-max"
+          x="30.5" y="36"
+          text-anchor="middle">/{{ max }}</text>
+      </template>
+    </svg>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'mobile-gauge',
+  props: {
+    value: { type: Number, required: true },
+    max: { type: Number, required: true },
+    letter: { type: String, default: null },
+    glyph: { type: String, default: null },
+    theme: { type: String, default: null },
+    tooltip: { type: String, default: null },
+  },
+  computed: {
+    ratio() {
+      if (!this.max || this.max <= 0) return 0;
+      return Math.max(0, Math.min(100, Math.round((this.value / this.max) * 100)));
+    },
+  },
+  methods: {
+    ringDots(n, cx, cy, r) {
+      return Array.from({ length: n }, (_, i) => {
+        const angle = -Math.PI / 2 + (i * 2 * Math.PI) / n;
+        return {
+          x: +(cx + r * Math.cos(angle)).toFixed(2),
+          y: +(cy + r * Math.sin(angle)).toFixed(2),
+        };
+      });
+    },
+  },
+};
+</script>

--- a/front/src/game/components/navbar/MobileListModal.vue
+++ b/front/src/game/components/navbar/MobileListModal.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="mobile-list-modal">
+    <div
+      class="mlm-backdrop"
+      @click="$emit('close')"></div>
+    <div class="mlm-sheet">
+      <div class="mlm-header">
+        <span>{{ title }}</span>
+        <button
+          class="mlm-close"
+          @click="$emit('close')">
+          <svgicon name="close" />
+        </button>
+      </div>
+      <div class="mlm-list">
+        <div
+          v-for="item in items"
+          :key="item.id"
+          class="mlm-row"
+          @click="$emit('select', item)">
+          <svgicon
+            v-if="item.icon"
+            class="mlm-icon"
+            :name="item.icon" />
+          <div class="mlm-text">
+            <div class="mlm-label">{{ item.label }}</div>
+            <div
+              v-if="item.sub"
+              class="mlm-sub">{{ item.sub }}</div>
+          </div>
+          <div
+            v-if="item.right"
+            class="mlm-right">{{ item.right }}</div>
+        </div>
+        <div
+          v-if="items.length === 0"
+          class="mlm-empty">—</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'mobile-list-modal',
+  props: {
+    title: { type: String, required: true },
+    items: { type: Array, required: true },
+  },
+};
+</script>

--- a/front/src/game/components/navbar/MobileTriGauge.vue
+++ b/front/src/game/components/navbar/MobileTriGauge.vue
@@ -1,0 +1,66 @@
+<template>
+  <div
+    class="mobile-gauge mobile-tri-gauge"
+    v-tooltip="tooltip">
+    <svg viewBox="0 0 40 40">
+      <g
+        v-for="(seg, i) in arcs"
+        :key="seg.letter">
+        <circle
+          class="mg-track"
+          cx="20" cy="20" r="16"
+          pathLength="100"
+          :stroke-dasharray="`${segLength} ${100 - segLength}`"
+          :stroke-dashoffset="-(i * segWindow + segGap / 2)"
+          transform="rotate(-90 20 20)" />
+        <circle
+          v-if="seg.fillLength > 0"
+          class="mg-fill"
+          :class="{ 'is-seg-full': seg.value >= seg.max && seg.max > 0 }"
+          cx="20" cy="20" r="16"
+          pathLength="100"
+          :stroke-dasharray="`${seg.fillLength} ${100 - seg.fillLength}`"
+          :stroke-dashoffset="-(i * segWindow + segGap / 2)"
+          transform="rotate(-90 20 20)" />
+        <text
+          class="mg-seg-letter"
+          :x="seg.x" :y="seg.y"
+          text-anchor="middle">{{ seg.letter }}</text>
+      </g>
+    </svg>
+  </div>
+</template>
+
+<script>
+// One ring, three independent thirds — each third fills with its own
+// usage ratio. Segment 0 starts at 12 o'clock and they run clockwise.
+const SEG_WINDOW = 100 / 3;
+const SEG_GAP = 4;
+
+export default {
+  name: 'mobile-tri-gauge',
+  props: {
+    // [{ letter, value, max }] — exactly three entries.
+    segments: { type: Array, required: true },
+    tooltip: { type: String, default: null },
+  },
+  computed: {
+    segWindow() { return SEG_WINDOW; },
+    segGap() { return SEG_GAP; },
+    segLength() { return SEG_WINDOW - SEG_GAP; },
+    arcs() {
+      return this.segments.map((seg, i) => {
+        const ratio = seg.max > 0 ? Math.max(0, Math.min(1, seg.value / seg.max)) : 0;
+        const midDeg = i * 120 + 60 - 90;
+        const rad = (midDeg * Math.PI) / 180;
+        return {
+          ...seg,
+          fillLength: +(ratio * this.segLength).toFixed(2),
+          x: +(20 + 10 * Math.cos(rad)).toFixed(2),
+          y: +(20 + 10 * Math.sin(rad) + 2.2).toFixed(2),
+        };
+      });
+    },
+  },
+};
+</script>

--- a/front/src/game/components/navbar/Topbar.vue
+++ b/front/src/game/components/navbar/Topbar.vue
@@ -63,6 +63,23 @@
       </div>
 
       <div class="navbar-right">
+        <!-- Phone-only: Lex and Patents promoted out of the bottom
+             bar's unlabeled mystery icons into labeled top-bar
+             buttons, peers of Market / Agent market. Desktop keeps
+             the bottom-bar buttons. -->
+        <div
+          v-if="isMobileView"
+          class="navbar-button-title mobile-minipanel-button"
+          @click="$root.$emit('openBottomMiniPanel', 'doctrine')">
+          {{ $t('navbar.bottombar.lexes') }}
+        </div>
+        <div
+          v-if="isMobileView"
+          class="navbar-button-title mobile-minipanel-button"
+          @click="$root.$emit('openBottomMiniPanel', 'patent')">
+          {{ $t('navbar.bottombar.patents') }}
+        </div>
+
         <div
           v-if="!isTutorial"
           class="navbar-button-title"
@@ -148,6 +165,7 @@
 <script>
 import { TimelineLite, Expo } from 'gsap';
 
+import viewport from '@/utils/viewport';
 import Calendar from '@/game/components/navbar/Calendar.vue';
 
 import CharacterMarketMiniPanel from '@/game/components/mini-panel/CharacterMarketMiniPanel.vue';
@@ -171,6 +189,7 @@ export default {
     };
   },
   computed: {
+    isMobileView() { return viewport.isMobile; },
     time() { return this.$store.state.game.time; },
     // Deploy-related pause: the portal socket flips this before the game
     // socket drops, so the "Paused" headband can name the real cause.

--- a/front/src/game/components/navbar/Topbar.vue
+++ b/front/src/game/components/navbar/Topbar.vue
@@ -63,23 +63,6 @@
       </div>
 
       <div class="navbar-right">
-        <!-- Phone-only: Lex and Patents promoted out of the bottom
-             bar's unlabeled mystery icons into labeled top-bar
-             buttons, peers of Market / Agent market. Desktop keeps
-             the bottom-bar buttons. -->
-        <div
-          v-if="isMobileView"
-          class="navbar-button-title mobile-minipanel-button"
-          @click="$root.$emit('openBottomMiniPanel', 'doctrine')">
-          {{ $t('navbar.bottombar.lexes') }}
-        </div>
-        <div
-          v-if="isMobileView"
-          class="navbar-button-title mobile-minipanel-button"
-          @click="$root.$emit('openBottomMiniPanel', 'patent')">
-          {{ $t('navbar.bottombar.patents') }}
-        </div>
-
         <div
           v-if="!isTutorial"
           class="navbar-button-title"

--- a/front/src/game/components/overlay/opened-character.vue
+++ b/front/src/game/components/overlay/opened-character.vue
@@ -4,6 +4,14 @@
     v-if="character && character.owner"
     :class="`f-${theme}`"
     class="opened-character-container">
+    <!-- Mobile-only (styled in game/mobile.scss): the stacked layout
+         leaves little backdrop to tap, so give an explicit close. -->
+    <button
+      @click="close"
+      class="system-close-button">
+      <svgicon name="close" />
+    </button>
+
     <div class="opened-character">
       <div class="opened-character-owner">
         <span v-html="$tmd('galaxy.opened_character.commanded_by', {characterName: character.owner.name})"/>

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -509,6 +509,14 @@ export default class Map {
 
       this.mouseLastPosition = {};
       this.mouseDownAt = 0;
+
+      // Touch has no hover-off: whatever the tap raycast lit up (the
+      // shared hover ring — reads as a stuck crosshair on phones —
+      // plus path previews and labels) would linger forever. The click
+      // logic above has consumed it; clear it.
+      if (event.pointerType === 'touch' || event.pointerType === 'pen') {
+        this.hideHover();
+      }
     }
   }
 

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -11,6 +11,7 @@ import { MapControls } from 'three/examples/jsm/controls/OrbitControls';
 import Stats from 'stats-js';
 import TWEEN from '@tweenjs/tween.js';
 import store from '@/store';
+import viewport from '@/utils/viewport';
 import config from '@/config';
 import eventBus from '@/plugins/event-bus';
 import { loadFonts, materialsFactory } from './three-utils';
@@ -244,8 +245,9 @@ export default class Map {
   }
 
   destroy() {
-    if (this.isDev) {
-      const stats = document.getElementById('threejs-stats');
+    // The stats panel is opt-in now (see init) — it may not exist.
+    const stats = document.getElementById('threejs-stats');
+    if (stats && stats.parentNode) {
       stats.parentNode.removeChild(stats);
     }
 
@@ -473,10 +475,24 @@ export default class Map {
         if (clickedObject.type === 'system') {
           const system = clickedObject.data;
 
+          // Phone with an agent selected: a long-press on a system is
+          // an ORDER gesture — fan out the agent's possible actions
+          // (move/conquer/infiltrate/...) instead of the icon picker.
+          // With nothing selected the long-press keeps its icon-picker
+          // meaning on mobile too.
+          const wantsActionRadial = viewport.isMobile
+            && isLongPress
+            && !!store.state.game.selectedCharacter;
+
           // Picker wins over every other gesture on a system — the
           // user explicitly held / alt-clicked, so don't also fire
           // openSystem or jump.
-          if (wantsIconPicker) {
+          if (wantsActionRadial) {
+            eventBus.$emit('map:action-radial:show', {
+              systemId: system.id,
+              screen: { x: event.clientX, y: event.clientY },
+            });
+          } else if (wantsIconPicker) {
             eventBus.$emit('system-icon-picker:show', {
               systemId: system.id,
               screen: { x: event.clientX, y: event.clientY },

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -22,6 +22,11 @@ import { Radar, Sector, System, SystemIcons, Blackhole, Skydome, Character, Dete
 const ICON_PICKER_LONG_PRESS_MS = 500;
 const ICON_PICKER_JITTER_PX = 8;
 
+// Pan-vs-click slop: max down→up drift for a release to still count as
+// a click. A finger tap (and even a fast mouse click) drifts a few
+// pixels between down and up; exact-equality rejected every touch tap.
+const TAP_SLOP_PX = 8;
+
 let currentlyHoveredObject;
 
 export default class Map {
@@ -58,6 +63,10 @@ export default class Map {
     this.windowWidth = 100;
 
     this.onWindowResize();
+    // MapControls (three r126) handles touch pan/pinch itself but never
+    // sets touch-action, so the browser's own scroll/zoom gestures
+    // compete with the map's on mobile.
+    renderer.domElement.style.touchAction = 'none';
     this.controls = new MapControls(this.camera, renderer.domElement);
     this.controls.enableKeys = true;
     this.controls.keyPanSpeed = 30;
@@ -122,6 +131,13 @@ export default class Map {
 
     this.mouse = new Vector2(1, 1);
     this.mouseLastPosition = {};
+    // Touch bookkeeping: a pinch (two pointers down at any point in the
+    // gesture) must never resolve as a tap on release, and the
+    // contextmenu Android fires mid-long-press must not re-run the
+    // click path on top of the pointerup that follows.
+    this.activePointers = new Set();
+    this.sawMultiTouch = false;
+    this.lastPointerType = 'mouse';
     this.onMouseMoveBound = this.onMouseMove.bind(this);
     this.onMouseDownBound = this.onMouseDown.bind(this);
     this.onMouseUpBound = this.onMouseUp.bind(this);
@@ -312,10 +328,36 @@ export default class Map {
 
   // EVENT LISTENERS
   onMouseDown(event) {
+    if (event.pointerId !== undefined) {
+      this.activePointers.add(event.pointerId);
+      if (this.activePointers.size > 1) this.sawMultiTouch = true;
+    }
+    if (event.pointerType) this.lastPointerType = event.pointerType;
     this.onClick(event, 'down');
   }
 
   onMouseUp(event) {
+    // contextmenu re-enters here after pointerup. On touch it fires
+    // mid-long-press (Android); the pointerup path already owns
+    // long-press semantics, so swallow the duplicate.
+    if (event.type === 'contextmenu' && this.lastPointerType === 'touch') {
+      event.preventDefault();
+      return;
+    }
+
+    if (event.pointerId !== undefined) {
+      this.activePointers.delete(event.pointerId);
+    }
+
+    // A pinch is not a tap: once two pointers were down, every release
+    // in that gesture belongs to the zoom, not to a click.
+    if (this.sawMultiTouch) {
+      if (this.activePointers.size === 0) this.sawMultiTouch = false;
+      this.mouseLastPosition = {};
+      this.mouseDownAt = 0;
+      return;
+    }
+
     this.onClick(event, 'up');
   }
 
@@ -347,8 +389,18 @@ export default class Map {
       // that happens to release over a system doesn't get treated as
       // a waypoint commit.
       const rulerActive = store.state.game.ruler.active;
-      const isTrueClick = this.mouseLastPosition.x === event.clientX
-        && this.mouseLastPosition.y === event.clientY;
+      const isTrueClick = this.mouseLastPosition.x !== undefined
+        && Math.abs(event.clientX - this.mouseLastPosition.x) <= TAP_SLOP_PX
+        && Math.abs(event.clientY - this.mouseLastPosition.y) <= TAP_SLOP_PX;
+
+      // Touch has no hover phase: at tap time currentlyHoveredObject is
+      // unset (or stale from a previous gesture) because the mousemove
+      // raycast never ran. Raycast the release point now so the tap
+      // sees what's actually under the finger.
+      if (isTrueClick && (event.pointerType === 'touch' || event.pointerType === 'pen')) {
+        this.updateHoverAt(event.clientX, event.clientY);
+      }
+
       if (rulerActive && button === 'left' && isTrueClick && currentlyHoveredObject) {
         let clickedObject = currentlyHoveredObject.gameObject;
         if (clickedObject && clickedObject.type === 'system_icon') {
@@ -363,7 +415,14 @@ export default class Map {
         }
       }
 
-      if (currentlyHoveredObject) {
+      // Gate on isTrueClick so a pan that started (or, via the touch
+      // re-raycast above, ended) over a system doesn't open it, and so
+      // the contextmenu that trails a handled right-click pointerup
+      // (mouseLastPosition already cleared) can't fire the action a
+      // second time. A contextmenu that arrives *without* a preceding
+      // pointerup (macOS ctrl+click suppression) still carries the
+      // press coordinates and passes.
+      if (isTrueClick && currentlyHoveredObject) {
         let clickedObject = currentlyHoveredObject.gameObject;
 
         // Icon clicks delegate to the system underneath them. The
@@ -441,10 +500,8 @@ export default class Map {
             store.dispatch('game/selectCharacter', { vm: this.vm, id: characterId });
           }
         }
-      } else if (button === 'left') {
-        if (this.mouseLastPosition.x === event.clientX && this.mouseLastPosition.y === event.clientY) {
-          store.dispatch('game/unselectCharacter');
-        }
+      } else if (button === 'left' && isTrueClick) {
+        store.dispatch('game/unselectCharacter');
       }
 
       this.mouseLastPosition = {};
@@ -470,6 +527,10 @@ export default class Map {
     this.camera.aspect = this.windowWidth / this.windowHeight;
     this.camera.updateProjectionMatrix();
 
+    // Phones are DPR 2-3: without an explicit pixel ratio the canvas
+    // renders at CSS resolution and looks soft. Capped at 2 to bound
+    // fill-rate cost on 4K desktops.
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     this.renderer.setSize(this.windowWidth, this.windowHeight);
   }
 
@@ -527,107 +588,114 @@ export default class Map {
 
     // hover system
     if (!this.inSystem) {
-      this.mouse.x = (event.clientX / this.windowWidth) * 2 - 1;
-      this.mouse.y = -(event.clientY / this.windowHeight) * 2 + 1;
-      this.hovercaster.setFromCamera(this.mouse, this.camera);
+      this.updateHoverAt(event.clientX, event.clientY);
+    }
+  }
 
-      // we can "generically" use hover
-      //
-      // SystemIcons goes FIRST so an icon-hover takes priority over
-      // the system underneath it — otherwise the system label can
-      // "swallow" the icon for the cursor and the "by X" attribution
-      // never surfaces. Falling back to System (and on to Character /
-      // Sector) when the cursor isn't over an icon works because the
-      // standard intersection path clears currentlyHoveredObject on
-      // miss, so the next type's check starts clean.
-      const types = [
-        { block: 'SystemIcons', group: 'icons-near' },
-        { block: 'System', group: 'systems-near' },
-        { block: 'Character', group: 'characters-on-map' },
-        { block: 'Character', group: 'character-names-on-map' },
-        { block: 'Sector', group: 'sector-far' },
-      ];
+  // Raycast pick at a client-space point and refresh hover state.
+  // Shared by the mousemove hover path and the touch-tap path in
+  // onClick, which has no hover phase to rely on.
+  updateHoverAt(clientX, clientY) {
+    this.mouse.x = (clientX / this.windowWidth) * 2 - 1;
+    this.mouse.y = -(clientY / this.windowHeight) * 2 + 1;
+    this.hovercaster.setFromCamera(this.mouse, this.camera);
 
-      for (let i = 0; i < types.length; i += 1) {
-        const type = types[i];
-        const block = this.getBlockByName(type.block);
-        if (!block) {
-          continue;
-        }
+    // we can "generically" use hover
+    //
+    // SystemIcons goes FIRST so an icon-hover takes priority over
+    // the system underneath it — otherwise the system label can
+    // "swallow" the icon for the cursor and the "by X" attribution
+    // never surfaces. Falling back to System (and on to Character /
+    // Sector) when the cursor isn't over an icon works because the
+    // standard intersection path clears currentlyHoveredObject on
+    // miss, so the next type's check starts clean.
+    const types = [
+      { block: 'SystemIcons', group: 'icons-near' },
+      { block: 'System', group: 'systems-near' },
+      { block: 'Character', group: 'characters-on-map' },
+      { block: 'Character', group: 'character-names-on-map' },
+      { block: 'Sector', group: 'sector-far' },
+    ];
 
-        if (type.block === 'Sector' && block.shown !== type.group) {
-          break;
-        }
+    for (let i = 0; i < types.length; i += 1) {
+      const type = types[i];
+      const block = this.getBlockByName(type.block);
+      if (!block) {
+        continue;
+      }
 
-        if (type.block === 'System' && currentlyHoveredObject) {
-          // something is already hovered
-          const intersection = this.hovercaster
-            .intersectObjects([currentlyHoveredObject, ...currentlyHoveredObject.children], true);
+      if (type.block === 'Sector' && block.shown !== type.group) {
+        break;
+      }
 
-          // see if it's still hovered or if one of its children is hovered
-          if (intersection.length) {
-            if (intersection[0].object.parent.id === currentlyHoveredObject.id) {
-              break;
-            }
+      if (type.block === 'System' && currentlyHoveredObject) {
+        // something is already hovered
+        const intersection = this.hovercaster
+          .intersectObjects([currentlyHoveredObject, ...currentlyHoveredObject.children], true);
 
-            if (intersection[0]?.object?.parent?.gameObject) {
-              currentlyHoveredObject = intersection[0].object.parent;
-              break;
-            }
+        // see if it's still hovered or if one of its children is hovered
+        if (intersection.length) {
+          if (intersection[0].object.parent.id === currentlyHoveredObject.id) {
+            break;
+          }
+
+          if (intersection[0]?.object?.parent?.gameObject) {
+            currentlyHoveredObject = intersection[0].object.parent;
+            break;
           }
         }
+      }
 
-        if (block) {
-          const groups = block.getGroupByName(type.group).children;
-          const intersection = this.hovercaster
-            .intersectObjects(groups, true)
-            .filter(({ object }) => object.userData?.hoverable);
+      if (block) {
+        const groups = block.getGroupByName(type.group).children;
+        const intersection = this.hovercaster
+          .intersectObjects(groups, true)
+          .filter(({ object }) => object.userData?.hoverable);
 
-          if (intersection.length > 0) {
-            const intersecting = 0;
-            const { object: intersectedObject } = intersection[intersecting];
-            // We intersected a single object, we want the hover to effect the whole system,
-            // not just the hovered ring or child-object.
-            // Search in intersected object's parents the closer 'hoverable object'.
-            let hoveredGroup;
+        if (intersection.length > 0) {
+          const intersecting = 0;
+          const { object: intersectedObject } = intersection[intersecting];
+          // We intersected a single object, we want the hover to effect the whole system,
+          // not just the hovered ring or child-object.
+          // Search in intersected object's parents the closer 'hoverable object'.
+          let hoveredGroup;
 
-            // System base sprites are batched into InstancedMesh objects
-            // by System#buildBaseSpritesInstancedMeshes — those carry a
-            // userData.systemGroupByInstanceId map back to the per-system
-            // sn Group that holds gameObject and showOnHover children.
-            // Resolve InstancedMesh hits through that map instead of
-            // walking parents (the InstancedMesh has no gameObject and
-            // its parent is sng, also without one).
-            if (intersectedObject.isInstancedMesh
-                && intersection[intersecting].instanceId !== undefined
-                && intersectedObject.userData.systemGroupByInstanceId) {
-              hoveredGroup = intersectedObject.userData
-                .systemGroupByInstanceId[intersection[intersecting].instanceId];
-            } else {
-              hoveredGroup = intersectedObject;
-              while (hoveredGroup && !('gameObject' in hoveredGroup)) {
-                hoveredGroup = hoveredGroup.parent;
-              }
-            }
-
-            const stillHovering = currentlyHoveredObject && (hoveredGroup.id === currentlyHoveredObject.id);
-
-            if (!hoveredGroup) {
-              this.hideHover();
-            } else if (!stillHovering) {
-              if (hoveredGroup.gameObject.type === 'sector') {
-                store.commit('game/addMapOverlay', hoveredGroup.gameObject);
-              }
-
-              this.hideHover();
-              this.showHover(hoveredGroup, type.block);
-              break;
-            } else {
-              break;
-            }
+          // System base sprites are batched into InstancedMesh objects
+          // by System#buildBaseSpritesInstancedMeshes — those carry a
+          // userData.systemGroupByInstanceId map back to the per-system
+          // sn Group that holds gameObject and showOnHover children.
+          // Resolve InstancedMesh hits through that map instead of
+          // walking parents (the InstancedMesh has no gameObject and
+          // its parent is sng, also without one).
+          if (intersectedObject.isInstancedMesh
+              && intersection[intersecting].instanceId !== undefined
+              && intersectedObject.userData.systemGroupByInstanceId) {
+            hoveredGroup = intersectedObject.userData
+              .systemGroupByInstanceId[intersection[intersecting].instanceId];
           } else {
-            this.hideHover();
+            hoveredGroup = intersectedObject;
+            while (hoveredGroup && !('gameObject' in hoveredGroup)) {
+              hoveredGroup = hoveredGroup.parent;
+            }
           }
+
+          const stillHovering = currentlyHoveredObject && (hoveredGroup.id === currentlyHoveredObject.id);
+
+          if (!hoveredGroup) {
+            this.hideHover();
+          } else if (!stillHovering) {
+            if (hoveredGroup.gameObject.type === 'sector') {
+              store.commit('game/addMapOverlay', hoveredGroup.gameObject);
+            }
+
+            this.hideHover();
+            this.showHover(hoveredGroup, type.block);
+            break;
+          } else {
+            break;
+          }
+        } else {
+          this.hideHover();
         }
       }
     }

--- a/front/src/game/map/map.js
+++ b/front/src/game/map/map.js
@@ -194,9 +194,12 @@ export default class Map {
   }
 
   async init() {
-    // setup stats for dev only
+    // FPS meter (stats-js): opt-in even in dev — run
+    // `localStorage.setItem('rc:fps', '1')` in the console and reload
+    // to get it back. Always-on it just sat over the top-left of the
+    // UI (especially bad on phones).
     let stats = { begin() { }, end() { } };
-    if (this.isDev) {
+    if (this.isDev && window.localStorage && localStorage.getItem('rc:fps') === '1') {
       stats = new Stats();
       stats.setMode(0);
       stats.domElement.setAttribute('id', 'threejs-stats');

--- a/front/src/locales/de/game.json
+++ b/front/src/locales/de/game.json
@@ -168,6 +168,8 @@
         "colonize": "Kolonisieren",
         "conquer": "Erobern",
         "deploy": "Einsetzen",
+        "select": "Auswählen",
+        "selected": "Ausgewählt",
         "fail_hint_assassination": "Ermordung unmöglich",
         "fail_hint_assassination_coeff": "Attentatssstärke zu niedrig.",
         "fail_hint_colonization": "Kolonisation unmöglich :",

--- a/front/src/locales/en/game.json
+++ b/front/src/locales/en/game.json
@@ -248,6 +248,8 @@
         "conquer": "Conquer",
         "conversion": "Seduce",
         "deploy": "Deploy",
+        "select": "Select",
+        "selected": "Selected",
         "encourage_hate": "Destabilize",
         "fail_already_one_colonization": "Colonization already planned.",
         "fail_hint_assassination": "Removal impossible",

--- a/front/src/locales/en/portal.json
+++ b/front/src/locales/en/portal.json
@@ -239,6 +239,10 @@
         "description": "Reworked system-view agent display: agents sort into a fan by threat, owners with several agents collapse into squadrons that unfurl on hover, and names move to hover cards with threat stats.",
         "label": "Agent stack and fan out"
       },
+      "mobile_ui": {
+        "description": "Phone-friendly layout on small screens: stacked system view, ring gauges, touch orders via long-press, vertical patent and lex trees. Only affects devices narrower than 768px.",
+        "label": "Mobile interface"
+      },
       "header": "Beta **Features**",
       "intro": "Try new features before they roll out to everyone. Betas work but are still being polished — expect rough edges, and please report anything odd on our Discord. You can switch back at any time.",
       "saved": "Preference saved"

--- a/front/src/locales/fr/game.json
+++ b/front/src/locales/fr/game.json
@@ -248,6 +248,8 @@
         "conquer": "Conquérir",
         "conversion": "Séduire",
         "deploy": "Déployer",
+        "select": "Sélectionner",
+        "selected": "Sélectionné",
         "encourage_hate": "Déstabiliser",
         "fail_already_one_colonization": "Une colonisation est déjà prévue.",
         "fail_hint_assassination": "Suppression impossible",

--- a/front/src/locales/fr/portal.json
+++ b/front/src/locales/fr/portal.json
@@ -137,6 +137,10 @@
         "description": "Nouvel affichage des agents dans la vue système : agents triés en éventail selon la menace, escadrons repliés par joueur qui se déploient au survol, noms et statistiques dans des infobulles.",
         "label": "Agents empilés et en éventail"
       },
+      "mobile_ui": {
+        "description": "Interface adaptée aux téléphones : vue système empilée, jauges circulaires, ordres tactiles par appui long, arbres de brevets et de lois verticaux. N'affecte que les écrans de moins de 768px.",
+        "label": "Interface mobile"
+      },
       "header": "Fonctionnalités **bêta**",
       "intro": "Essayez les nouvelles fonctionnalités avant leur sortie générale. Les bêtas fonctionnent mais sont encore en cours de finition — signalez toute anomalie sur notre Discord. Vous pouvez revenir en arrière à tout moment.",
       "saved": "Préférence enregistrée"

--- a/front/src/portal/pages/account/BetaFeatures.vue
+++ b/front/src/portal/pages/account/BetaFeatures.vue
@@ -43,7 +43,7 @@ export default {
       // Mirrors the backend whitelist (RC.Accounts.AccountFeature.known/0);
       // each key needs a label + description under
       // page.account_beta_features.<key> in the locales.
-      featureList: ['agent_fan_display'],
+      featureList: ['agent_fan_display', 'mobile_ui'],
     };
   },
   computed: {

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -217,31 +217,16 @@
       }
     }
 
-    // Governor avatar and production ticker: desktop pins them to
-    // fixed offsets of the big square; here they flow after the yields.
+    // Governor avatar docks at the right end of the system-name
+    // header line; the production ticker becomes a full-width block at
+    // the card's bottom edge — directly above the celestial list.
     .governor-box {
-      position: relative;
+      position: absolute;
       left: auto;
-      top: auto;
-      display: inline-block;
-      vertical-align: top;
-      margin: 10px 8px 0 0;
+      top: 2px;
+      right: 4px;
     }
 
-    .production-box {
-      position: relative;
-      right: auto;
-      top: auto;
-      display: inline-block;
-      vertical-align: top;
-      width: auto;
-      min-width: 150px;
-      margin: 10px 0 24px; // bottom room for the absolute counter chip
-
-      .round-icon {
-        right: -10px;
-      }
-    }
 
     .system-population {
       position: static;
@@ -249,6 +234,37 @@
       width: auto;
       height: auto;
       margin: 8px 0 0;
+    }
+  }
+
+  // Production strip: standalone between the summary card and the
+  // celestial list (desktop pins this same component inside the
+  // square at a fixed offset).
+  .mobile-production {
+    position: relative;
+    right: auto;
+    top: auto;
+    display: flex;
+    align-items: center;
+    width: auto;
+    min-width: 0;
+    min-height: 40px;
+    margin: 8px 0 0;
+    padding: 4px 96px 4px 8px; // right room for counter + queue toggle
+
+    .round-icon {
+      position: absolute;
+      top: 50%;
+      right: 8px;
+      transform: translateY(-50%);
+    }
+
+    .production-counter {
+      position: absolute;
+      top: 50%;
+      right: 62px;
+      bottom: auto;
+      transform: translateY(-50%);
     }
   }
 

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -1240,6 +1240,74 @@
     }
   }
 
+  /* --- responsiveness sweep: remaining fixed-width game surfaces --- */
+
+  // Center-screen text notifications (500px strip).
+  .text-notification-container {
+    width: auto;
+    left: 8px;
+    right: 8px;
+    transform: none;
+  }
+
+  // Loading splashscreen: logo-beside-text (320+400) stacks.
+  .splashscreen .container {
+    width: calc(100vw - 24px);
+    flex-direction: column;
+    align-items: center;
+
+    .logo {
+      width: 220px;
+      padding-right: 0;
+      margin-bottom: 20px;
+    }
+
+    .content {
+      width: 100%;
+      max-width: 400px;
+    }
+  }
+
+  // Flying detail card inside mini-panels: 610px = 300px card +
+  // 364px side text at a fixed offset. Stack them.
+  .mini-panels-container .flying {
+    width: calc(100vw - 16px);
+    left: 8px;
+
+    .fl-content {
+      position: static;
+      margin: 0 auto;
+    }
+
+    .fl-side-content {
+      position: static;
+      left: auto;
+      width: auto;
+      margin-top: 8px;
+    }
+  }
+
+  // Locked-feature / long-text blurbs in mini-panels (1000px + 100px
+  // padding).
+  .mpc-long-text {
+    width: 100%;
+    padding: 24px 16px;
+    font-size: 1.6rem;
+  }
+
+  // Faction market block: 400px with a 95px margin ring.
+  .faction-market {
+    width: auto;
+    margin: 12px;
+  }
+
+  // Event panel's notification dropdown runs 364px inside the 356px
+  // mobile panel.
+  .box-notification-item {
+    width: 340px;
+    max-width: calc(100vw - 72px);
+  }
+
   // Doctrine lex slots: compact full-width row at the panel's bottom
   // instead of the fixed 305px right rail overlapping the tree.
   .mini-panel-policies {

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -14,6 +14,10 @@
 }
 
 @media screen and (max-width: $mobile-breakpoint) {
+  // Gated by the mobile_ui beta toggle: utils/viewport.js stamps
+  // is-mobile-ui on <body> only when the account opted in AND the
+  // viewport is phone-sized. `&` is .game-context here.
+  body.is-mobile-ui & {
   // Double-tap on game buttons must not trigger the browser's
   // double-tap zoom (pan/pinch on the map canvas is unaffected — the
   // canvas opts out entirely via touch-action: none in map.js).
@@ -1321,5 +1325,6 @@
     padding: 6px 8px;
     border-top: 1px solid rgba(255, 255, 255, .15);
     background: rgba(0, 0, 0, .35);
+  }
   }
 }

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -75,6 +75,12 @@
 
   }
 
+  // The decorative screen-center crosshair reads as UI noise on a
+  // phone (and suggests a cursor the platform doesn't have).
+  .map-cross {
+    display: none;
+  }
+
   // Chat: a pull-out drawer under the top bar, toggled by the topbar
   // chat button (it starts closed on phones — Game.vue).
   .chat-container {
@@ -964,9 +970,288 @@
 
   .mp-container {
     max-width: 100vw;
+    max-height: calc(100vh - 100px);
     overflow-x: auto;
     overflow-y: auto;
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* --- selected-agent floating bubble --- */
+
+  .mobile-agent-bubble {
+    position: fixed;
+    z-index: 650;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px 4px 4px;
+    touch-action: none;
+
+    background: rgba(10, 12, 15, .92);
+    border: 1px solid rgba(255, 255, 255, .35);
+    border-radius: 26px;
+    box-shadow: 0 0 12px rgba(0, 0, 0, .7);
+
+    .bubble-icon {
+      position: relative;
+      width: 40px;
+      height: 40px;
+      flex: 0 0 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 2px solid $white;
+      border-radius: 50%;
+      background: $grey-dark;
+
+      svg {
+        width: 20px;
+        height: 20px;
+      }
+
+      .number {
+        position: absolute;
+        bottom: -4px;
+        right: -4px;
+        min-width: 14px;
+        height: 14px;
+        line-height: 14px;
+        text-align: center;
+        border-radius: 7px;
+        padding: 0 2px;
+
+        background: $grey-darker;
+        border: 1px solid rgba(255, 255, 255, .3);
+        font-size: 1rem;
+      }
+    }
+
+    .bubble-name {
+      font-size: 1.1rem;
+      max-width: 92px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .bubble-close {
+      width: 26px;
+      height: 26px;
+      flex: 0 0 26px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+
+      background: rgba(255, 255, 255, .12);
+      border: 1px solid rgba(255, 255, 255, .3);
+      color: $white;
+
+      .svg-icon {
+        width: 10px;
+        height: 10px;
+      }
+    }
+  }
+
+  @each $class, $color in $themes-list {
+    .mobile-agent-bubble.f-#{$class} .bubble-icon {
+      border-color: $color;
+    }
+  }
+
+  /* --- long-press map action wheel --- */
+
+  .map-action-radial {
+    position: fixed;
+    z-index: 660;
+    width: 0;
+    height: 0;
+
+    .map-action-radial-item {
+      position: absolute;
+      left: -28px;
+      top: -34px;
+      width: 56px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2px;
+
+      .radial-icon {
+        width: 48px;
+        height: 48px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+
+        background: $grey-dark;
+        border: 1px solid rgba(255, 255, 255, .4);
+        box-shadow: 0 0 10px rgba(0, 0, 0, .8);
+
+        .svg-icon {
+          width: 24px;
+          height: 24px;
+        }
+      }
+
+      .radial-label {
+        font-size: .9rem;
+        text-transform: uppercase;
+        text-align: center;
+        white-space: nowrap;
+        padding: 1px 5px;
+        background: rgba(0, 0, 0, .65);
+        border-radius: 2px;
+      }
+    }
+  }
+
+  /* --- patent / lex trees: vertical top-down flow --- */
+
+  .mp-scrollbar {
+    overflow: visible !important;
+  }
+
+  .mp-content {
+    height: auto !important;
+    flex-direction: column;
+  }
+
+  .mpc-header {
+    width: auto;
+    padding: 8px 10px;
+  }
+
+  .mpc-tree {
+    flex-direction: column;
+    align-items: stretch;
+    padding-bottom: 16px;
+  }
+
+  .tree-column {
+    flex-direction: row;
+    justify-content: center;
+    left: 0;
+    padding: 0;
+    min-width: 0;
+
+    &:last-child {
+      min-width: 0;
+      flex-grow: 0;
+    }
+  }
+
+  .tree-row {
+    width: 86px;
+    height: 118px;
+  }
+
+  .tree-node {
+    flex-direction: column;
+    align-items: center;
+    height: auto;
+    margin: 8px 0 0;
+    width: 100%;
+  }
+
+  .tree-node-icon {
+    position: relative;
+    z-index: 1;
+  }
+
+  .tree-node-label {
+    position: relative;
+    z-index: 1;
+    align-self: center;
+    padding: 4px 2px 0;
+    max-width: 84px;
+    text-align: center;
+    font-size: 1rem;
+    line-height: 1.2rem;
+
+    &.shifted {
+      align-self: center;
+      padding-top: 4px;
+    }
+  }
+
+  // Connectors, re-derived for downward flow. Child tier sits one row
+  // below; same-line child = straight vertical, ±1 line = diagonals
+  // from the parent icon's center to the neighbor slot below.
+  .tree-node-links {
+    z-index: 0;
+
+    .link.middle {
+      top: 56px;
+      bottom: -64px;
+      left: 50%;
+      right: auto;
+      width: 8px;
+      height: auto;
+      margin-left: -4px;
+    }
+
+    .link.top,
+    .link.bottom {
+      top: 31px;
+      left: 50%;
+      right: auto;
+      bottom: auto;
+      width: 0;
+      height: 0;
+
+      &:before {
+        width: 146px;
+        top: -4px;
+        left: 0;
+        transform-origin: 0 50%;
+      }
+
+      &:after {
+        display: none;
+      }
+    }
+
+    .link.top:before {
+      transform: rotate(126deg);
+    }
+
+    .link.bottom:before {
+      transform: rotate(54deg);
+    }
+  }
+
+  // Node detail cards: centered overlay, opened by tapping the node
+  // (tap again to close; tapping another node switches).
+  .tree-node-card {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 700;
+
+    &.is-open {
+      display: flex;
+    }
+  }
+
+  // Doctrine lex slots: compact full-width row at the panel's bottom
+  // instead of the fixed 305px right rail overlapping the tree.
+  .mini-panel-policies {
+    position: static;
+    order: 99;
+    width: auto;
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    padding: 6px 8px;
+    border-top: 1px solid rgba(255, 255, 255, .15);
+    background: rgba(0, 0, 0, .35);
   }
 }

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -1,40 +1,19 @@
-// Bare-basics mobile support for the in-game shell. Imported last
-// inside .game-context so these rules win the cascade at phone widths.
+// Mobile layout for the in-game shell. Imported last inside
+// .game-context so these rules win the cascade at phone widths.
 //
-// The galaxy canvas itself is size-agnostic (map.js resizes to the
-// window); what breaks on phones is the fixed-width DOM around it: the
-// system view square is sized off viewport HEIGHT, and the slide-in
-// panels are 600-1200px wide.
+// Below $mobile-breakpoint the system view is a different DOM branch
+// (View.vue renders .mobile-system-view instead of the desktop square
+// overlay), the bottom bar swaps to ring gauges (Bottombar.vue), and
+// Lex/Patents surface as labeled top-bar buttons (Topbar.vue). Styles
+// for all three live here; the desktop partials are untouched.
 
-// Desktop closes the system view with Esc, scroll-down, or the visible
-// backdrop; none of those exist on touch, so the view carries an
-// explicit close button that only mobile widths reveal.
+// Rendered only on the mobile branch, but keep it inert on desktop in
+// case the viewport crosses the breakpoint mid-session.
 .system-close-button {
   display: none;
 }
 
 @media screen and (max-width: $mobile-breakpoint) {
-  .system-close-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    width: 44px;
-    height: 44px;
-    z-index: 10;
-
-    background: rgba(0, 0, 0, .6);
-    border: solid 1px rgba(255, 255, 255, .2);
-    color: $white;
-
-    .svg-icon {
-      width: 20px;
-      height: 20px;
-    }
-  }
-
   // Double-tap on game buttons must not trigger the browser's
   // double-tap zoom (pan/pinch on the map canvas is unaffected — the
   // canvas opts out entirely via touch-action: none in map.js).
@@ -42,7 +21,7 @@
     touch-action: manipulation;
   }
 
-  /* --- top/bottom bars: static flex row, swipeable sideways --- */
+  /* --- top/bottom bars: static flex rows, swipeable, slimmer --- */
 
   .navbar {
     &.top,
@@ -65,59 +44,533 @@
     }
   }
 
-  /* --- system view: the square is sized off viewport height, which is
-     wider than any portrait phone; size it off the width instead --- */
+  .navbar.top {
+    height: 40px;
 
-  .system-content {
-    width: 100vw;
+    .navbar-button-title {
+      height: 39px;
+      line-height: 38px;
+      padding: 0 8px;
+      font-size: 1.1rem;
+    }
+
+    .navbar-main-button {
+      height: 40px;
+      width: 40px;
+
+      .navbar-main-button-icon {
+        padding: 6px;
+
+        .icon {
+          width: 28px;
+          height: 28px;
+        }
+      }
+    }
+
+    .navbar-center {
+      transform: scale(.75);
+      transform-origin: center top;
+    }
+
+    // Lex / Patents: labeled chips, visually distinct from the plain
+    // text nav items around them.
+    .mobile-minipanel-button {
+      height: 26px;
+      line-height: 24px;
+      margin: 6px 3px 0;
+      padding: 0 8px;
+      border: 1px solid rgba(255, 255, 255, .3);
+      border-radius: 3px;
+      color: $white;
+    }
+  }
+
+  /* --- system view: full-screen page between the bars --- */
+
+  .mobile-system-view {
+    position: absolute;
+    top: 40px;
+    bottom: 44px;
     left: 0;
+    right: 0;
+    z-index: $z-map-system;
+    background: $grey-darker;
+  }
 
-    // At full width the content column covers the click-to-close
-    // backdrop completely, and the desktop escape hatches (Esc,
-    // scroll-down) don't exist on touch. Let taps on the column's
-    // empty areas fall through to the backdrop.
-    pointer-events: none;
+  .mobile-system-scroll {
+    position: absolute;
+    top: 0; bottom: 0; left: 0; right: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+    padding: 8px 8px 20px;
+  }
 
-    > * {
-      pointer-events: auto;
+  .system-close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    width: 40px;
+    height: 40px;
+    z-index: 10;
+
+    background: rgba(0, 0, 0, .6);
+    border: solid 1px rgba(255, 255, 255, .2);
+    color: $white;
+
+    .svg-icon {
+      width: 18px;
+      height: 18px;
     }
   }
 
-  .system-svg {
-    top: 0;
-    width: 100vw;
-    height: 100vw;
-  }
+  /* --- summary card: properties + population folded together --- */
 
-  .system-properties {
-    max-width: 100vw;
+  .mobile-system-summary {
+    background: rgba(0, 0, 0, .35);
+    border: 1px solid rgba(255, 255, 255, .08);
+    padding: 8px;
+    margin-right: 48px; // room for the close button on short titles
 
-    .box-line.info {
-      width: calc(100vw - 20px);
+    .system-properties {
+      // relative, not static: the marker diamond, box-asides, governor
+      // and production boxes are all absolutely placed and must keep
+      // anchoring to the properties block, not the page.
+      position: relative;
+      top: auto;
+      left: auto;
+      transform: none;
+      padding: 0;
+      max-width: none;
+
+      .box-line {
+        width: auto;
+        max-width: none;
+
+        &.info {
+          width: auto;
+        }
+
+        &.yields {
+          width: auto;
+          margin: 5px 0 0;
+        }
+      }
+
+      // Desktop hangs these 55px outside the box; keep them inside.
+      .box-aside {
+        &.left { left: 2px; }
+        &.right { right: 2px; }
+      }
     }
 
-    .box-line.yields {
-      max-width: calc(100vw - 20px);
+    // Governor avatar and production ticker: desktop pins them to
+    // fixed offsets of the big square; here they flow after the yields.
+    .governor-box {
+      position: relative;
+      left: auto;
+      top: auto;
+      display: inline-block;
+      vertical-align: top;
+      margin: 10px 8px 0 0;
+    }
+
+    .production-box {
+      position: relative;
+      right: auto;
+      top: auto;
+      display: inline-block;
+      vertical-align: top;
+      width: auto;
+      min-width: 150px;
+      margin: 10px 0 24px; // bottom room for the absolute counter chip
+
+      .round-icon {
+        right: -10px;
+      }
+    }
+
+    .system-population {
+      position: static;
+      left: auto;
+      width: auto;
+      height: auto;
+      margin: 8px 0 0;
     }
   }
 
-  .system-production {
-    max-width: 100vw;
-  }
+  /* --- celestials list: full width, page scroll instead of inner --- */
 
-  // Desktop nudges it 50px off the left edge of .system-info; on a
-  // phone that just pushes it off-screen.
-  .system-population {
-    left: 0;
-  }
-
-  .system-info {
-    max-width: 100vw;
-  }
-
-  // Leave room for the tab strip that hangs at right: -26px.
   .system-content-container {
-    width: calc(100vw - 27px);
+    position: relative;
+    width: auto;
+    margin-top: 8px;
+  }
+
+  .system-content-menu {
+    position: static;
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    margin: 0 0 4px;
+
+    .system-tab-item {
+      margin-bottom: 0;
+    }
+  }
+
+  .system-content-scrollbar {
+    height: auto !important;
+    max-height: none !important;
+  }
+
+  // Celestial rows: icon + info share the first line, the build-slot
+  // tile strip wraps to its own full-width line under them (desktop
+  // puts everything on one 560px row, which can't fit a phone).
+  .system-content-group-item {
+    flex-wrap: wrap;
+
+    .body-info {
+      flex: 1;
+      width: auto;
+      min-width: 0;
+    }
+
+    .body-tiles {
+      flex-basis: 100%;
+      flex-wrap: wrap;
+      margin: 4px 0 0 40px;
+      row-gap: 2px;
+    }
+  }
+
+  /* --- agents: flat list, mine left-anchored, others mirrored --- */
+
+  .mobile-agents {
+    margin-top: 10px;
+  }
+
+  .mobile-agents-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+
+    font-size: 1.2rem;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+    color: $white-alt-1;
+  }
+
+  .mobile-agent-deploy,
+  .mobile-order-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px 9px;
+
+    background: rgba(255, 255, 255, .06);
+    border: 1px solid rgba(255, 255, 255, .3);
+    border-radius: 3px;
+    color: $white;
+    font-size: 1.2rem;
+    font-family: $default-font;
+
+    .svg-icon {
+      width: 14px;
+      height: 14px;
+    }
+
+    &.is-disabled {
+      opacity: .4;
+    }
+  }
+
+  .mobile-siege {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    margin-bottom: 6px;
+
+    background: rgba(188, 36, 51, .15);
+    border: 1px solid rgba(188, 36, 51, .5);
+    font-size: 1.2rem;
+
+    .svg-icon {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  .mobile-system-orders {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 8px;
+    margin-bottom: 6px;
+
+    background: rgba(0, 0, 0, .35);
+    border: 1px solid rgba(255, 255, 255, .08);
+
+    .mobile-orders-label {
+      font-size: 1.2rem;
+      font-weight: bold;
+      margin-right: 4px;
+    }
+  }
+
+  .mobile-agent-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    margin-bottom: 5px;
+
+    background: rgba(0, 0, 0, .35);
+    border: 1px solid rgba(255, 255, 255, .08);
+
+    // Own agents read left-to-right; everyone else is mirrored so
+    // their identity anchors right and their buttons anchor left.
+    &.is-mine {
+      border-left: 3px solid currentColor;
+    }
+
+    &.is-other {
+      flex-direction: row-reverse;
+      border-right: 3px solid currentColor;
+
+      .mobile-agent-identity {
+        flex-direction: row-reverse;
+        text-align: right;
+      }
+    }
+
+    &.is-selected {
+      background: rgba(255, 255, 255, .1);
+    }
+  }
+
+  .mobile-agent-identity {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .mobile-agent-icon {
+    position: relative;
+    width: 34px;
+    height: 34px;
+    flex: 0 0 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background: rgba(255, 255, 255, .08);
+    border: 1px solid currentColor;
+    border-radius: 50%;
+
+    .svg-icon {
+      width: 18px;
+      height: 18px;
+    }
+
+    .number {
+      position: absolute;
+      bottom: -4px;
+      right: -4px;
+      min-width: 14px;
+      height: 14px;
+      line-height: 14px;
+      text-align: center;
+      border-radius: 7px;
+      padding: 0 2px;
+
+      background: $grey-dark;
+      border: 1px solid rgba(255, 255, 255, .3);
+      font-size: 1rem;
+      color: $white;
+    }
+  }
+
+  .mobile-agent-name {
+    min-width: 0;
+
+    .name {
+      font-size: 1.3rem;
+      font-weight: bold;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .info {
+      font-size: 1.1rem;
+      color: $white-alt-1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .mobile-agent-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: flex-end;
+    flex: 0 1 auto;
+  }
+
+  /* --- bottom bar: gauges + compact totals --- */
+
+  .navbar.bottom.is-mobile {
+    height: 44px;
+  }
+
+  .mobile-bottombar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    padding: 0 4px;
+  }
+
+  .mobile-gauge {
+    width: 36px;
+    height: 36px;
+    flex: 0 0 36px;
+    color: $primary;
+
+    svg {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+  }
+
+  @each $class, $color in $themes-list {
+    .mobile-gauge.is-color-#{$class} {
+      color: $color;
+    }
+  }
+
+  .mobile-gauge {
+    .mg-track {
+      fill: none;
+      stroke: rgba(255, 255, 255, .15);
+      stroke-width: 3.5;
+    }
+
+    .mg-fill {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 3.5;
+      stroke-linecap: round;
+    }
+
+    &.is-full .mg-fill {
+      stroke: $theme-red;
+    }
+
+    .mg-value {
+      fill: $white;
+      font-size: 13px;
+      font-weight: bold;
+    }
+
+    .mg-max {
+      fill: rgba(230, 230, 230, .55);
+      font-size: 8px;
+    }
+
+    .mg-letter {
+      fill: $white;
+      font-size: 14px;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+
+    .mg-glyph-core {
+      fill: currentColor;
+    }
+
+    .mg-glyph-dot {
+      fill: rgba(230, 230, 230, .5);
+    }
+
+    .mg-glyph-hollow {
+      fill: none;
+      stroke: rgba(230, 230, 230, .6);
+      stroke-width: 1.2;
+    }
+  }
+
+  .mobile-bb-divider {
+    width: 1px;
+    height: 26px;
+    flex: 0 0 1px;
+    background: rgba(255, 255, 255, .15);
+    margin: 0 2px;
+  }
+
+  .mobile-bb-spacer {
+    flex: 1 1 auto;
+  }
+
+  .mobile-bb-btn {
+    position: relative;
+    width: 34px;
+    height: 34px;
+    flex: 0 0 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    background: rgba(255, 255, 255, .06);
+    border: 1px solid rgba(255, 255, 255, .2);
+    border-radius: 4px;
+
+    .icon {
+      width: 18px;
+      height: 18px;
+    }
+
+    .badge {
+      position: absolute;
+      top: -5px;
+      right: -5px;
+      min-width: 14px;
+      height: 14px;
+      line-height: 14px;
+      padding: 0 3px;
+      text-align: center;
+      border-radius: 7px;
+
+      background: $primary;
+      color: darken($primary, 30%);
+      font-size: 1rem;
+      font-weight: bold;
+    }
+  }
+
+  .mobile-bb-resource {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 1.1rem;
+    white-space: nowrap;
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
   }
 
   /* --- slide-in side panels (600/900/1200px on desktop) --- */
@@ -129,5 +582,9 @@
       width: calc(100vw - 80px); // 80px = .panel-navbar rail alongside
       max-width: 100vw;
     }
+  }
+
+  .system-production {
+    max-width: 100vw;
   }
 }

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -105,6 +105,7 @@
     overflow-y: auto;
     overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
     padding: 8px 8px 20px;
   }
 
@@ -749,6 +750,7 @@
       position: absolute;
       top: 0; bottom: 0; left: 0; right: 0;
       background: rgba(0, 0, 0, .6);
+      touch-action: none;
     }
 
     .mlm-sheet {
@@ -797,6 +799,9 @@
     .mlm-list {
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+      // A drag past the list's end must die here, not grab the page.
+      overscroll-behavior: contain;
+      touch-action: pan-y;
       padding: 6px 8px 12px;
     }
 
@@ -868,7 +873,100 @@
     }
   }
 
+  // Build menu / production queue: centered sheet instead of the
+  // desktop's fixed-offset 300px column.
   .system-production {
+    position: absolute;
+    top: 48px;
+    bottom: 48px;
+    left: 8px;
+    right: 8px;
+    width: auto;
+    max-width: none;
+    transform: none;
+    display: flex;
+    flex-direction: column;
+    background: $grey-default;
+    box-shadow:
+      inset 0 0 0 1px $grey-lighter,
+      0 0 20px rgba(0, 0, 0, .8);
+
+    .system-production-content {
+      flex: 1;
+      min-height: 0;
+      overscroll-behavior: contain;
+    }
+  }
+
+  /* --- agent summary overlay: stack the three columns --- */
+
+  .opened-character-container {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+    background: rgba(0, 0, 0, .55);
+  }
+
+  .opened-character {
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin: 50px 0 60px;
+  }
+
+  .opened-character-owner {
+    margin: 0;
+    width: calc(100vw - 24px);
+  }
+
+  .opened-character-card {
+    align-self: center;
+  }
+
+  .opened-character-aside {
+    margin: 0;
+    width: calc(100vw - 24px);
+    max-width: 380px;
+  }
+
+  /* --- big side panels (Overview, Possessions, Survey, Government)
+     and top/bottom mini-panels (victory, markets, patent/lex trees):
+     keep them inside the viewport and let their content scroll --- */
+
+  .panel-container .panel-content {
+    overflow-x: auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .panel-navbar {
+    width: 56px;
+
+    button {
+      width: 56px;
+      height: 56px;
+
+      &:before {
+        top: 18px;
+        left: 18px;
+      }
+    }
+  }
+
+  .panel-content {
+    &.is-small,
+    &.is-medium,
+    &.is-large {
+      width: calc(100vw - 56px);
+    }
+  }
+
+  .mp-container {
     max-width: 100vw;
+    overflow-x: auto;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
 }

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -73,17 +73,18 @@
       transform-origin: center top;
     }
 
-    // Lex / Patents: labeled chips, visually distinct from the plain
-    // text nav items around them.
-    .mobile-minipanel-button {
-      height: 26px;
-      line-height: 24px;
-      margin: 6px 3px 0;
-      padding: 0 8px;
-      border: 1px solid rgba(255, 255, 255, .3);
-      border-radius: 3px;
-      color: $white;
-    }
+  }
+
+  // Chat: a pull-out drawer under the top bar, toggled by the topbar
+  // chat button (it starts closed on phones — Game.vue).
+  .chat-container {
+    top: 42px;
+    left: 0;
+    right: 0;
+    width: auto;
+    background: rgba(10, 12, 15, .96);
+    border-bottom: 1px solid rgba(255, 255, 255, .15);
+    padding-bottom: 4px;
   }
 
   /* --- system view: full-screen page between the bars --- */
@@ -161,10 +162,58 @@
         }
       }
 
-      // Desktop hangs these 55px outside the box; keep them inside.
+      // Desktop hangs these 55px outside the box; keep them inside,
+      // and reserve side room in the info row so the owner/star text
+      // can't run underneath them.
       .box-aside {
         &.left { left: 2px; }
         &.right { right: 2px; }
+      }
+
+      .box-line.info {
+        padding-left: 54px;
+        padding-right: 54px;
+      }
+
+      // "System of" / "Dominion of" label: the owner name alone reads
+      // fine, and the row needs the width.
+      .owner .label {
+        display: none;
+      }
+
+      // Star class + coordinates are flavor — back seat on phones.
+      .star {
+        .value {
+          font-size: 1.1rem;
+        }
+
+        .label {
+          font-size: 1rem;
+        }
+      }
+
+      // Population-class diamond: desktop floats it dead-center over
+      // the info row where it collides with everything. Make .owner
+      // the anchor and dock a smaller diamond at its left edge, with
+      // the owner text flowing beside it.
+      .owner {
+        position: relative;
+        min-height: 44px;
+        padding-left: 44px;
+        display: flex;
+        align-items: center;
+      }
+
+      .marker {
+        left: 20px;
+        top: 50%;
+        transform: translate(-50%, -50%) rotate(45deg) scale(.5);
+      }
+
+      .marker-label {
+        left: 20px;
+        top: 50%;
+        transform: translate(-50%, -50%) scale(.9);
       }
     }
 
@@ -228,23 +277,54 @@
     max-height: none !important;
   }
 
-  // Celestial rows: icon + info share the first line, the build-slot
-  // tile strip wraps to its own full-width line under them (desktop
-  // puts everything on one 560px row, which can't fit a phone).
+  // Celestial rows: icon, type and potentials share one line
+  // ("BARREN PLANET · 4⚙ 3⚛ 1▲"); the build-slot strip wraps to its
+  // own line under them, tiles at 80% size, no reserved dead space.
   .system-content-group-item {
     flex-wrap: wrap;
+    align-items: center;
 
     .body-info {
       flex: 1;
       width: auto;
       min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+
+      .body-info-potentials {
+        flex: 0 0 auto;
+      }
     }
 
     .body-tiles {
       flex-basis: 100%;
       flex-wrap: wrap;
-      margin: 4px 0 0 40px;
+      margin: 2px 0 0 40px;
       row-gap: 2px;
+
+      .tile {
+        width: 32px;
+        height: 32px;
+        line-height: 32px;
+
+        .main-icon,
+        .tile-icon {
+          width: 28px;
+          height: 28px;
+          margin: 2px;
+        }
+      }
+    }
+  }
+
+  // Tab squares and the collapse caret sit on one aligned row.
+  .system-content-menu {
+    align-items: center;
+
+    .system-tab-item,
+    .system-tab-item.is-tool {
+      margin: 0;
     }
   }
 
@@ -563,13 +643,201 @@
   .mobile-bb-resource {
     display: flex;
     align-items: center;
-    gap: 3px;
-    font-size: 1.1rem;
+    gap: 2px;
+    font-size: 1rem;
     white-space: nowrap;
 
     svg {
-      width: 14px;
-      height: 14px;
+      width: 12px;
+      height: 12px;
+    }
+  }
+
+  .mobile-gauge-press {
+    flex: 0 0 auto;
+    touch-action: none; // long-press must not turn into a bar scroll
+  }
+
+  .mobile-bb-minipanel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    height: 36px;
+    padding: 2px 4px 1px;
+    flex: 0 0 auto;
+
+    background: rgba(255, 255, 255, .06);
+    border: 1px solid rgba(255, 255, 255, .2);
+    border-radius: 4px;
+    font-size: .9rem;
+    text-transform: uppercase;
+    white-space: nowrap;
+    line-height: 1;
+
+    svg {
+      width: 15px;
+      height: 15px;
+    }
+  }
+
+  // Long-press radial over the NES gauge.
+  .mobile-radial {
+    position: absolute;
+    bottom: 52px;
+    width: 0;
+    z-index: $z-navbar + 2;
+
+    .mobile-radial-item {
+      position: absolute;
+      bottom: 0;
+      width: 52px;
+      height: 52px;
+      margin-left: -26px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+
+      background: $grey-dark;
+      border: 1px solid rgba(255, 255, 255, .35);
+      border-radius: 50%;
+      box-shadow: 0 0 12px rgba(0, 0, 0, .7);
+
+      .letter {
+        font-size: 1.5rem;
+        font-weight: bold;
+        line-height: 1.6rem;
+      }
+
+      .count {
+        font-size: 1rem;
+        color: $white-alt-1;
+      }
+
+      // Semi-circle fan: left, top, right of the gauge.
+      &.is-pos-0 { transform: translate(-58px, -14px); }
+      &.is-pos-1 { transform: translate(0, -50px); }
+      &.is-pos-2 { transform: translate(58px, -14px); }
+    }
+  }
+
+  // Full-screen list modal (agents per class, systems, dominions).
+  .mobile-list-modal {
+    position: fixed;
+    top: 0; bottom: 0; left: 0; right: 0;
+    z-index: $z-navbar + 3;
+
+    .mlm-backdrop {
+      position: absolute;
+      top: 0; bottom: 0; left: 0; right: 0;
+      background: rgba(0, 0, 0, .6);
+    }
+
+    .mlm-sheet {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      max-height: 70%;
+      display: flex;
+      flex-direction: column;
+
+      background: $grey-darker;
+      border-top: 1px solid rgba(255, 255, 255, .2);
+    }
+
+    .mlm-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px;
+      border-bottom: 1px solid rgba(255, 255, 255, .1);
+
+      font-size: 1.3rem;
+      font-weight: bold;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+    }
+
+    .mlm-close {
+      width: 34px;
+      height: 34px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      background: rgba(255, 255, 255, .06);
+      border: 1px solid rgba(255, 255, 255, .2);
+      color: $white;
+
+      .svg-icon {
+        width: 14px;
+        height: 14px;
+      }
+    }
+
+    .mlm-list {
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      padding: 6px 8px 12px;
+    }
+
+    .mlm-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 8px;
+      margin-top: 4px;
+
+      background: rgba(255, 255, 255, .05);
+      border: 1px solid rgba(255, 255, 255, .1);
+
+      .mlm-icon {
+        width: 22px;
+        height: 22px;
+        flex: 0 0 22px;
+      }
+
+      .mlm-text {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .mlm-label {
+        font-size: 1.3rem;
+        font-weight: bold;
+      }
+
+      .mlm-sub {
+        font-size: 1.1rem;
+        color: $white-alt-1;
+      }
+
+      .mlm-right {
+        font-size: 1.1rem;
+        color: $white-alt-1;
+        white-space: nowrap;
+      }
+    }
+
+    .mlm-empty {
+      padding: 20px;
+      text-align: center;
+      color: $white-alt-2;
+    }
+  }
+
+  .mobile-tri-gauge {
+    .mg-seg-letter {
+      fill: $white;
+      font-size: 7.5px;
+      font-weight: bold;
+    }
+
+    .mg-fill.is-seg-full {
+      stroke: $theme-red;
     }
   }
 

--- a/front/src/styles/game/mobile.scss
+++ b/front/src/styles/game/mobile.scss
@@ -1,0 +1,133 @@
+// Bare-basics mobile support for the in-game shell. Imported last
+// inside .game-context so these rules win the cascade at phone widths.
+//
+// The galaxy canvas itself is size-agnostic (map.js resizes to the
+// window); what breaks on phones is the fixed-width DOM around it: the
+// system view square is sized off viewport HEIGHT, and the slide-in
+// panels are 600-1200px wide.
+
+// Desktop closes the system view with Esc, scroll-down, or the visible
+// backdrop; none of those exist on touch, so the view carries an
+// explicit close button that only mobile widths reveal.
+.system-close-button {
+  display: none;
+}
+
+@media screen and (max-width: $mobile-breakpoint) {
+  .system-close-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 44px;
+    height: 44px;
+    z-index: 10;
+
+    background: rgba(0, 0, 0, .6);
+    border: solid 1px rgba(255, 255, 255, .2);
+    color: $white;
+
+    .svg-icon {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  // Double-tap on game buttons must not trigger the browser's
+  // double-tap zoom (pan/pinch on the map canvas is unaffected — the
+  // canvas opts out entirely via touch-action: none in map.js).
+  .game-container {
+    touch-action: manipulation;
+  }
+
+  /* --- top/bottom bars: static flex row, swipeable sideways --- */
+
+  .navbar {
+    &.top,
+    &.bottom {
+      display: flex;
+      justify-content: space-between;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+
+    .navbar-left,
+    .navbar-center,
+    .navbar-right {
+      position: static;
+      flex: 0 0 auto;
+    }
+
+    .navbar-center .navbar-center-container {
+      left: 0;
+    }
+  }
+
+  /* --- system view: the square is sized off viewport height, which is
+     wider than any portrait phone; size it off the width instead --- */
+
+  .system-content {
+    width: 100vw;
+    left: 0;
+
+    // At full width the content column covers the click-to-close
+    // backdrop completely, and the desktop escape hatches (Esc,
+    // scroll-down) don't exist on touch. Let taps on the column's
+    // empty areas fall through to the backdrop.
+    pointer-events: none;
+
+    > * {
+      pointer-events: auto;
+    }
+  }
+
+  .system-svg {
+    top: 0;
+    width: 100vw;
+    height: 100vw;
+  }
+
+  .system-properties {
+    max-width: 100vw;
+
+    .box-line.info {
+      width: calc(100vw - 20px);
+    }
+
+    .box-line.yields {
+      max-width: calc(100vw - 20px);
+    }
+  }
+
+  .system-production {
+    max-width: 100vw;
+  }
+
+  // Desktop nudges it 50px off the left edge of .system-info; on a
+  // phone that just pushes it off-screen.
+  .system-population {
+    left: 0;
+  }
+
+  .system-info {
+    max-width: 100vw;
+  }
+
+  // Leave room for the tab strip that hangs at right: -26px.
+  .system-content-container {
+    width: calc(100vw - 27px);
+  }
+
+  /* --- slide-in side panels (600/900/1200px on desktop) --- */
+
+  .panel-content {
+    &.is-small,
+    &.is-medium,
+    &.is-large {
+      width: calc(100vw - 80px); // 80px = .panel-navbar rail alongside
+      max-width: 100vw;
+    }
+  }
+}

--- a/front/src/styles/main.scss
+++ b/front/src/styles/main.scss
@@ -41,6 +41,9 @@
   // grid the in-game Army.vue uses without dragging in the rest of game styles.
   @import 'game/components/tile';
   @import 'game/components/galaxy/selection/army';
+
+  // Mobile overrides — keep last so they win the cascade.
+  @import 'portal/mobile';
 }
 
 // game
@@ -100,4 +103,7 @@
   @import 'game/components/mini-panels/policy';
   @import 'game/components/mini-panels/tree-node';
   @import 'game/components/mini-panels/victory';
+
+  // Mobile overrides — keep last so they win the cascade.
+  @import 'game/mobile';
 }

--- a/front/src/styles/portal/mobile.scss
+++ b/front/src/styles/portal/mobile.scss
@@ -9,6 +9,10 @@
 // with panels stacked full-width.
 
 @media screen and (max-width: $mobile-breakpoint) {
+  // Gated by the mobile_ui beta toggle: utils/viewport.js stamps
+  // is-mobile-ui on <body> only when the account opted in AND the
+  // viewport is phone-sized. `&` is .portal-context here.
+  body.is-mobile-ui & {
   .layout .layout-content {
     padding: 10px;
     overflow-y: auto;
@@ -152,5 +156,6 @@
         margin-top: 20px;
       }
     }
+  }
   }
 }

--- a/front/src/styles/portal/mobile.scss
+++ b/front/src/styles/portal/mobile.scss
@@ -1,0 +1,156 @@
+// Bare-basics mobile support for the portal. Kept in one partial,
+// imported last inside .portal-context, so every rule here wins the
+// cascade at phone widths without touching the desktop partials.
+//
+// The desktop portal is a fixed-viewport app: body{overflow:hidden},
+// absolutely-positioned shells, fixed-pixel panel widths, and a
+// non-wrapping centered flex row. Below $mobile-breakpoint we fall back
+// to the natural phone layout instead: one page-level vertical scroll
+// with panels stacked full-width.
+
+@media screen and (max-width: $mobile-breakpoint) {
+  .layout .layout-content {
+    padding: 10px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* --- topbar: swap the two absolutely-positioned (and colliding)
+     nav groups for a static flex row that can swipe sideways --- */
+
+  .layout-topbar {
+    .navbar.top {
+      display: flex;
+      justify-content: space-between;
+      align-items: stretch;
+      height: 100%;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+
+    .navbar-left,
+    .navbar-right {
+      position: static;
+      flex: 0 0 auto;
+    }
+
+    .navbar-button-title {
+      padding: 0 10px;
+      font-size: 1.2rem;
+    }
+
+    // The logo button is taller than the 54px bar and carries rotated
+    // edge decorations that clip inside a scrolling flex row.
+    .navbar-main-button {
+      height: $navbar-height;
+      width: $navbar-height;
+
+      &:before,
+      &:after {
+        display: none;
+      }
+
+      .navbar-main-button-icon {
+        padding: (($navbar-height - 40px) / 2);
+
+        .icon {
+          width: 40px;
+          height: 40px;
+        }
+      }
+    }
+
+    // The avatar hangs 30px outside its button (clip-path collage) —
+    // that reads as decoration, not navigation; the account button
+    // right next to it keeps profile access.
+    .navbar-right .navbar-main-button {
+      display: none;
+    }
+
+    .navbar-group-buttons .navbar-button-account {
+      padding: 0 10px;
+    }
+  }
+
+  /* --- landing page --- */
+
+  .menu-sidebar {
+    width: 100%;
+    border-right: none;
+  }
+
+  // 1200x1200 decorative blinking logo; pure overflow on a phone.
+  .main-logo {
+    display: none;
+  }
+
+  .menu-sidebar-section.is-nav > * {
+    padding: 20px 25px;
+  }
+
+  .menu-card-container {
+    margin: 15px;
+  }
+
+  /* --- the shared panel pattern (Play, Standings, Account, Settings,
+     Instance, Profile, NewPlayer, Messenger, FightSimulator) --- */
+
+  .fluid-panel {
+    flex-direction: column;
+    justify-content: flex-start;
+    height: auto;
+    min-height: 100%;
+
+    .panel-fragment {
+      flex-direction: column;
+      flex-grow: 0;
+    }
+
+    .panel-aside {
+      width: 100%;
+      margin: 10px 0;
+    }
+
+    .panel-content {
+      &.is-small,
+      &.is-medium,
+      &.is-large,
+      &.is-full-sized,
+      &.is-square {
+        width: 100%;
+      }
+    }
+
+    .free-dashed-overlay .fd-content {
+      width: calc(100% - 20px);
+    }
+  }
+
+  // Some pages (Invites, account tabs) use .panel-content without the
+  // .fluid-panel wrapper.
+  .panel-content {
+    max-width: 100%;
+  }
+
+  .column-container {
+    flex-direction: column;
+    align-items: stretch;
+
+    .column-item {
+      flex-basis: auto;
+    }
+
+    &.is-two {
+      .column-item:nth-child(1) {
+        padding-right: 0;
+      }
+
+      .column-item:nth-child(2) {
+        border-left: none;
+        padding-left: 0;
+        margin-top: 20px;
+      }
+    }
+  }
+}

--- a/front/src/styles/shared/base.scss
+++ b/front/src/styles/shared/base.scss
@@ -16,6 +16,16 @@ body {
   background: $grey-darker;
 }
 
+// Phones: a drag that runs out of scrollable content must never chain
+// into moving the browser viewport (URL-bar collapse shifts every
+// absolutely-positioned shell and "floats" the bars off their edges).
+@media screen and (max-width: $mobile-breakpoint) {
+  html,
+  body {
+    overscroll-behavior: none;
+  }
+}
+
 body, input, textarea, a {
   font-family: $default-font;
   color: $white;

--- a/front/src/styles/shared/base.scss
+++ b/front/src/styles/shared/base.scss
@@ -16,14 +16,14 @@ body {
   background: $grey-darker;
 }
 
-// Phones: a drag that runs out of scrollable content must never chain
-// into moving the browser viewport (URL-bar collapse shifts every
-// absolutely-positioned shell and "floats" the bars off their edges).
-@media screen and (max-width: $mobile-breakpoint) {
-  html,
-  body {
-    overscroll-behavior: none;
-  }
+// Mobile UI (beta): a drag that runs out of scrollable content must
+// never chain into moving the browser viewport (URL-bar collapse
+// shifts every absolutely-positioned shell and "floats" the bars off
+// their edges). The is-mobile-ui class is maintained by
+// utils/viewport.js — phone-sized viewport AND the account's
+// mobile_ui beta toggle.
+body.is-mobile-ui {
+  overscroll-behavior: none;
 }
 
 body, input, textarea, a {

--- a/front/src/styles/shared/variables.scss
+++ b/front/src/styles/shared/variables.scss
@@ -60,3 +60,9 @@ $themes-list: (
 /* Portal theme color */
 
 $primary: #00b89a;
+
+/* Responsive */
+
+// Single breakpoint for the bare-basics mobile support: below this the
+// portal stacks vertically and the game shell caps its fixed widths.
+$mobile-breakpoint: 768px;

--- a/front/src/utils/viewport.js
+++ b/front/src/utils/viewport.js
@@ -1,0 +1,24 @@
+import Vue from 'vue';
+
+// Single source of truth for "are we on a phone-sized viewport". Kept as
+// a shared observable (not per-component matchMedia listeners) so every
+// component flips together and tests can stub one place. Must match
+// $mobile-breakpoint in styles/shared/variables.scss.
+const MOBILE_QUERY = '(max-width: 768px)';
+
+const mq = window.matchMedia(MOBILE_QUERY);
+
+const viewport = Vue.observable({
+  isMobile: mq.matches,
+});
+
+const onChange = (e) => { viewport.isMobile = e.matches; };
+
+if (typeof mq.addEventListener === 'function') {
+  mq.addEventListener('change', onChange);
+} else {
+  // Safari < 14
+  mq.addListener(onChange);
+}
+
+export default viewport;

--- a/front/src/utils/viewport.js
+++ b/front/src/utils/viewport.js
@@ -1,24 +1,45 @@
 import Vue from 'vue';
+import store from '@/store';
 
-// Single source of truth for "are we on a phone-sized viewport". Kept as
-// a shared observable (not per-component matchMedia listeners) so every
-// component flips together and tests can stub one place. Must match
-// $mobile-breakpoint in styles/shared/variables.scss.
+// Single source of truth for "should the mobile UI be active".
+//
+// Two gates, both required:
+//   1. the viewport is phone-sized (must match $mobile-breakpoint in
+//      styles/shared/variables.scss), and
+//   2. the account opted into the `mobile_ui` beta feature
+//      (Account → Beta Features; default off).
+//
+// JS consumers read the `viewport.isMobile` observable; CSS consumers
+// key off the `is-mobile-ui` class this module maintains on <body> —
+// every mobile stylesheet block is scoped `body.is-mobile-ui`.
 const MOBILE_QUERY = '(max-width: 768px)';
 
 const mq = window.matchMedia(MOBILE_QUERY);
 
 const viewport = Vue.observable({
-  isMobile: mq.matches,
+  isMobile: false,
 });
 
-const onChange = (e) => { viewport.isMobile = e.matches; };
+const update = () => {
+  const features = (store.state.portal && store.state.portal.features) || {};
+  const active = mq.matches && features.mobile_ui === true;
+  viewport.isMobile = active;
+  if (document.body) {
+    document.body.classList.toggle('is-mobile-ui', active);
+  }
+};
 
 if (typeof mq.addEventListener === 'function') {
-  mq.addEventListener('change', onChange);
+  mq.addEventListener('change', update);
 } else {
   // Safari < 14
-  mq.addListener(onChange);
+  mq.addListener(update);
 }
+
+// Features arrive async (portal boot) and can change from the Beta
+// Features tab at any time.
+store.watch((state) => state.portal.features, update);
+
+update();
 
 export default viewport;

--- a/lib/rc/accounts/account_feature.ex
+++ b/lib/rc/accounts/account_feature.ex
@@ -12,7 +12,7 @@ defmodule RC.Accounts.AccountFeature do
 
   # Every shippable beta feature. Add new keys here (and a matching toggle
   # in front/src/portal/pages/account/BetaFeatures.vue).
-  @known ~w(agent_fan_display)
+  @known ~w(agent_fan_display mobile_ui)
 
   def known, do: @known
 

--- a/lib/rc/discord/gov_relay.ex
+++ b/lib/rc/discord/gov_relay.ex
@@ -283,9 +283,7 @@ defmodule RC.Discord.GovRelay do
         :ok
 
       {:error, reason} ->
-        Logger.warning(
-          "[RC.Discord.GovRelay] #{op} #{seat} role failed for #{discord_id}: #{inspect(reason)}"
-        )
+        Logger.warning("[RC.Discord.GovRelay] #{op} #{seat} role failed for #{discord_id}: #{inspect(reason)}")
     end
   end
 
@@ -327,9 +325,7 @@ defmodule RC.Discord.GovRelay do
             :ok
 
           {:error, reason} ->
-            Logger.warning(
-              "[RC.Discord.GovRelay] post failed (instance ##{instance_id}): #{inspect(reason)}"
-            )
+            Logger.warning("[RC.Discord.GovRelay] post failed (instance ##{instance_id}): #{inspect(reason)}")
         end
     end
   end

--- a/lib/rc/discord/legacy_match.ex
+++ b/lib/rc/discord/legacy_match.ex
@@ -609,9 +609,7 @@ defmodule RC.Discord.LegacyMatch do
         {:error, reason} ->
           # Skip and continue — a partial pair set beats an aborted
           # promotion. The success reply's channel count is the alarm.
-          Logger.warning(
-            "[RC.Discord.LegacyMatch] diplomacy channel ##{name} failed: #{inspect(reason)}"
-          )
+          Logger.warning("[RC.Discord.LegacyMatch] diplomacy channel ##{name} failed: #{inspect(reason)}")
 
           acc
       end

--- a/lib/rc/instances.ex
+++ b/lib/rc/instances.ex
@@ -438,6 +438,12 @@ defmodule RC.Instances do
       from(faction in Faction,
         left_join: registrations in assoc(faction, :registrations),
         group_by: faction.id,
+        # Without an explicit order the planner returns factions in
+        # arbitrary order (it differs between local PG and the CI
+        # service container), which jitters the UI faction list and
+        # made InstancesTest's struct-equality assert CI-flaky. id
+        # order = insertion order = scenario definition order.
+        order_by: faction.id,
         select_merge: %{registrations_count: count(registrations.id)}
       )
 


### PR DESCRIPTION
## What

Mobile was never a priority; this adds the bare basics in three areas:

### 1. Tapping systems on the galaxy map (the finicky one)

Root cause: the tap handler never raycasted. `pointerup` only read `currentlyHoveredObject`, which is set exclusively by the `mousemove` hover raycast — and touch has no hover, so at tap time nothing was "under the cursor". On top of that, the click-vs-pan check required *exactly* identical down/up coordinates, which finger taps never produce.

- Touch/pen taps now raycast at the release point (`updateHoverAt`, extracted from the mousemove hover path)
- Click-vs-pan uses an 8px slop instead of exact equality (helps twitchy mouse clicks too)
- A pinch (two pointers at any point in the gesture) never resolves as a tap
- The stale-hover click branch is gated on the slop check — a pan that starts or ends over a system no longer opens it, and the `contextmenu` that trails a handled right-click can't double-fire the jump action
- `touch-action: none` on the canvas so MapControls' built-in one-finger pan / two-finger pinch don't fight the browser's own gestures
- `setPixelRatio(min(dpr, 2))` — phones (DPR 2-3) no longer get a blurry CSS-resolution render

### 2. Portal main pages at phone widths (`portal/mobile.scss`, ≤768px)

Single page-level vertical scroll, panels stacked full-width (Play/Standings/Account/Instance/Profile/NewPlayer share the `.fluid-panel` pattern), static swipeable topbar instead of the two colliding absolute nav groups, full-width landing sidebar. Desktop rules untouched — everything lives behind the breakpoint, imported last in the cascade.

### 3. Galaxy/system view shell (`game/mobile.scss`, ≤768px)

The system view square was sized off viewport *height* (wider than any portrait phone); it now sizes off width. Fixed-width side panels (500-1200px) capped to 100vw, game navbars swipeable, and a mobile-only ✕ button on the system view — touch has no Esc, no scroll-wheel, and (at full width) no visible backdrop to tap-close otherwise.

## Verified

Against the dev stack at 375px (synthetic `PointerEvent`s with `pointerType: 'touch'`, no hover phase):

- Portal Menu/Play/Standings/Account/login: zero horizontal overflow, content scrolls
- Tap with 3px finger jitter opens the system view (repeated on multiple clean mounts)
- Drag ending on a system dot does **not** open it; pinch releasing over the dot does **not** open it
- Mobile close button renders, is hit-testable, closes the view; hidden at desktop widths
- Desktop hover→click path unchanged (re-verified end-to-end)
- Canvas renders at 2× device pixels; `touch-action: none` applied

## Known gaps (out of scope for bare basics)

- No touch path for right-click actions (jump orders) or hover-only reveals (agent cards, tooltips)
- Forge/editor and Messenger are functional-but-cramped, not redesigned
- The long-press icon picker works on touch by design (500ms hold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)